### PR TITLE
fix own goal deserialization [korastats]

### DIFF
--- a/kloppy/infra/serializers/event/korastats/deserializer.py
+++ b/kloppy/infra/serializers/event/korastats/deserializer.py
@@ -232,10 +232,17 @@ class KoraStatsDeserializer(EventDataDeserializer[KoraStatsInputs]):
                     is_pass_event = (
                         potential_assist_event.event_type == EventType.PASS
                     )
-                    is_same_team_event = (
-                        event.team == potential_assist_event.team
-                    )
-                    if is_pass_event and is_same_team_event:
+                    # For own goals the shot is attributed to the conceding
+                    # team, but the assisting pass comes from the opponent.
+                    if event.result == ShotResult.OWN_GOAL:
+                        is_assisting_team_event = (
+                            event.team != potential_assist_event.team
+                        )
+                    else:
+                        is_assisting_team_event = (
+                            event.team == potential_assist_event.team
+                        )
+                    if is_pass_event and is_assisting_team_event:
                         potential_assist_event.qualifiers.append(
                             PassQualifier(value=PassType.SHOT_ASSIST)
                         )

--- a/kloppy/infra/serializers/event/korastats/specification.py
+++ b/kloppy/infra/serializers/event/korastats/specification.py
@@ -483,6 +483,38 @@ class SHOT(EVENT):
         return [shot_event]
 
 
+class OWN_GOAL(EVENT):
+    """KoraStats Own Goal event.
+
+    KoraStats emits own goals as a pair of events:
+    - ATTACK_OWN_GOAL_IN_OPPONENT (5, 30) on the benefiting team's side
+      (no player_id).
+    - GOALKEEPER_OWN_GOAL_CONCEDED (2, 49) on the conceding team's side,
+      attached to the goalkeeper.
+
+    Following the StatsBomb convention, we emit a single SHOT event with
+    ShotResult.OWN_GOAL attributed to the conceding team from the
+    goalkeeper event, and drop the benefiting-side event.
+    """
+
+    def _create_events(
+        self,
+        event_factory: EventFactory,
+        teams: List[Team],
+        prior_event: Optional[Dict],
+        next_event: Optional[Dict],
+        **generic_event_kwargs,
+    ) -> List[Event]:
+        shot_event = event_factory.build_shot(
+            result=ShotResult.OWN_GOAL,
+            qualifiers=[],
+            result_coordinates=None,
+            **generic_event_kwargs,
+        )
+
+        return [shot_event]
+
+
 class TACKLE(EVENT):
     """KoraStats Tackle event."""
 
@@ -887,10 +919,10 @@ def event_decoder(raw_event: Dict) -> Optional[EVENT]:
         EVENT_CATEGORY_TYPE.GOALKEEPER_ONE_ON_ONE: GOALKEEPER,
         EVENT_CATEGORY_TYPE.GOALKEEPER_SHOOT: GOALKEEPER,
         # EVENT_CATEGORY_TYPE.GOALKEEPER_PENALTY_SHOOT_OUT: None,
-        EVENT_CATEGORY_TYPE.GOALKEEPER_OWN_GOAL_CONCEDED: None,
+        EVENT_CATEGORY_TYPE.GOALKEEPER_OWN_GOAL_CONCEDED: OWN_GOAL,
         # Defensive events
         EVENT_CATEGORY_TYPE.DEFENSIVE_BLOCK: BLOCK,
-        # (EVENT_CATEGORY.DEFENSIVE, EVENT_TYPE.OWN_GOAL): None,
+        EVENT_CATEGORY_TYPE.DEFENSIVE_OWN_GOAL: None,
         EVENT_CATEGORY_TYPE.DEFENSIVE_TACKLE_CLEAR: TACKLE,
         EVENT_CATEGORY_TYPE.DEFENSIVE_INTERCEPT_CLEAR: INTERCEPTION,
         EVENT_CATEGORY_TYPE.DEFENSIVE_CLEAR: CLEAR,
@@ -928,7 +960,7 @@ def event_decoder(raw_event: Dict) -> Optional[EVENT]:
         EVENT_CATEGORY_TYPE.ATTACK_PENALTY: SHOT,
         EVENT_CATEGORY_TYPE.ATTACK_CORNER: SHOT,
         EVENT_CATEGORY_TYPE.ATTACK_FREEKICK: SHOT,
-        EVENT_CATEGORY_TYPE.ATTACK_OWN_GOAL_IN_OPPONENT: SHOT,
+        EVENT_CATEGORY_TYPE.ATTACK_OWN_GOAL_IN_OPPONENT: None,
         EVENT_CATEGORY_TYPE.ATTACK_SHOOT_LOCATION: None,
         # ATTACK_PENALTY_SHOOTOUT = "PenaltyShootOut"
         # Ball actions

--- a/kloppy/tests/test_korastats.py
+++ b/kloppy/tests/test_korastats.py
@@ -301,6 +301,42 @@ class TestKoraStatsShotEvent:
         )
 
 
+class TestKoraStatsOwnGoalEvent:
+    """Tests related to deserializing own goal events.
+
+    KoraStats emits own goals as a pair:
+    - ATTACK_OWN_GOAL_IN_OPPONENT (5, 30) on the benefiting team's side
+      (no player_id)
+    - GOALKEEPER_OWN_GOAL_CONCEDED (2, 49) on the conceding team's side,
+      attached to the goalkeeper.
+
+    Only the conceding-side event should produce a SHOT with
+    ShotResult.OWN_GOAL.
+    """
+
+    def test_own_goal_count(self, dataset: EventDataset):
+        """Exactly one own-goal shot event per own goal should be emitted."""
+        shots = dataset.find_all("shot")
+        own_goals = [s for s in shots if s.result == ShotResult.OWN_GOAL]
+        assert len(own_goals) == 1
+
+    def test_own_goal_attribution(self, dataset: EventDataset):
+        """Own-goal shot should be attributed to the conceding team."""
+        # _id 144883828 is the GOALKEEPER_OWN_GOAL_CONCEDED event
+        # conceded by Kalmar FF (team_id 10107).
+        shot = dataset.get_event_by_id("144883828")
+        assert shot is not None
+        assert shot.event_type == EventType.SHOT
+        assert shot.result == ShotResult.OWN_GOAL
+        assert shot.team.team_id == "10107"
+
+    def test_benefiting_side_dropped(self, dataset: EventDataset):
+        """The benefiting-side event should not produce a separate shot."""
+        # _id 144883827 is the ATTACK_OWN_GOAL_IN_OPPONENT event
+        # which should be silently dropped.
+        assert dataset.get_event_by_id("144883827") is None
+
+
 class TestKoraStatsClearanceEvent:
     """Tests related to deserializing 9/Clearance events"""
 


### PR DESCRIPTION
## Summary

Fixes how KoraStats own goals are deserialized. Previously they were stored as a regular `ShotResult.GOAL` by the benefiting team (no player, no `OWN_GOAL` flag), and the paired goalkeeper event was silently dropped. This caused own goals to disappear from the "Goals Conceded" tracker in Box Defending.

KoraStats emits own goals as a pair:
- `ATTACK_OWN_GOAL_IN_OPPONENT (5, 30)` on the **benefiting** team's side (no `player_id`)
- `GOALKEEPER_OWN_GOAL_CONCEDED (2, 49)` on the **conceding** team's side, attached to the goalkeeper

Following the StatsBomb convention (`OWN_GOAL_AGAINST` / `OWN_GOAL_FOR`):
- Drop the attacker-side event.
- Emit a single `SHOT` with `ShotResult.OWN_GOAL` from the goalkeeper-side event, attributed to the **conceding** team. The kloppy `ScoreStateBuilder` already interprets this correctly and credits the goal to the opposing team.
- Map `DEFENSIVE_OWN_GOAL (3, 14)` to `None` so future occurrences don't `KeyError` (it was declared in the enum but absent from the dispatch map).

Also adjust `mark_events_as_assists` so that for `OWN_GOAL` shots the assisting pass is matched against the **opposing** team (since the shot is now attributed to the conceding team, but the assisting cross/pass comes from the benefiting team).

Notion ticket: https://www.notion.so/Own-goals-are-not-properly-processed-for-KoraStats-3483bf87de63805283c6f64e5efb93dd

## Test plan

- [x] Added `TestKoraStatsOwnGoalEvent` in `kloppy/tests/test_korastats.py` with three cases:
  - exactly one `SHOT` with `ShotResult.OWN_GOAL` is emitted
  - the shot is attributed to the conceding team (`team_id 10107` = Kalmar FF in the fixture)
  - the attacker-side event (`_id 144883827`) is dropped
- [x] All existing korastats tests still pass (30/30)
- [x] Existing shot/goalkeeper/pass counts unchanged
- [ ] After merge, bump `kloppy@mgp-fork/v11` commit in `data-processing/requirements.txt` and re-run the `EVENT` pipeline for Nõmme Utd vs Harju JK (match `69c29a853929ab368ef0811d`) to verify the own goal surfaces in Harju's "Box defending → Goals Conceded" tracker.

https://claude.ai/code/session_01C9A3otsb7ddQ49XLb9BAs5