### PR TITLE
feat: add pass technique (inswinger/outswinger/straight)

### DIFF
--- a/kloppy/domain/models/event.py
+++ b/kloppy/domain/models/event.py
@@ -448,6 +448,26 @@ class BodyPartQualifier(EnumQualifier):
     value: BodyPart
 
 
+class TechniqueType(Enum):
+    """
+    TechniqueType
+
+    Attributes:
+        INSWINGER (TechniqueType): In-swinging delivery
+        OUTSWINGER (TechniqueType): Out-swinging delivery
+        STRAIGHT (TechniqueType): Straight delivery
+    """
+
+    INSWINGER = "INSWINGER"
+    OUTSWINGER = "OUTSWINGER"
+    STRAIGHT = "STRAIGHT"
+
+
+@dataclass
+class TechniqueQualifier(EnumQualifier):
+    value: TechniqueType
+
+
 class GoalkeeperAction(Enum):
     """
     Deprecated: GoalkeeperAction has been renamed to GoalkeeperActionType.
@@ -1498,6 +1518,8 @@ __all__ = [
     "PassType",
     "BodyPart",
     "BodyPartQualifier",
+    "TechniqueType",
+    "TechniqueQualifier",
     "GoalkeeperEvent",
     "GoalkeeperQualifier",
     "GoalkeeperAction",

--- a/kloppy/infra/serializers/event/statsbomb/specification.py
+++ b/kloppy/infra/serializers/event/statsbomb/specification.py
@@ -31,6 +31,8 @@ from kloppy.domain import (
     SetPieceType,
     ShotResult,
     TakeOnResult,
+    TechniqueQualifier,
+    TechniqueType,
 )
 from kloppy.domain.models.event import UnderPressureQualifier
 from kloppy.exceptions import DeserializationError
@@ -1444,6 +1446,15 @@ def _get_pass_qualifiers(pass_dict: Dict) -> List[PassQualifier]:
         technique_id = PASS.TECHNIQUE(pass_dict["technique"])
         if technique_id == PASS.TECHNIQUE.THROUGH_BALL:
             add_qualifier(PassType.THROUGH_BALL)
+        technique_mapping = {
+            PASS.TECHNIQUE.INSWINGING: TechniqueType.INSWINGER,
+            PASS.TECHNIQUE.OUTSWINGING: TechniqueType.OUTSWINGER,
+            PASS.TECHNIQUE.STRAIGHT: TechniqueType.STRAIGHT,
+        }
+        if technique_id in technique_mapping:
+            qualifiers.append(
+                TechniqueQualifier(value=technique_mapping[technique_id])
+            )
     if "switch" in pass_dict:
         add_qualifier(PassType.SWITCH_OF_PLAY)
     if "height" in pass_dict:

--- a/kloppy/infra/serializers/event/statsperform/deserializer.py
+++ b/kloppy/infra/serializers/event/statsperform/deserializer.py
@@ -40,6 +40,8 @@ from kloppy.domain import (
     ShotResult,
     TakeOnResult,
     Team,
+    TechniqueQualifier,
+    TechniqueType,
 )
 from kloppy.exceptions import DeserializationError
 from kloppy.infra.serializers.event.deserializer import EventDataDeserializer
@@ -148,6 +150,10 @@ EVENT_QUALIFIER_ASSIST_2ND = 218
 EVENT_QUALIFIER_FIRST_YELLOW_CARD = 31
 EVENT_QUALIFIER_SECOND_YELLOW_CARD = 32
 EVENT_QUALIFIER_RED_CARD = 33
+
+EVENT_QUALIFIER_INSWINGER = 223
+EVENT_QUALIFIER_OUTSWINGER = 224
+EVENT_QUALIFIER_STRAIGHT = 225
 
 EVENT_QUALIFIER_COUNTER_ATTACK = 23
 
@@ -639,6 +645,7 @@ def _get_event_qualifiers(raw_qualifiers: Dict[int, str]) -> List[Qualifier]:
     qualifiers = []
     qualifiers.extend(_get_event_setpiece_qualifiers(raw_qualifiers))
     qualifiers.extend(_get_event_bodypart_qualifiers(raw_qualifiers))
+    qualifiers.extend(_get_event_technique_qualifiers(raw_qualifiers))
     qualifiers.extend(_get_event_card_qualifiers(raw_qualifiers))
     qualifiers.extend(_get_event_counter_attack_qualifiers(raw_qualifiers))
     return qualifiers
@@ -713,6 +720,19 @@ def _get_event_bodypart_qualifiers(
         qualifiers.append(BodyPartQualifier(value=BodyPart.RIGHT_FOOT))
     elif EVENT_QUALIFIER_OTHER_BODYPART in raw_qualifiers:
         qualifiers.append(BodyPartQualifier(value=BodyPart.OTHER))
+    return qualifiers
+
+
+def _get_event_technique_qualifiers(
+    raw_qualifiers: Dict[int, str],
+) -> List[Qualifier]:
+    qualifiers = []
+    if EVENT_QUALIFIER_INSWINGER in raw_qualifiers:
+        qualifiers.append(TechniqueQualifier(value=TechniqueType.INSWINGER))
+    elif EVENT_QUALIFIER_OUTSWINGER in raw_qualifiers:
+        qualifiers.append(TechniqueQualifier(value=TechniqueType.OUTSWINGER))
+    elif EVENT_QUALIFIER_STRAIGHT in raw_qualifiers:
+        qualifiers.append(TechniqueQualifier(value=TechniqueType.STRAIGHT))
     return qualifiers
 
 


### PR DESCRIPTION
## Summary
- Add `TechniqueType` enum and `TechniqueQualifier` to domain model
- Parse StatsPerform F24 qualifiers 223/224/225 (inswinger/outswinger/straight)
- Map StatsBomb pass technique field (104/105/107) to `TechniqueQualifier`
- `to_df()` automatically produces a `technique_type` column

## Provider coverage
- **StatsPerform**: qualifiers 223, 224, 225
- **StatsBomb**: pass.technique IDs 104, 105, 107

🤖 Generated with [Claude Code](https://claude.com/claude-code)