### PR TITLE
Fix mirrored throw-in start x in smrtstats parser

### DIFF
--- a/kloppy/infra/serializers/event/smrtstats/deserializer.py
+++ b/kloppy/infra/serializers/event/smrtstats/deserializer.py
@@ -297,6 +297,37 @@ class SmrtStatsInputs(NamedTuple):
     pitch_width: Optional[float] = None
 
 
+THROW_IN_SET_PIECE_ID = 2
+# Raw relative_coord_* values are in meters on smrtstats's 105x68 pitch.
+SMRTSTATS_PITCH_LENGTH = 105
+SMRTSTATS_PITCH_MIDFIELD = SMRTSTATS_PITCH_LENGTH / 2
+
+
+def _correct_throwin_start_x(raw_event: Dict) -> bool:
+    """Mirror the throw-in start x when smrtstats delivers it on the
+    opposite sideline from the destination.
+
+    Smrtstats occasionally encodes ``relative_coord_x`` (start) in a
+    different attacking-direction frame than
+    ``relative_coord_x_destination`` (end), producing throw-ins whose
+    start and end sit on opposite sidelines. Affects ~25% of throw-ins
+    across multiple competitions. Mutates ``raw_event`` in place and
+    returns whether a correction was applied.
+    """
+    if raw_event.get("set_piece_id") != THROW_IN_SET_PIECE_ID:
+        return False
+    start_x = raw_event.get("relative_coord_x")
+    end_x = raw_event.get("relative_coord_x_destination")
+    if start_x is None or end_x is None:
+        return False
+    if (start_x > SMRTSTATS_PITCH_MIDFIELD) == (
+        end_x > SMRTSTATS_PITCH_MIDFIELD
+    ):
+        return False
+    raw_event["relative_coord_x"] = SMRTSTATS_PITCH_LENGTH - start_x
+    return True
+
+
 def _get_event_set_piece_qualifier(
     set_piece_id: Optional[int],
 ) -> List[SetPieceQualifier]:
@@ -910,6 +941,12 @@ class SmrtStatsDeserializer(EventDataDeserializer[SmrtStatsInputs]):
                         or raw_event["coord_y"] is None
                     ):
                         pass
+
+                    if _correct_throwin_start_x(raw_event):
+                        logger.debug(
+                            f"Corrected mirrored throw-in start_x for "
+                            f"event {raw_event.get('id')}"
+                        )
 
                     x = (
                         raw_event["relative_coord_x"]

--- a/kloppy/tests/test_smrtstats.py
+++ b/kloppy/tests/test_smrtstats.py
@@ -8,7 +8,6 @@ import pytest
 from kloppy import smrtstats
 from kloppy.infra.serializers.event.smrtstats.deserializer import (
     SmrtStatsDeserializer,
-    _correct_throwin_start_x,
 )
 from kloppy.domain import (
     BallState,
@@ -543,83 +542,22 @@ class TestSmrtStatsFoulCommittedEvent:
 #         ]
 
 
-class TestCorrectThrowinStartX:
-    """Smrtstats occasionally delivers throw-in start x on the opposite
-    sideline from the destination (~25% of throw-ins). The parser mirrors
-    start_x when this happens. Raw smrtstats coords are in meters on a
-    105x68 pitch, so midfield is x=52.5 and mirroring is ``105 - x``."""
-
-    def test_mirrors_when_start_and_end_on_opposite_sides(self):
-        raw = {
-            "set_piece_id": 2,
-            "relative_coord_x": 105,
-            "relative_coord_x_destination": 5,
-        }
-        assert _correct_throwin_start_x(raw) is True
-        assert raw["relative_coord_x"] == 0
-
-    def test_mirrors_when_start_lt_midfield_and_end_gt_midfield(self):
-        raw = {
-            "set_piece_id": 2,
-            "relative_coord_x": 2,
-            "relative_coord_x_destination": 96,
-        }
-        assert _correct_throwin_start_x(raw) is True
-        assert raw["relative_coord_x"] == 103
-
-    def test_leaves_good_throwin_unchanged(self):
-        raw = {
-            "set_piece_id": 2,
-            "relative_coord_x": 0,
-            "relative_coord_x_destination": 8,
-        }
-        assert _correct_throwin_start_x(raw) is False
-        assert raw["relative_coord_x"] == 0
-
-    def test_ignores_non_throwin_events(self):
-        raw = {
-            "set_piece_id": 5,  # corner kick
-            "relative_coord_x": 105,
-            "relative_coord_x_destination": 5,
-        }
-        assert _correct_throwin_start_x(raw) is False
-        assert raw["relative_coord_x"] == 105
-
-    def test_ignores_open_play(self):
-        raw = {
-            "set_piece_id": 1,
-            "relative_coord_x": 90,
-            "relative_coord_x_destination": 10,
-        }
-        assert _correct_throwin_start_x(raw) is False
-        assert raw["relative_coord_x"] == 90
-
-    def test_handles_missing_coordinates(self):
-        assert (
-            _correct_throwin_start_x(
-                {
-                    "set_piece_id": 2,
-                    "relative_coord_x": None,
-                    "relative_coord_x_destination": 5,
-                }
-            )
-            is False
-        )
-        assert (
-            _correct_throwin_start_x(
-                {
-                    "set_piece_id": 2,
-                    "relative_coord_x": 105,
-                    "relative_coord_x_destination": None,
-                }
-            )
-            is False
-        )
-
-
 class TestSmrtStatsThrowInCoordinates:
-    """Integration check: no throw-in in the parsed dataset should have
-    start and end x-coordinates on opposite sides of midfield."""
+    """Smrtstats encodes ``relative_coord_x`` for ~25% of throw-ins on
+    the opposite sideline from the destination; the parser mirrors
+    start_x (``105 - x``) to put the thrower back on the receiver's
+    sideline."""
+
+    def test_known_mirrored_throwin_is_corrected(self, dataset: EventDataset):
+        """Anchor: event 239947349 has raw start_x=35.8 and end_x=54.18
+        (opposite sides of midfield). The parser must mirror start_x to
+        ``105 - 35.8 = 69.2``."""
+        throw_in = dataset.get_event_by_id("239947349")
+        assert throw_in is not None
+        assert SetPieceType.THROW_IN in throw_in.get_qualifier_values(
+            SetPieceQualifier
+        )
+        assert throw_in.coordinates.x == pytest.approx(69.2)
 
     def test_no_throwins_with_mirrored_start(self, dataset: EventDataset):
         throw_ins = [

--- a/kloppy/tests/test_smrtstats.py
+++ b/kloppy/tests/test_smrtstats.py
@@ -8,6 +8,7 @@ import pytest
 from kloppy import smrtstats
 from kloppy.infra.serializers.event.smrtstats.deserializer import (
     SmrtStatsDeserializer,
+    _correct_throwin_start_x,
 )
 from kloppy.domain import (
     BallState,
@@ -540,6 +541,103 @@ class TestSmrtStatsFoulCommittedEvent:
 #                 PositionType.LeftMidfield,
 #             )
 #         ]
+
+
+class TestCorrectThrowinStartX:
+    """Smrtstats occasionally delivers throw-in start x on the opposite
+    sideline from the destination (~25% of throw-ins). The parser mirrors
+    start_x when this happens. Raw smrtstats coords are in meters on a
+    105x68 pitch, so midfield is x=52.5 and mirroring is ``105 - x``."""
+
+    def test_mirrors_when_start_and_end_on_opposite_sides(self):
+        raw = {
+            "set_piece_id": 2,
+            "relative_coord_x": 105,
+            "relative_coord_x_destination": 5,
+        }
+        assert _correct_throwin_start_x(raw) is True
+        assert raw["relative_coord_x"] == 0
+
+    def test_mirrors_when_start_lt_midfield_and_end_gt_midfield(self):
+        raw = {
+            "set_piece_id": 2,
+            "relative_coord_x": 2,
+            "relative_coord_x_destination": 96,
+        }
+        assert _correct_throwin_start_x(raw) is True
+        assert raw["relative_coord_x"] == 103
+
+    def test_leaves_good_throwin_unchanged(self):
+        raw = {
+            "set_piece_id": 2,
+            "relative_coord_x": 0,
+            "relative_coord_x_destination": 8,
+        }
+        assert _correct_throwin_start_x(raw) is False
+        assert raw["relative_coord_x"] == 0
+
+    def test_ignores_non_throwin_events(self):
+        raw = {
+            "set_piece_id": 5,  # corner kick
+            "relative_coord_x": 105,
+            "relative_coord_x_destination": 5,
+        }
+        assert _correct_throwin_start_x(raw) is False
+        assert raw["relative_coord_x"] == 105
+
+    def test_ignores_open_play(self):
+        raw = {
+            "set_piece_id": 1,
+            "relative_coord_x": 90,
+            "relative_coord_x_destination": 10,
+        }
+        assert _correct_throwin_start_x(raw) is False
+        assert raw["relative_coord_x"] == 90
+
+    def test_handles_missing_coordinates(self):
+        assert (
+            _correct_throwin_start_x(
+                {
+                    "set_piece_id": 2,
+                    "relative_coord_x": None,
+                    "relative_coord_x_destination": 5,
+                }
+            )
+            is False
+        )
+        assert (
+            _correct_throwin_start_x(
+                {
+                    "set_piece_id": 2,
+                    "relative_coord_x": 105,
+                    "relative_coord_x_destination": None,
+                }
+            )
+            is False
+        )
+
+
+class TestSmrtStatsThrowInCoordinates:
+    """Integration check: no throw-in in the parsed dataset should have
+    start and end x-coordinates on opposite sides of midfield."""
+
+    def test_no_throwins_with_mirrored_start(self, dataset: EventDataset):
+        throw_ins = [
+            e
+            for e in dataset.events
+            if e.event_type == EventType.PASS
+            and SetPieceType.THROW_IN
+            in e.get_qualifier_values(SetPieceQualifier)
+        ]
+        for tin in throw_ins:
+            if tin.receiver_coordinates is None:
+                continue
+            start_side = tin.coordinates.x > 52.5
+            end_side = tin.receiver_coordinates.x > 52.5
+            assert start_side == end_side, (
+                f"throw-in {tin.event_id} has start x={tin.coordinates.x} "
+                f"and end x={tin.receiver_coordinates.x} on opposite sides"
+            )
 
 
 class TestSmrtStatsCreatePeriods:


### PR DESCRIPTION
## Summary
- Smrtstats encodes `relative_coord_x` for ~25% of throw-ins in a different attacking-direction frame than `relative_coord_x_destination`, placing the thrower on the opposite sideline from the receiver. This surfaces in the app as very long throw-in lines crossing the entire pitch ([TAS-2889](https://www.notion.so/mygameplan/Wrong-throw-in-start-coordinates-from-smrtstats-3443bf87de63800bbcc5db48ce284e2d)).
- Fix: in the smrtstats deserializer, detect throw-ins whose start and end x-coordinates sit on opposite sides of midfield and mirror start x (`105 - x`) so the thrower lands on the same sideline as the receiver.
- Raw smrtstats coords are in meters on a 105×68 pitch, so midfield is 52.5 (the Notion ticket's `100 - x` formula was from the downstream DB's 0-100 frame).

## Test plan
- [x] New unit tests for `_correct_throwin_start_x` cover mirror cases, good throw-ins, non-throw-in events, and missing coords
- [x] Integration assertion that no parsed throw-in in the existing fixture ends up with start and end on opposite sides of midfield
- [x] `pytest kloppy/tests/test_smrtstats.py` — 61 passed
- [ ] Manual spot-check in a downstream visual once merged & ingested

🤖 Generated with [Claude Code](https://claude.com/claude-code)