### PR TITLE
fix(opta): normalize wall-clock timestamps across abandonment/suspension gaps

### DIFF
--- a/kloppy/infra/serializers/event/statsperform/deserializer.py
+++ b/kloppy/infra/serializers/event/statsperform/deserializer.py
@@ -59,6 +59,11 @@ EVENT_TYPE_START_DELAY = 27
 EVENT_TYPE_END_DELAY = 28
 EVENT_TYPE_OFFSIDE_PROVOKED = 55
 
+# Minimum wall-clock excess over game-clock to treat as an abandonment / extended
+# suspension and shift subsequent F24 event timestamps back accordingly. Set above
+# routine in-play delays (injuries, VAR) so only true match suspensions trigger.
+SUSPENSION_GAP_THRESHOLD = timedelta(minutes=15)
+
 EVENT_TYPE_PASS = 1
 EVENT_TYPE_OFFSIDE_PASS = 2
 EVENT_TYPE_TAKE_ON = 3
@@ -784,6 +789,58 @@ def _get_event_type_name(type_id: int) -> str:
     return event_type_names.get(type_id, "unknown")
 
 
+def _normalize_suspension_gaps(raw_events: List[OptaEvent]) -> None:
+    """Shift wall-clock event timestamps back across abandonment/suspension gaps.
+
+    Opta F24 events carry both a wall-clock `timestamp` and a game-clock
+    `time_min`/`time_sec`. When a match is paused for an extended period (a
+    suspension or abandonment with later resumption), wall-clock advances while
+    the game-clock does not. Without correction, `period.end_timestamp -
+    period.start_timestamp` and per-event offsets reflect wall-clock time,
+    which breaks consumers that assume game-clock semantics (notably the
+    minutes-played aggregator with `breakdown_key="possession_state"`).
+
+    For each period, walk events in order and apply a cumulative shift to each
+    event's wall-clock timestamp whenever the wall-clock delta between two
+    consecutive events exceeds the game-clock delta by more than
+    `SUSPENSION_GAP_THRESHOLD`. The END_PERIOD event is included in the walk,
+    so `period.end_timestamp` (set later from that event) is also corrected.
+    """
+    shift_per_period: Dict[int, timedelta] = {}
+    prev_per_period: Dict[int, OptaEvent] = {}
+    for raw_event in raw_events:
+        period_id = raw_event.period_id
+        shift = shift_per_period.get(period_id, timedelta(0))
+        if shift:
+            raw_event.timestamp -= shift
+        prev = prev_per_period.get(period_id)
+        if prev is not None:
+            wall_delta = raw_event.timestamp - prev.timestamp
+            game_delta = timedelta(
+                minutes=raw_event.time_min - prev.time_min,
+                seconds=raw_event.time_sec - prev.time_sec,
+            )
+            excess = wall_delta - game_delta
+            if excess > SUSPENSION_GAP_THRESHOLD:
+                logger.warning(
+                    "Detected suspension gap of %s in period %s between "
+                    "events %s (game %d:%02d) and %s (game %d:%02d); "
+                    "shifting subsequent timestamps back to preserve "
+                    "game-clock semantics.",
+                    excess,
+                    period_id,
+                    prev.id,
+                    prev.time_min,
+                    prev.time_sec,
+                    raw_event.id,
+                    raw_event.time_min,
+                    raw_event.time_sec,
+                )
+                raw_event.timestamp -= excess
+                shift_per_period[period_id] = shift + excess
+        prev_per_period[period_id] = raw_event
+
+
 class StatsPerformInputs(NamedTuple):
     meta_data: IO[bytes]
     meta_feed: str
@@ -825,6 +882,9 @@ class StatsPerformDeserializer(EventDataDeserializer[StatsPerformInputs]):
                 for event in events_parser.extract_events()
                 if event.type_id != EVENT_TYPE_DELETED_EVENT
             ]
+
+            if inputs.event_feed.upper() == "F24":
+                _normalize_suspension_gaps(raw_events)
 
             possession_team = None
             periods_with_start_event = set()

--- a/kloppy/tests/files/opta_abandonment_f24.xml
+++ b/kloppy/tests/files/opta_abandonment_f24.xml
@@ -1,0 +1,11146 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Copyright 2001-2026 Opta Sportsdata Ltd. All rights reserved. -->
+<!-- PRODUCTION HEADER
+     produced on:       inxopta-djobqueue03
+     production time:   2026-05-19T16:32:19.263+0100
+     production module: feed:soccer:f24 -->
+<Games timestamp="2026-05-19T16:32:19">
+  <Game competition_id="226" game_date="2026-05-19T14:00:00" game_date_utc="2026-05-19T13:00:00" game_date_local="2026-05-19T15:00:00" game_date_local_offset="+02:00" matchday="8" home_team_id="417" home_team_name="Örgryte" away_team_id="244" away_team_name="IFK Göteborg" season_id="2026" id="2615297" competition_name="Swedish Allsvenskan" season_name="Season 2026/2027" home_team_official="Örgryte IS" home_team_short="Örgryte" home_score="2" away_team_official="IFK Göteborg" away_team_short="IFK Göteborg" away_score="3" period_1_start="2026-05-18T18:05:49" period_1_start_utc="2026-05-18T17:05:49" period_2_start="2026-05-19T14:23:00" period_2_start_utc="2026-05-19T13:23:00">
+    <Event id="2939599805" event_id="1" type_id="34" period_id="16" min="0" sec="0" team_id="244" outcome="1" x="0.0" y="0.0" timestamp="2026-05-18T17:19:50.512" timestamp_utc="2026-05-18T16:19:50.512" last_modified="2026-05-18T18:00:16" version="1779123616771">
+      <Q id="6427305249" qualifier_id="30" value="578592, 240166, 575855, 232091, 627127, 180662, 479433, 515742, 207884, 625775, 648131, 157846, 495426, 508143, 213399, 482450, 531792, 246081, 689776, 581866"/>
+      <Q id="6427305251" qualifier_id="44" value="1, 2, 2, 3, 2, 2, 3, 3, 4, 4, 3, 5, 5, 5, 5, 5, 5, 5, 5, 5"/>
+      <Q id="6427305253" qualifier_id="59" value="25, 17, 18, 3, 4, 5, 29, 15, 14, 7, 26, 34, 8, 9, 10, 11, 16, 23, 27, 30"/>
+      <Q id="6427305255" qualifier_id="130" value="2"/>
+      <Q id="6427305257" qualifier_id="131" value="1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 0, 0, 0, 0, 0, 0, 0, 0, 0"/>
+      <Q id="6427305259" qualifier_id="194" value="232091"/>
+      <Q id="6427344227" qualifier_id="197" value="30572"/>
+      <Q id="6427305261" qualifier_id="227" value="0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0"/>
+    </Event>
+    <Event id="2939600441" event_id="1" type_id="34" period_id="16" min="0" sec="0" team_id="417" outcome="1" x="0.0" y="0.0" timestamp="2026-05-18T17:23:20.366" timestamp_utc="2026-05-18T16:23:20.366" last_modified="2026-05-18T18:12:00" version="1779124320305">
+      <Q id="6427309033" qualifier_id="30" value="565487, 157851, 164593, 624620, 61812, 531784, 685390, 218339, 61778, 445539, 720682, 106936, 731191, 570078, 565492, 570081, 683488, 720789, 548847, 587639"/>
+      <Q id="6427309035" qualifier_id="44" value="1, 2, 2, 2, 2, 2, 3, 3, 4, 4, 3, 5, 5, 5, 5, 5, 5, 5, 5, 5"/>
+      <Q id="6427309037" qualifier_id="59" value="44, 14, 19, 2, 6, 5, 17, 23, 22, 11, 8, 3, 15, 16, 21, 24, 25, 29, 33, 34"/>
+      <Q id="6427309039" qualifier_id="130" value="10"/>
+      <Q id="6427309041" qualifier_id="131" value="1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 0, 0, 0, 0, 0, 0, 0, 0, 0"/>
+      <Q id="6427309043" qualifier_id="194" value="157851"/>
+      <Q id="6427343765" qualifier_id="197" value="28364"/>
+      <Q id="6427309045" qualifier_id="227" value="0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0"/>
+    </Event>
+    <Event id="2939608539" event_id="2" type_id="32" period_id="1" min="0" sec="0" team_id="417" outcome="1" x="0.0" y="0.0" timestamp="2026-05-18T18:05:49.862" timestamp_utc="2026-05-18T17:05:49.862" last_modified="2026-05-18T18:05:50" version="1779123949866">
+      <Q id="6427355627" qualifier_id="127" value="Left to Right"/>
+    </Event>
+    <Event id="2939608541" event_id="2" type_id="32" period_id="1" min="0" sec="0" team_id="244" outcome="1" x="0.0" y="0.0" timestamp="2026-05-18T18:05:49.862" timestamp_utc="2026-05-18T17:05:49.862" last_modified="2026-05-18T18:05:51" version="1779123950504">
+      <Q id="6427355629" qualifier_id="127" value="Right to Left"/>
+    </Event>
+    <Event id="2939608583" event_id="3" type_id="1" period_id="1" min="0" sec="0" player_id="445539" team_id="417" outcome="1" x="49.8" y="49.9" timestamp="2026-05-18T18:05:49.863" timestamp_utc="2026-05-18T17:05:49.863" last_modified="2026-05-18T19:31:05" version="1779129065397">
+      <Q id="6427355813" qualifier_id="56" value="Back"/>
+      <Q id="6427355815" qualifier_id="140" value="27.6"/>
+      <Q id="6427355817" qualifier_id="141" value="40.0"/>
+      <Q id="6427355819" qualifier_id="212" value="24.3"/>
+      <Q id="6427355821" qualifier_id="213" value="3.42"/>
+      <Q id="6427355823" qualifier_id="279" value="S"/>
+    </Event>
+    <Event id="2939608585" event_id="4" type_id="1" period_id="1" min="0" sec="4" player_id="531784" team_id="417" outcome="0" x="29.2" y="35.5" timestamp="2026-05-18T18:05:54.746" timestamp_utc="2026-05-18T17:05:54.746" last_modified="2026-05-18T18:05:56" version="1779123955715">
+      <Q id="6427355839" qualifier_id="1"/>
+      <Q id="6427355829" qualifier_id="56" value="Center"/>
+      <Q id="6427355831" qualifier_id="140" value="74.3"/>
+      <Q id="6427355833" qualifier_id="141" value="63.7"/>
+      <Q id="6427355827" qualifier_id="157"/>
+      <Q id="6427355835" qualifier_id="212" value="51.1"/>
+      <Q id="6427355837" qualifier_id="213" value="0.38"/>
+    </Event>
+    <Event id="2939608595" event_id="3" type_id="1" period_id="1" min="0" sec="6" player_id="627127" team_id="244" outcome="0" x="22.1" y="36.1" timestamp="2026-05-18T18:05:55.924" timestamp_utc="2026-05-18T17:05:55.924" last_modified="2026-05-18T18:05:57" version="1779123957860">
+      <Q id="6427355871" qualifier_id="3"/>
+      <Q id="6427355873" qualifier_id="56" value="Back"/>
+      <Q id="6427355875" qualifier_id="140" value="37.7"/>
+      <Q id="6427355877" qualifier_id="141" value="34.5"/>
+      <Q id="6427355879" qualifier_id="212" value="16.4"/>
+      <Q id="6427355881" qualifier_id="213" value="6.22"/>
+    </Event>
+    <Event id="2939608607" event_id="5" type_id="1" period_id="1" min="0" sec="9" player_id="218339" team_id="417" outcome="0" x="55.4" y="65.2" timestamp="2026-05-18T18:05:59.114" timestamp_utc="2026-05-18T17:05:59.114" last_modified="2026-05-18T18:06:00" version="1779123960365">
+      <Q id="6427355955" qualifier_id="56" value="Left"/>
+      <Q id="6427355957" qualifier_id="140" value="74.9"/>
+      <Q id="6427355959" qualifier_id="141" value="100.0"/>
+      <Q id="6427355961" qualifier_id="212" value="32.0"/>
+      <Q id="6427355963" qualifier_id="213" value="0.88"/>
+    </Event>
+    <Event id="2939608609" event_id="6" type_id="5" period_id="1" min="0" sec="10" player_id="218339" team_id="417" outcome="0" x="77.1" y="101.4" timestamp="2026-05-18T18:06:00.371" timestamp_utc="2026-05-18T17:06:00.371" last_modified="2026-05-18T19:36:45" version="1779129405396">
+      <Q id="6427355965" qualifier_id="56" value="Left"/>
+      <Q id="6427356335" qualifier_id="233" value="4"/>
+      <Q id="6427355967" qualifier_id="347"/>
+    </Event>
+    <Event id="2939608665" event_id="4" type_id="5" period_id="1" min="0" sec="10" player_id="627127" team_id="244" outcome="1" x="22.9" y="-1.4" timestamp="2026-05-18T18:06:00.371" timestamp_utc="2026-05-18T17:06:00.371" last_modified="2026-05-18T19:36:45" version="1779129405379">
+      <Q id="6427356315" qualifier_id="56" value="Back"/>
+      <Q id="6427356319" qualifier_id="233" value="6"/>
+      <Q id="6427356317" qualifier_id="347"/>
+    </Event>
+    <Event id="2939608673" event_id="5" type_id="1" period_id="1" min="0" sec="18" player_id="240166" team_id="244" outcome="1" x="21.6" y="0.0" timestamp="2026-05-18T18:06:08.290" timestamp_utc="2026-05-18T17:06:08.290" last_modified="2026-05-18T18:06:09" version="1779123968705">
+      <Q id="6427356365" qualifier_id="56" value="Back"/>
+      <Q id="6427356363" qualifier_id="107"/>
+      <Q id="6427356367" qualifier_id="140" value="22.6"/>
+      <Q id="6427356369" qualifier_id="141" value="22.5"/>
+      <Q id="6427356371" qualifier_id="212" value="16.4"/>
+      <Q id="6427356373" qualifier_id="213" value="1.51"/>
+    </Event>
+    <Event id="2939608679" event_id="6" type_id="1" period_id="1" min="0" sec="19" player_id="515742" team_id="244" outcome="0" x="22.9" y="23.0" timestamp="2026-05-18T18:06:09.523" timestamp_utc="2026-05-18T17:06:09.523" last_modified="2026-05-18T18:06:11" version="1779123971035">
+      <Q id="6427356419" qualifier_id="1"/>
+      <Q id="6427356409" qualifier_id="56" value="Back"/>
+      <Q id="6427356411" qualifier_id="140" value="43.9"/>
+      <Q id="6427356413" qualifier_id="141" value="21.0"/>
+      <Q id="6427356407" qualifier_id="157"/>
+      <Q id="6427356415" qualifier_id="212" value="22.1"/>
+      <Q id="6427356417" qualifier_id="213" value="6.22"/>
+    </Event>
+    <Event id="2939608689" event_id="7" type_id="1" period_id="1" min="0" sec="21" player_id="624620" team_id="417" outcome="0" x="55.5" y="87.8" timestamp="2026-05-18T18:06:11.514" timestamp_utc="2026-05-18T17:06:11.514" last_modified="2026-05-18T18:06:12" version="1779123972018">
+      <Q id="6427356465" qualifier_id="56" value="Center"/>
+      <Q id="6427356467" qualifier_id="140" value="65.4"/>
+      <Q id="6427356469" qualifier_id="141" value="69.6"/>
+      <Q id="6427356471" qualifier_id="212" value="16.2"/>
+      <Q id="6427356473" qualifier_id="213" value="5.41"/>
+    </Event>
+    <Event id="2939608705" event_id="8" type_id="83" period_id="1" min="0" sec="24" player_id="685390" team_id="417" outcome="0" x="56.0" y="70.5" timestamp="2026-05-18T18:06:14.778" timestamp_utc="2026-05-18T17:06:14.778" last_modified="2026-05-18T18:19:44" version="1779124784630">
+      <Q id="6427356793" qualifier_id="399" value="207884"/>
+    </Event>
+    <Event id="2939608747" event_id="7" type_id="1" period_id="1" min="0" sec="25" player_id="207884" team_id="244" outcome="1" x="38.4" y="39.8" timestamp="2026-05-18T18:06:15.787" timestamp_utc="2026-05-18T17:06:15.787" last_modified="2026-05-18T18:06:18" version="1779123976171">
+      <Q id="6427356779" qualifier_id="56" value="Back"/>
+      <Q id="6427356781" qualifier_id="140" value="28.5"/>
+      <Q id="6427356783" qualifier_id="141" value="31.3"/>
+      <Q id="6427356785" qualifier_id="212" value="11.9"/>
+      <Q id="6427356787" qualifier_id="213" value="3.65"/>
+    </Event>
+    <Event id="2939608773" event_id="8" type_id="1" period_id="1" min="0" sec="29" player_id="627127" team_id="244" outcome="1" x="24.0" y="31.3" timestamp="2026-05-18T18:06:19.378" timestamp_utc="2026-05-18T17:06:19.378" last_modified="2026-05-18T18:06:21" version="1779123980220">
+      <Q id="6427356899" qualifier_id="56" value="Back"/>
+      <Q id="6427356901" qualifier_id="140" value="22.0"/>
+      <Q id="6427356903" qualifier_id="141" value="68.4"/>
+      <Q id="6427356905" qualifier_id="212" value="25.3"/>
+      <Q id="6427356907" qualifier_id="213" value="1.65"/>
+    </Event>
+    <Event id="2939608803" event_id="9" type_id="1" period_id="1" min="0" sec="31" player_id="180662" team_id="244" outcome="1" x="25.3" y="72.4" timestamp="2026-05-18T18:06:21.266" timestamp_utc="2026-05-18T17:06:21.266" last_modified="2026-05-18T18:06:26" version="1779123981748">
+      <Q id="6427357049" qualifier_id="56" value="Back"/>
+      <Q id="6427357051" qualifier_id="140" value="35.6"/>
+      <Q id="6427357053" qualifier_id="141" value="88.9"/>
+      <Q id="6427357055" qualifier_id="212" value="15.6"/>
+      <Q id="6427357057" qualifier_id="213" value="0.80"/>
+    </Event>
+    <Event id="2939608839" event_id="10" type_id="1" period_id="1" min="0" sec="36" player_id="575855" team_id="244" outcome="1" x="55.6" y="83.2" timestamp="2026-05-18T18:06:26.019" timestamp_utc="2026-05-18T17:06:26.019" last_modified="2026-05-18T18:06:31" version="1779123986747">
+      <Q id="6427357295" qualifier_id="56" value="Left"/>
+      <Q id="6427357297" qualifier_id="140" value="70.3"/>
+      <Q id="6427357299" qualifier_id="141" value="88.9"/>
+      <Q id="6427357301" qualifier_id="212" value="15.9"/>
+      <Q id="6427357303" qualifier_id="213" value="0.25"/>
+    </Event>
+    <Event id="2939608853" event_id="11" type_id="1" period_id="1" min="0" sec="41" player_id="648131" team_id="244" outcome="1" x="82.5" y="91.8" timestamp="2026-05-18T18:06:31.730" timestamp_utc="2026-05-18T17:06:31.730" last_modified="2026-05-18T18:06:34" version="1779123992267">
+      <Q id="6427357393" qualifier_id="56" value="Left"/>
+      <Q id="6427357395" qualifier_id="140" value="72.4"/>
+      <Q id="6427357397" qualifier_id="141" value="79.6"/>
+      <Q id="6427357399" qualifier_id="212" value="13.5"/>
+      <Q id="6427357401" qualifier_id="213" value="3.81"/>
+    </Event>
+    <Event id="2939608869" event_id="12" type_id="1" period_id="1" min="0" sec="44" player_id="515742" team_id="244" outcome="1" x="72.8" y="81.5" timestamp="2026-05-18T18:06:34.274" timestamp_utc="2026-05-18T17:06:34.274" last_modified="2026-05-18T18:06:36" version="1779123994563">
+      <Q id="6427357469" qualifier_id="56" value="Left"/>
+      <Q id="6427357471" qualifier_id="140" value="65.6"/>
+      <Q id="6427357473" qualifier_id="141" value="80.2"/>
+      <Q id="6427357475" qualifier_id="212" value="7.6"/>
+      <Q id="6427357477" qualifier_id="213" value="3.26"/>
+    </Event>
+    <Event id="2939608887" event_id="13" type_id="1" period_id="1" min="0" sec="46" player_id="180662" team_id="244" outcome="1" x="63.6" y="72.0" timestamp="2026-05-18T18:06:36.426" timestamp_utc="2026-05-18T17:06:36.426" last_modified="2026-05-18T18:06:40" version="1779123996819">
+      <Q id="6427357535" qualifier_id="56" value="Center"/>
+      <Q id="6427357537" qualifier_id="140" value="63.5"/>
+      <Q id="6427357539" qualifier_id="141" value="30.0"/>
+      <Q id="6427357541" qualifier_id="212" value="28.6"/>
+      <Q id="6427357543" qualifier_id="213" value="4.71"/>
+    </Event>
+    <Event id="2939608925" event_id="14" type_id="1" period_id="1" min="0" sec="50" player_id="240166" team_id="244" outcome="1" x="63.9" y="22.1" keypass="1" timestamp="2026-05-18T18:06:40.098" timestamp_utc="2026-05-18T17:06:40.098" last_modified="2026-05-18T18:06:56" version="1779124016106">
+      <Q id="6427357757" qualifier_id="56" value="Right"/>
+      <Q id="6427357759" qualifier_id="140" value="75.0"/>
+      <Q id="6427357761" qualifier_id="141" value="4.9"/>
+      <Q id="6427358047" qualifier_id="210" value="13"/>
+      <Q id="6427357763" qualifier_id="212" value="16.5"/>
+      <Q id="6427357765" qualifier_id="213" value="5.50"/>
+    </Event>
+    <Event id="2939608927" event_id="15" type_id="13" period_id="1" min="0" sec="56" player_id="625775" team_id="244" outcome="1" x="76.1" y="36.1" timestamp="2026-05-18T18:06:46.626" timestamp_utc="2026-05-18T17:06:46.626" last_modified="2026-05-18T18:09:06" version="1779124145896">
+      <Q id="6427357771" qualifier_id="18"/>
+      <Q id="6427357769" qualifier_id="22"/>
+      <Q id="6427358053" qualifier_id="29"/>
+      <Q id="6427358055" qualifier_id="55" value="14"/>
+      <Q id="6427357773" qualifier_id="56" value="Center"/>
+      <Q id="6427357913" qualifier_id="72"/>
+      <Q id="6427358051" qualifier_id="74"/>
+      <Q id="6427358059" qualifier_id="102" value="52.1"/>
+      <Q id="6427358061" qualifier_id="103" value="65.3"/>
+      <Q id="6427358063" qualifier_id="215"/>
+      <Q id="6427358065" qualifier_id="230" value="100.0"/>
+      <Q id="6427358067" qualifier_id="231" value="49.5"/>
+    </Event>
+    <Event id="2939608949" event_id="16" type_id="5" period_id="1" min="0" sec="57" player_id="625775" team_id="244" outcome="0" x="100.7" y="48.3" timestamp="2026-05-18T18:06:47.226" timestamp_utc="2026-05-18T17:06:47.226" last_modified="2026-05-18T19:36:46" version="1779129405412">
+      <Q id="6427357891" qualifier_id="56" value="Center"/>
+      <Q id="6427358619" qualifier_id="233" value="9"/>
+      <Q id="6427357893" qualifier_id="346"/>
+    </Event>
+    <Event id="2939609079" event_id="9" type_id="5" period_id="1" min="0" sec="57" player_id="164593" team_id="417" outcome="1" x="-0.7" y="51.7" timestamp="2026-05-18T18:06:47.226" timestamp_utc="2026-05-18T17:06:47.226" last_modified="2026-05-18T19:36:46" version="1779129405400">
+      <Q id="6427358583" qualifier_id="56" value="Back"/>
+      <Q id="6427358615" qualifier_id="233" value="16"/>
+      <Q id="6427358585" qualifier_id="346"/>
+    </Event>
+    <Event id="2939609103" event_id="10" type_id="1" period_id="1" min="1" sec="23" player_id="565487" team_id="417" outcome="0" x="2.6" y="46.1" timestamp="2026-05-18T18:07:13.225" timestamp_utc="2026-05-18T17:07:13.225" last_modified="2026-05-18T18:07:17" version="1779124037535">
+      <Q id="6427358737" qualifier_id="1"/>
+      <Q id="6427358727" qualifier_id="56" value="Center"/>
+      <Q id="6427358741" qualifier_id="74"/>
+      <Q id="6427358725" qualifier_id="124"/>
+      <Q id="6427358729" qualifier_id="140" value="68.7"/>
+      <Q id="6427358731" qualifier_id="141" value="30.3"/>
+      <Q id="6427358733" qualifier_id="212" value="70.2"/>
+      <Q id="6427358735" qualifier_id="213" value="6.13"/>
+    </Event>
+    <Event id="2939609115" event_id="17" type_id="44" period_id="1" min="1" sec="27" player_id="232091" team_id="244" outcome="1" x="31.3" y="69.7" timestamp="2026-05-18T18:07:17.232" timestamp_utc="2026-05-18T17:07:17.232" last_modified="2026-05-18T19:37:34" version="1779129454747">
+      <Q id="6427358775" qualifier_id="56" value="Back"/>
+      <Q id="6427358797" qualifier_id="233" value="11"/>
+      <Q id="6427358777" qualifier_id="285"/>
+    </Event>
+    <Event id="2939609107" event_id="11" type_id="44" period_id="1" min="1" sec="27" player_id="685390" team_id="417" outcome="0" x="68.7" y="30.3" timestamp="2026-05-18T18:07:17.233" timestamp_utc="2026-05-18T17:07:17.233" last_modified="2026-05-18T19:37:35" version="1779129455012">
+      <Q id="6427358755" qualifier_id="56" value="Center"/>
+      <Q id="6427358805" qualifier_id="233" value="17"/>
+      <Q id="6427358757" qualifier_id="286"/>
+    </Event>
+    <Event id="2939609131" event_id="18" type_id="1" period_id="1" min="1" sec="27" player_id="232091" team_id="244" outcome="1" x="31.3" y="69.7" timestamp="2026-05-18T18:07:17.777" timestamp_utc="2026-05-18T17:07:17.777" last_modified="2026-05-18T19:37:35" version="1779129455271">
+      <Q id="6427358867" qualifier_id="3"/>
+      <Q id="6427358869" qualifier_id="56" value="Back"/>
+      <Q id="6427358871" qualifier_id="140" value="41.7"/>
+      <Q id="6427358873" qualifier_id="141" value="74.1"/>
+      <Q id="6427358875" qualifier_id="212" value="11.3"/>
+      <Q id="6427358877" qualifier_id="213" value="0.27"/>
+    </Event>
+    <Event id="2939609133" event_id="19" type_id="61" period_id="1" min="1" sec="30" player_id="207884" team_id="244" outcome="0" x="51.7" y="80.2" timestamp="2026-05-18T18:07:19.945" timestamp_utc="2026-05-18T17:07:19.945" last_modified="2026-05-18T18:07:20" version="1779124039947">
+      <Q id="6427358885" qualifier_id="56" value="Left"/>
+    </Event>
+    <Event id="2939616981" event_id="93" type_id="56" period_id="1" min="1" sec="31" player_id="157851" team_id="417" outcome="1" x="43.8" y="7.1" timestamp="2026-05-18T18:07:21.757" timestamp_utc="2026-05-18T17:07:21.757" last_modified="2026-05-18T18:21:48" version="1779124908840">
+      <Q id="6427402931" qualifier_id="56" value="Back"/>
+    </Event>
+    <Event id="2939609157" event_id="20" type_id="5" period_id="1" min="1" sec="33" player_id="207884" team_id="244" outcome="0" x="57.0" y="101.9" timestamp="2026-05-18T18:07:23.337" timestamp_utc="2026-05-18T17:07:23.337" last_modified="2026-05-18T19:36:46" version="1779129405444">
+      <Q id="6427359031" qualifier_id="56" value="Left"/>
+      <Q id="6427359171" qualifier_id="233" value="12"/>
+      <Q id="6427359033" qualifier_id="347"/>
+    </Event>
+    <Event id="2939609185" event_id="12" type_id="5" period_id="1" min="1" sec="33" player_id="157851" team_id="417" outcome="1" x="43.0" y="-1.9" timestamp="2026-05-18T18:07:23.337" timestamp_utc="2026-05-18T17:07:23.337" last_modified="2026-05-18T19:36:46" version="1779129405420">
+      <Q id="6427359163" qualifier_id="56" value="Back"/>
+      <Q id="6427359167" qualifier_id="233" value="20"/>
+      <Q id="6427359165" qualifier_id="347"/>
+    </Event>
+    <Event id="2939609197" event_id="13" type_id="1" period_id="1" min="1" sec="40" player_id="157851" team_id="417" outcome="1" x="44.0" y="0.0" timestamp="2026-05-18T18:07:30.073" timestamp_utc="2026-05-18T17:07:30.073" last_modified="2026-05-18T18:07:32" version="1779124051147">
+      <Q id="6427359221" qualifier_id="56" value="Right"/>
+      <Q id="6427359219" qualifier_id="107"/>
+      <Q id="6427359223" qualifier_id="140" value="56.7"/>
+      <Q id="6427359225" qualifier_id="141" value="18.8"/>
+      <Q id="6427359227" qualifier_id="212" value="19.4"/>
+      <Q id="6427359229" qualifier_id="213" value="0.81"/>
+    </Event>
+    <Event id="2939609201" event_id="14" type_id="1" period_id="1" min="1" sec="42" player_id="61778" team_id="417" outcome="0" x="55.8" y="10.3" timestamp="2026-05-18T18:07:32.056" timestamp_utc="2026-05-18T17:07:32.056" last_modified="2026-05-18T18:07:32" version="1779124052427">
+      <Q id="6427359237" qualifier_id="56" value="Right"/>
+      <Q id="6427359239" qualifier_id="140" value="56.8"/>
+      <Q id="6427359241" qualifier_id="141" value="10.6"/>
+      <Q id="6427359243" qualifier_id="212" value="1.1"/>
+      <Q id="6427359245" qualifier_id="213" value="0.19"/>
+      <Q id="6427359253" qualifier_id="233" value="21"/>
+      <Q id="6427359247" qualifier_id="236"/>
+      <Q id="6427359251" qualifier_id="286"/>
+    </Event>
+    <Event id="2939609199" event_id="21" type_id="74" period_id="1" min="1" sec="42" player_id="232091" team_id="244" outcome="1" x="43.2" y="89.4" timestamp="2026-05-18T18:07:32.057" timestamp_utc="2026-05-18T17:07:32.057" last_modified="2026-05-18T19:37:38" version="1779129458671">
+      <Q id="6427359233" qualifier_id="56" value="Back"/>
+      <Q id="6427359269" qualifier_id="233" value="14"/>
+      <Q id="6427359235" qualifier_id="285"/>
+    </Event>
+    <Event id="2939609215" event_id="22" type_id="1" period_id="1" min="1" sec="43" player_id="232091" team_id="244" outcome="1" x="38.9" y="96.9" timestamp="2026-05-18T18:07:33.492" timestamp_utc="2026-05-18T17:07:33.492" last_modified="2026-05-18T18:07:35" version="1779124053643">
+      <Q id="6427359313" qualifier_id="56" value="Back"/>
+      <Q id="6427359315" qualifier_id="140" value="22.6"/>
+      <Q id="6427359317" qualifier_id="141" value="88.3"/>
+      <Q id="6427359319" qualifier_id="212" value="18.1"/>
+      <Q id="6427359321" qualifier_id="213" value="3.47"/>
+    </Event>
+    <Event id="2939609221" event_id="23" type_id="1" period_id="1" min="1" sec="45" player_id="575855" team_id="244" outcome="0" x="26.4" y="89.9" timestamp="2026-05-18T18:07:35.217" timestamp_utc="2026-05-18T17:07:35.217" last_modified="2026-05-18T18:07:37" version="1779124057435">
+      <Q id="6427359373" qualifier_id="1"/>
+      <Q id="6427359363" qualifier_id="56" value="Left"/>
+      <Q id="6427359365" qualifier_id="140" value="67.6"/>
+      <Q id="6427359367" qualifier_id="141" value="100.0"/>
+      <Q id="6427359361" qualifier_id="157"/>
+      <Q id="6427359369" qualifier_id="212" value="44.0"/>
+      <Q id="6427359371" qualifier_id="213" value="0.19"/>
+    </Event>
+    <Event id="2939609225" event_id="24" type_id="5" period_id="1" min="1" sec="47" player_id="575855" team_id="244" outcome="0" x="67.3" y="101.8" timestamp="2026-05-18T18:07:37.360" timestamp_utc="2026-05-18T17:07:37.360" last_modified="2026-05-18T19:36:47" version="1779129405451">
+      <Q id="6427359387" qualifier_id="56" value="Left"/>
+      <Q id="6427359823" qualifier_id="233" value="15"/>
+      <Q id="6427359389" qualifier_id="347"/>
+    </Event>
+    <Event id="2939609291" event_id="15" type_id="5" period_id="1" min="1" sec="47" player_id="61778" team_id="417" outcome="1" x="32.7" y="-1.8" timestamp="2026-05-18T18:07:37.360" timestamp_utc="2026-05-18T17:07:37.360" last_modified="2026-05-18T19:36:47" version="1779129405447">
+      <Q id="6427359775" qualifier_id="56" value="Back"/>
+      <Q id="6427359801" qualifier_id="233" value="24"/>
+      <Q id="6427359777" qualifier_id="347"/>
+    </Event>
+    <Event id="2939609315" event_id="16" type_id="1" period_id="1" min="1" sec="57" player_id="157851" team_id="417" outcome="1" x="32.1" y="0.0" timestamp="2026-05-18T18:07:47.760" timestamp_utc="2026-05-18T17:07:47.760" last_modified="2026-05-18T18:07:49" version="1779124069131">
+      <Q id="6427359889" qualifier_id="1"/>
+      <Q id="6427359879" qualifier_id="56" value="Right"/>
+      <Q id="6427359877" qualifier_id="107"/>
+      <Q id="6427359881" qualifier_id="140" value="63.1"/>
+      <Q id="6427359883" qualifier_id="141" value="12.2"/>
+      <Q id="6427359885" qualifier_id="212" value="33.9"/>
+      <Q id="6427359887" qualifier_id="213" value="0.28"/>
+    </Event>
+    <Event id="2939609327" event_id="17" type_id="1" period_id="1" min="1" sec="59" player_id="445539" team_id="417" outcome="1" x="63.1" y="12.2" timestamp="2026-05-18T18:07:49.816" timestamp_utc="2026-05-18T17:07:49.816" last_modified="2026-05-18T18:07:51" version="1779124070187">
+      <Q id="6427359951" qualifier_id="3"/>
+      <Q id="6427359953" qualifier_id="56" value="Center"/>
+      <Q id="6427359955" qualifier_id="140" value="62.4"/>
+      <Q id="6427359957" qualifier_id="141" value="23.9"/>
+      <Q id="6427359959" qualifier_id="212" value="8.0"/>
+      <Q id="6427359961" qualifier_id="213" value="1.66"/>
+    </Event>
+    <Event id="2939609329" event_id="18" type_id="61" period_id="1" min="2" sec="1" player_id="61778" team_id="417" outcome="0" x="62.3" y="22.4" timestamp="2026-05-18T18:07:51.704" timestamp_utc="2026-05-18T17:07:51.704" last_modified="2026-05-18T18:22:25" version="1779124945061">
+      <Q id="6427359967" qualifier_id="56" value="Center"/>
+    </Event>
+    <Event id="2939609343" event_id="25" type_id="61" period_id="1" min="2" sec="5" player_id="515742" team_id="244" outcome="0" x="35.4" y="74.2" timestamp="2026-05-18T18:07:55.257" timestamp_utc="2026-05-18T17:07:55.257" last_modified="2026-05-18T18:25:23" version="1779125122884">
+      <Q id="6427360031" qualifier_id="56" value="Back"/>
+    </Event>
+    <Event id="2939609345" event_id="26" type_id="5" period_id="1" min="2" sec="6" player_id="515742" team_id="244" outcome="0" x="37.9" y="101.5" timestamp="2026-05-18T18:07:56.014" timestamp_utc="2026-05-18T17:07:56.014" last_modified="2026-05-18T18:10:47" version="1779124246728">
+      <Q id="6427360041" qualifier_id="56" value="Back"/>
+      <Q id="6427360273" qualifier_id="233" value="19"/>
+      <Q id="6427360043" qualifier_id="347"/>
+    </Event>
+    <Event id="2939609375" event_id="19" type_id="5" period_id="1" min="2" sec="6" player_id="685390" team_id="417" outcome="1" x="62.1" y="-1.5" timestamp="2026-05-18T18:07:56.014" timestamp_utc="2026-05-18T17:07:56.014" last_modified="2026-05-18T19:36:47" version="1779129405456">
+      <Q id="6427360207" qualifier_id="56" value="Right"/>
+      <Q id="6427360249" qualifier_id="233" value="26"/>
+      <Q id="6427360209" qualifier_id="347"/>
+    </Event>
+    <Event id="2939609395" event_id="20" type_id="1" period_id="1" min="2" sec="11" player_id="157851" team_id="417" outcome="1" x="63.9" y="0.0" timestamp="2026-05-18T18:08:01.257" timestamp_utc="2026-05-18T17:08:01.257" last_modified="2026-05-18T18:08:03" version="1779124082154">
+      <Q id="6427360325" qualifier_id="56" value="Right"/>
+      <Q id="6427360323" qualifier_id="107"/>
+      <Q id="6427360327" qualifier_id="140" value="73.5"/>
+      <Q id="6427360329" qualifier_id="141" value="5.8"/>
+      <Q id="6427360331" qualifier_id="212" value="11.4"/>
+      <Q id="6427360333" qualifier_id="213" value="0.48"/>
+    </Event>
+    <Event id="2939609401" event_id="21" type_id="1" period_id="1" min="2" sec="13" player_id="685390" team_id="417" outcome="0" x="73.5" y="5.8" timestamp="2026-05-18T18:08:03.320" timestamp_utc="2026-05-18T17:08:03.320" last_modified="2026-05-18T18:11:12" version="1779124272505">
+      <Q id="6427360365" qualifier_id="56" value="Right"/>
+      <Q id="6427360367" qualifier_id="140" value="74.5"/>
+      <Q id="6427360369" qualifier_id="141" value="16.4"/>
+      <Q id="6427360363" qualifier_id="168"/>
+      <Q id="6427360371" qualifier_id="212" value="7.3"/>
+      <Q id="6427360373" qualifier_id="213" value="1.43"/>
+    </Event>
+    <Event id="2939609425" event_id="28" type_id="43" period_id="1" min="2" sec="13" player_id="515742" team_id="244" outcome="1" x="0.0" y="0.0" timestamp="2026-05-18T18:08:03.321" timestamp_utc="2026-05-18T17:08:03.321" last_modified="2026-05-18T18:08:16" version="1779124094980">
+      <Q id="6427360509" qualifier_id="56" value="Back"/>
+      <Q id="6427360949" qualifier_id="144" value="74"/>
+      <Q id="6427360551" qualifier_id="233" value="21"/>
+      <Q id="6427360511" qualifier_id="285" value="0"/>
+    </Event>
+    <Event id="2939609415" event_id="22" type_id="43" period_id="1" min="2" sec="16" player_id="157851" team_id="417" outcome="1" x="0.0" y="0.0" timestamp="2026-05-18T18:08:06.000" timestamp_utc="2026-05-18T17:08:06.000" last_modified="2026-05-18T18:08:12" version="1779124086288">
+      <Q id="6427360451" qualifier_id="56" value="Right"/>
+      <Q id="6427360453" qualifier_id="140" value="74.3"/>
+      <Q id="6427360455" qualifier_id="141" value="19.8"/>
+      <Q id="6427360731" qualifier_id="144" value="1"/>
+      <Q id="6427360457" qualifier_id="212" value="2.2"/>
+      <Q id="6427360459" qualifier_id="213" value="1.22"/>
+    </Event>
+    <Event id="2939609421" event_id="27" type_id="1" period_id="1" min="2" sec="16" player_id="515742" team_id="244" outcome="0" x="25.4" y="77.2" timestamp="2026-05-18T18:08:06.312" timestamp_utc="2026-05-18T17:08:06.312" last_modified="2026-05-18T18:11:30" version="1779124290825">
+      <Q id="6427360485" qualifier_id="3"/>
+      <Q id="6427360487" qualifier_id="56" value="Back"/>
+      <Q id="6427360489" qualifier_id="140" value="28.4"/>
+      <Q id="6427360491" qualifier_id="141" value="78.5"/>
+      <Q id="6427360493" qualifier_id="212" value="3.3"/>
+      <Q id="6427360495" qualifier_id="213" value="0.27"/>
+    </Event>
+    <Event id="2939617737" event_id="94" type_id="61" period_id="1" min="2" sec="17" player_id="157851" team_id="417" outcome="0" x="64.3" y="21.6" timestamp="2026-05-18T18:08:07.196" timestamp_utc="2026-05-18T17:08:07.196" last_modified="2026-05-18T18:22:55" version="1779124975256">
+      <Q id="6427407075" qualifier_id="56" value="Center"/>
+    </Event>
+    <Event id="2939609445" event_id="29" type_id="4" period_id="1" min="2" sec="19" player_id="515742" team_id="244" outcome="1" x="30.2" y="85.4" timestamp="2026-05-18T18:08:09.576" timestamp_utc="2026-05-18T17:08:09.576" last_modified="2026-05-18T18:24:38" version="1779125078630">
+      <Q id="6427414245" qualifier_id="12"/>
+      <Q id="6427360709" qualifier_id="56" value="Back"/>
+      <Q id="6427360723" qualifier_id="233" value="23"/>
+      <Q id="6427414247" qualifier_id="241"/>
+      <Q id="6427360717" qualifier_id="285"/>
+    </Event>
+    <Event id="2939609447" event_id="23" type_id="4" period_id="1" min="2" sec="19" player_id="157851" team_id="417" outcome="0" x="69.8" y="14.6" timestamp="2026-05-18T18:08:09.577" timestamp_utc="2026-05-18T17:08:09.577" last_modified="2026-05-19T16:15:47" version="1779203747270">
+      <Q id="6427414281" qualifier_id="12"/>
+      <Q id="6427360645" qualifier_id="56" value="Right"/>
+      <Q id="6427360729" qualifier_id="233" value="29"/>
+      <Q id="6427414283" qualifier_id="241"/>
+      <Q id="6427360651" qualifier_id="286"/>
+    </Event>
+    <Event id="2939609521" event_id="30" type_id="1" period_id="1" min="2" sec="27" player_id="515742" team_id="244" outcome="1" x="29.7" y="77.5" timestamp="2026-05-18T18:08:17.849" timestamp_utc="2026-05-18T17:08:17.849" last_modified="2026-05-18T18:25:36" version="1779125136316">
+      <Q id="6427361003" qualifier_id="5"/>
+      <Q id="6427361007" qualifier_id="56" value="Back"/>
+      <Q id="6427361009" qualifier_id="140" value="23.3"/>
+      <Q id="6427361011" qualifier_id="141" value="60.3"/>
+      <Q id="6427361005" qualifier_id="152"/>
+      <Q id="6427361013" qualifier_id="212" value="13.5"/>
+      <Q id="6427361015" qualifier_id="213" value="4.19"/>
+    </Event>
+    <Event id="2939609539" event_id="31" type_id="1" period_id="1" min="2" sec="29" player_id="180662" team_id="244" outcome="1" x="24.1" y="56.0" timestamp="2026-05-18T18:08:19.440" timestamp_utc="2026-05-18T17:08:19.440" last_modified="2026-05-18T18:08:21" version="1779124099753">
+      <Q id="6427361091" qualifier_id="56" value="Back"/>
+      <Q id="6427361095" qualifier_id="140" value="27.9"/>
+      <Q id="6427361099" qualifier_id="141" value="22.8"/>
+      <Q id="6427361105" qualifier_id="212" value="22.9"/>
+      <Q id="6427361107" qualifier_id="213" value="4.89"/>
+    </Event>
+    <Event id="2939609563" event_id="32" type_id="1" period_id="1" min="2" sec="32" player_id="627127" team_id="244" outcome="0" x="27.2" y="25.9" timestamp="2026-05-18T18:08:22.600" timestamp_utc="2026-05-18T17:08:22.600" last_modified="2026-05-18T18:08:24" version="1779124104640">
+      <Q id="6427361283" qualifier_id="1"/>
+      <Q id="6427361273" qualifier_id="56" value="Center"/>
+      <Q id="6427361275" qualifier_id="140" value="72.8"/>
+      <Q id="6427361277" qualifier_id="141" value="32.4"/>
+      <Q id="6427361271" qualifier_id="155"/>
+      <Q id="6427361279" qualifier_id="212" value="48.1"/>
+      <Q id="6427361281" qualifier_id="213" value="0.09"/>
+    </Event>
+    <Event id="2939609569" event_id="24" type_id="1" period_id="1" min="2" sec="35" player_id="61812" team_id="417" outcome="0" x="28.7" y="69.0" timestamp="2026-05-18T18:08:25.497" timestamp_utc="2026-05-18T17:08:25.497" last_modified="2026-05-18T18:08:26" version="1779124106336">
+      <Q id="6427361313" qualifier_id="3"/>
+      <Q id="6427361315" qualifier_id="56" value="Back"/>
+      <Q id="6427361317" qualifier_id="140" value="34.7"/>
+      <Q id="6427361319" qualifier_id="141" value="83.5"/>
+      <Q id="6427361321" qualifier_id="212" value="11.7"/>
+      <Q id="6427361323" qualifier_id="213" value="1.00"/>
+    </Event>
+    <Event id="2939609581" event_id="33" type_id="61" period_id="1" min="2" sec="38" player_id="232091" team_id="244" outcome="0" x="72.6" y="19.2" timestamp="2026-05-18T18:08:28.649" timestamp_utc="2026-05-18T17:08:28.649" last_modified="2026-05-18T18:08:28" version="1779124108650">
+      <Q id="6427361409" qualifier_id="56" value="Right"/>
+    </Event>
+    <Event id="2939609601" event_id="25" type_id="1" period_id="1" min="2" sec="39" player_id="218339" team_id="417" outcome="1" x="31.5" y="93.9" timestamp="2026-05-18T18:08:29.088" timestamp_utc="2026-05-18T17:08:29.088" last_modified="2026-05-18T18:08:30" version="1779124109394">
+      <Q id="6427361483" qualifier_id="56" value="Back"/>
+      <Q id="6427361485" qualifier_id="140" value="23.8"/>
+      <Q id="6427361487" qualifier_id="141" value="84.1"/>
+      <Q id="6427361489" qualifier_id="212" value="10.5"/>
+      <Q id="6427361491" qualifier_id="213" value="3.83"/>
+    </Event>
+    <Event id="2939609603" event_id="26" type_id="49" period_id="1" min="2" sec="40" player_id="624620" team_id="417" outcome="1" x="23.8" y="84.1" timestamp="2026-05-18T18:08:29.888" timestamp_utc="2026-05-18T17:08:29.888" last_modified="2026-05-18T18:08:30" version="1779124109890"/>
+    <Event id="2939609653" event_id="34" type_id="43" period_id="1" min="2" sec="45" player_id="515742" team_id="244" outcome="1" x="0.0" y="0.0" timestamp="2026-05-18T18:08:35.599" timestamp_utc="2026-05-18T17:08:35.599" last_modified="2026-05-18T18:08:40" version="1779124115601">
+      <Q id="6427361741" qualifier_id="56" value="Center"/>
+      <Q id="6427361895" qualifier_id="144" value="45"/>
+      <Q id="6427361743" qualifier_id="285" value="0"/>
+    </Event>
+    <Event id="2939609663" event_id="27" type_id="4" period_id="1" min="2" sec="46" player_id="624620" team_id="417" outcome="1" x="37.2" y="70.4" timestamp="2026-05-18T18:08:36.328" timestamp_utc="2026-05-18T17:08:36.328" last_modified="2026-05-18T18:08:40" version="1779124118296">
+      <Q id="6427361789" qualifier_id="13"/>
+      <Q id="6427361791" qualifier_id="56" value="Back"/>
+      <Q id="6427361793" qualifier_id="152"/>
+      <Q id="6427361839" qualifier_id="233" value="35"/>
+      <Q id="6427361795" qualifier_id="265"/>
+      <Q id="6427361837" qualifier_id="286"/>
+    </Event>
+    <Event id="2939609667" event_id="35" type_id="4" period_id="1" min="2" sec="46" player_id="515742" team_id="244" outcome="0" x="62.8" y="29.6" timestamp="2026-05-18T18:08:36.329" timestamp_utc="2026-05-18T17:08:36.329" last_modified="2026-05-18T18:08:40" version="1779124118298">
+      <Q id="6427361821" qualifier_id="13"/>
+      <Q id="6427361823" qualifier_id="56" value="Center"/>
+      <Q id="6427361825" qualifier_id="152"/>
+      <Q id="6427361845" qualifier_id="233" value="27"/>
+      <Q id="6427361827" qualifier_id="265"/>
+      <Q id="6427361829" qualifier_id="285"/>
+    </Event>
+    <Event id="2939609757" event_id="28" type_id="1" period_id="1" min="2" sec="58" player_id="720682" team_id="417" outcome="1" x="32.8" y="77.2" timestamp="2026-05-18T18:08:48.712" timestamp_utc="2026-05-18T17:08:48.712" last_modified="2026-05-18T18:25:37" version="1779125137633">
+      <Q id="6427362271" qualifier_id="1"/>
+      <Q id="6427362255" qualifier_id="5"/>
+      <Q id="6427362261" qualifier_id="56" value="Left"/>
+      <Q id="6427362263" qualifier_id="140" value="73.3"/>
+      <Q id="6427362265" qualifier_id="141" value="84.1"/>
+      <Q id="6427362259" qualifier_id="152"/>
+      <Q id="6427362257" qualifier_id="155"/>
+      <Q id="6427362513" qualifier_id="189"/>
+      <Q id="6427362267" qualifier_id="212" value="42.8"/>
+      <Q id="6427362269" qualifier_id="213" value="0.11"/>
+    </Event>
+    <Event id="2939609761" event_id="29" type_id="1" period_id="1" min="3" sec="1" player_id="624620" team_id="417" outcome="0" x="76.7" y="81.5" timestamp="2026-05-18T18:08:51.176" timestamp_utc="2026-05-18T17:08:51.176" last_modified="2026-05-18T18:25:48" version="1779125148819">
+      <Q id="6427418269" qualifier_id="2"/>
+      <Q id="6427362277" qualifier_id="56" value="Center"/>
+      <Q id="6427362279" qualifier_id="140" value="89.1"/>
+      <Q id="6427362281" qualifier_id="141" value="58.5"/>
+      <Q id="6427362283" qualifier_id="212" value="20.4"/>
+      <Q id="6427362285" qualifier_id="213" value="5.41"/>
+    </Event>
+    <Event id="2939609771" event_id="36" type_id="12" period_id="1" min="3" sec="3" player_id="180662" team_id="244" outcome="1" x="13.3" y="41.5" timestamp="2026-05-18T18:08:52.959" timestamp_utc="2026-05-18T17:08:52.959" last_modified="2026-05-18T18:08:54" version="1779124134244">
+      <Q id="6427362331" qualifier_id="56" value="Back"/>
+      <Q id="6427362333" qualifier_id="140" value="24.5"/>
+      <Q id="6427362335" qualifier_id="141" value="0.0"/>
+      <Q id="6427362393" qualifier_id="167"/>
+      <Q id="6427362337" qualifier_id="212" value="31.8"/>
+      <Q id="6427362339" qualifier_id="213" value="5.09"/>
+    </Event>
+    <Event id="2939609775" event_id="37" type_id="5" period_id="1" min="3" sec="4" player_id="180662" team_id="244" outcome="0" x="26.8" y="-1.7" timestamp="2026-05-18T18:08:54.231" timestamp_utc="2026-05-18T17:08:54.231" last_modified="2026-05-18T19:36:48" version="1779129407835">
+      <Q id="6427362361" qualifier_id="56" value="Back"/>
+      <Q id="6427362545" qualifier_id="233" value="30"/>
+      <Q id="6427362363" qualifier_id="347"/>
+    </Event>
+    <Event id="2939609795" event_id="30" type_id="5" period_id="1" min="3" sec="4" player_id="624620" team_id="417" outcome="1" x="73.2" y="101.7" timestamp="2026-05-18T18:08:54.231" timestamp_utc="2026-05-18T17:08:54.231" last_modified="2026-05-18T19:36:47" version="1779129407818">
+      <Q id="6427362487" qualifier_id="56" value="Left"/>
+      <Q id="6427362529" qualifier_id="233" value="37"/>
+      <Q id="6427362489" qualifier_id="347"/>
+    </Event>
+    <Event id="2939609899" event_id="31" type_id="1" period_id="1" min="3" sec="24" player_id="624620" team_id="417" outcome="0" x="77.4" y="100.0" timestamp="2026-05-18T18:09:14.183" timestamp_utc="2026-05-18T17:09:14.183" last_modified="2026-05-18T18:09:16" version="1779124156615">
+      <Q id="6427363123" qualifier_id="1"/>
+      <Q id="6427363113" qualifier_id="56" value="Center"/>
+      <Q id="6427363111" qualifier_id="107"/>
+      <Q id="6427363115" qualifier_id="140" value="89.2"/>
+      <Q id="6427363117" qualifier_id="141" value="65.7"/>
+      <Q id="6427363119" qualifier_id="212" value="27.6"/>
+      <Q id="6427363121" qualifier_id="213" value="5.18"/>
+    </Event>
+    <Event id="2939609919" event_id="38" type_id="12" period_id="1" min="3" sec="28" player_id="479433" team_id="244" outcome="1" x="10.5" y="44.8" timestamp="2026-05-18T18:09:17.887" timestamp_utc="2026-05-18T17:09:17.887" last_modified="2026-05-18T18:25:49" version="1779125149388">
+      <Q id="6427363311" qualifier_id="15"/>
+      <Q id="6427363285" qualifier_id="56" value="Back"/>
+      <Q id="6427363287" qualifier_id="140" value="26.8"/>
+      <Q id="6427363289" qualifier_id="141" value="54.3"/>
+      <Q id="6427363291" qualifier_id="212" value="18.3"/>
+      <Q id="6427363293" qualifier_id="213" value="0.36"/>
+    </Event>
+    <Event id="2939609993" event_id="40" type_id="44" period_id="1" min="3" sec="29" player_id="207884" team_id="244" outcome="1" x="26.8" y="54.3" timestamp="2026-05-18T18:09:19.062" timestamp_utc="2026-05-18T17:09:19.062" last_modified="2026-05-18T18:22:49" version="1779124969756">
+      <Q id="6427363693" qualifier_id="56" value="Back"/>
+      <Q id="6427363697" qualifier_id="233" value="32"/>
+      <Q id="6427363695" qualifier_id="285"/>
+    </Event>
+    <Event id="2939609929" event_id="32" type_id="44" period_id="1" min="3" sec="29" player_id="61778" team_id="417" outcome="0" x="73.2" y="45.7" timestamp="2026-05-18T18:09:19.063" timestamp_utc="2026-05-18T17:09:19.063" last_modified="2026-05-18T18:22:50" version="1779124969806">
+      <Q id="6427363337" qualifier_id="56" value="Center"/>
+      <Q id="6427363723" qualifier_id="233" value="40"/>
+      <Q id="6427363339" qualifier_id="286"/>
+    </Event>
+    <Event id="2939609941" event_id="39" type_id="12" period_id="1" min="3" sec="29" player_id="207884" team_id="244" outcome="1" x="26.8" y="54.3" timestamp="2026-05-18T18:09:19.791" timestamp_utc="2026-05-18T17:09:19.791" last_modified="2026-05-18T18:09:22" version="1779124161454">
+      <Q id="6427363443" qualifier_id="15"/>
+      <Q id="6427363409" qualifier_id="56" value="Back"/>
+      <Q id="6427363411" qualifier_id="140" value="36.5"/>
+      <Q id="6427363413" qualifier_id="141" value="57.3"/>
+      <Q id="6427363415" qualifier_id="212" value="10.4"/>
+      <Q id="6427363417" qualifier_id="213" value="0.20"/>
+    </Event>
+    <Event id="2939609969" event_id="33" type_id="1" period_id="1" min="3" sec="34" player_id="720682" team_id="417" outcome="0" x="55.0" y="48.1" timestamp="2026-05-18T18:09:24.351" timestamp_utc="2026-05-18T17:09:24.351" last_modified="2026-05-18T18:26:28" version="1779125187966">
+      <Q id="6427363599" qualifier_id="1"/>
+      <Q id="6427363589" qualifier_id="56" value="Center"/>
+      <Q id="6427363591" qualifier_id="140" value="90.5"/>
+      <Q id="6427363593" qualifier_id="141" value="62.4"/>
+      <Q id="6427373691" qualifier_id="157"/>
+      <Q id="6427363595" qualifier_id="212" value="38.5"/>
+      <Q id="6427363597" qualifier_id="213" value="0.26"/>
+    </Event>
+    <Event id="2939609995" event_id="41" type_id="52" period_id="1" min="3" sec="38" player_id="578592" team_id="244" outcome="1" x="7.6" y="56.4" timestamp="2026-05-18T18:09:28.662" timestamp_utc="2026-05-18T17:09:28.662" last_modified="2026-05-18T18:09:29" version="1779124168664"/>
+    <Event id="2939610017" event_id="42" type_id="1" period_id="1" min="3" sec="39" player_id="578592" team_id="244" outcome="0" x="9.1" y="58.7" timestamp="2026-05-18T18:09:29.192" timestamp_utc="2026-05-18T17:09:29.192" last_modified="2026-05-18T18:09:31" version="1779124171607">
+      <Q id="6427363829" qualifier_id="1"/>
+      <Q id="6427363819" qualifier_id="56" value="Center"/>
+      <Q id="6427363821" qualifier_id="140" value="70.7"/>
+      <Q id="6427363823" qualifier_id="141" value="38.3"/>
+      <Q id="6427363817" qualifier_id="199"/>
+      <Q id="6427363825" qualifier_id="212" value="66.2"/>
+      <Q id="6427363827" qualifier_id="213" value="6.07"/>
+    </Event>
+    <Event id="2939610027" event_id="34" type_id="12" period_id="1" min="3" sec="42" player_id="720682" team_id="417" outcome="1" x="32.1" y="67.6" timestamp="2026-05-18T18:09:32.183" timestamp_utc="2026-05-18T17:09:32.183" last_modified="2026-05-18T18:09:33" version="1779124172974">
+      <Q id="6427363861" qualifier_id="56" value="Back"/>
+      <Q id="6427363863" qualifier_id="140" value="34.9"/>
+      <Q id="6427363865" qualifier_id="141" value="100.0"/>
+      <Q id="6427363903" qualifier_id="167"/>
+      <Q id="6427363867" qualifier_id="212" value="23.6"/>
+      <Q id="6427363869" qualifier_id="213" value="1.45"/>
+    </Event>
+    <Event id="2939610031" event_id="35" type_id="5" period_id="1" min="3" sec="43" player_id="720682" team_id="417" outcome="0" x="33.8" y="102.0" timestamp="2026-05-18T18:09:32.960" timestamp_utc="2026-05-18T17:09:32.960" last_modified="2026-05-18T19:36:48" version="1779129407842">
+      <Q id="6427363887" qualifier_id="56" value="Back"/>
+      <Q id="6427364177" qualifier_id="233" value="43"/>
+      <Q id="6427363889" qualifier_id="347"/>
+    </Event>
+    <Event id="2939610085" event_id="43" type_id="5" period_id="1" min="3" sec="43" player_id="578592" team_id="244" outcome="1" x="66.2" y="-2.0" timestamp="2026-05-18T18:09:32.960" timestamp_utc="2026-05-18T17:09:32.960" last_modified="2026-05-18T19:36:48" version="1779129407838">
+      <Q id="6427364151" qualifier_id="56" value="Right"/>
+      <Q id="6427364173" qualifier_id="233" value="35"/>
+      <Q id="6427364153" qualifier_id="347"/>
+    </Event>
+    <Event id="2939610169" event_id="44" type_id="1" period_id="1" min="3" sec="56" player_id="625775" team_id="244" outcome="0" x="68.1" y="0.0" timestamp="2026-05-18T18:09:46.662" timestamp_utc="2026-05-18T17:09:46.662" last_modified="2026-05-18T18:15:08" version="1779124508717">
+      <Q id="6427364737" qualifier_id="56" value="Right"/>
+      <Q id="6427364735" qualifier_id="107"/>
+      <Q id="6427364739" qualifier_id="140" value="73.0"/>
+      <Q id="6427364741" qualifier_id="141" value="8.8"/>
+      <Q id="6427379829" qualifier_id="189"/>
+      <Q id="6427364743" qualifier_id="212" value="9.0"/>
+      <Q id="6427364745" qualifier_id="213" value="0.96"/>
+    </Event>
+    <Event id="2939610131" event_id="36" type_id="4" period_id="1" min="3" sec="59" player_id="61778" team_id="417" outcome="1" x="32.3" y="87.6" timestamp="2026-05-18T18:09:49.015" timestamp_utc="2026-05-18T17:09:49.015" last_modified="2026-05-18T18:22:45" version="1779124965258">
+      <Q id="6427364497" qualifier_id="13"/>
+      <Q id="6427364499" qualifier_id="56" value="Back"/>
+      <Q id="6427364501" qualifier_id="152"/>
+      <Q id="6427364525" qualifier_id="189"/>
+      <Q id="6427378791" qualifier_id="233" value="45"/>
+      <Q id="6427364503" qualifier_id="265"/>
+      <Q id="6427378795" qualifier_id="285"/>
+    </Event>
+    <Event id="2939610173" event_id="45" type_id="4" period_id="1" min="3" sec="59" player_id="240166" team_id="244" outcome="0" x="67.7" y="12.4" timestamp="2026-05-18T18:09:49.016" timestamp_utc="2026-05-18T17:09:49.016" last_modified="2026-05-18T18:22:45" version="1779124965269">
+      <Q id="6427364761" qualifier_id="13"/>
+      <Q id="6427364763" qualifier_id="56" value="Right"/>
+      <Q id="6427364765" qualifier_id="152"/>
+      <Q id="6427379665" qualifier_id="189"/>
+      <Q id="6427378813" qualifier_id="233" value="36"/>
+      <Q id="6427364767" qualifier_id="265"/>
+      <Q id="6427364769" qualifier_id="286"/>
+    </Event>
+    <Event id="2939610205" event_id="37" type_id="1" period_id="1" min="4" sec="10" player_id="720682" team_id="417" outcome="0" x="36.5" y="88.0" timestamp="2026-05-18T18:10:00.479" timestamp_utc="2026-05-18T17:10:00.479" last_modified="2026-05-18T18:27:08" version="1779125228045">
+      <Q id="6427364947" qualifier_id="1"/>
+      <Q id="6427364931" qualifier_id="5"/>
+      <Q id="6427364937" qualifier_id="56" value="Center"/>
+      <Q id="6427364939" qualifier_id="140" value="69.7"/>
+      <Q id="6427364941" qualifier_id="141" value="66.7"/>
+      <Q id="6427364935" qualifier_id="152"/>
+      <Q id="6427364933" qualifier_id="155"/>
+      <Q id="6427422765" qualifier_id="189"/>
+      <Q id="6427364943" qualifier_id="212" value="37.7"/>
+      <Q id="6427364945" qualifier_id="213" value="5.89"/>
+    </Event>
+    <Event id="2939610221" event_id="46" type_id="1" period_id="1" min="4" sec="12" player_id="180662" team_id="244" outcome="1" x="29.6" y="62.9" timestamp="2026-05-18T18:10:02.366" timestamp_utc="2026-05-18T17:10:02.366" last_modified="2026-05-18T18:10:04" version="1779124202839">
+      <Q id="6427365033" qualifier_id="3"/>
+      <Q id="6427365035" qualifier_id="56" value="Back"/>
+      <Q id="6427365037" qualifier_id="140" value="44.6"/>
+      <Q id="6427365039" qualifier_id="141" value="32.5"/>
+      <Q id="6427365041" qualifier_id="212" value="26.0"/>
+      <Q id="6427365043" qualifier_id="213" value="5.36"/>
+    </Event>
+    <Event id="2939610223" event_id="47" type_id="49" period_id="1" min="4" sec="14" player_id="625775" team_id="244" outcome="1" x="42.2" y="32.4" timestamp="2026-05-18T18:10:03.958" timestamp_utc="2026-05-18T17:10:03.958" last_modified="2026-05-18T18:10:04" version="1779124203960"/>
+    <Event id="2939610227" event_id="38" type_id="83" period_id="1" min="4" sec="14" player_id="720682" team_id="417" outcome="0" x="62.6" y="80.2" timestamp="2026-05-18T18:10:04.406" timestamp_utc="2026-05-18T17:10:04.406" last_modified="2026-05-18T18:10:09" version="1779124209038">
+      <Q id="6427365267" qualifier_id="399" value="625775"/>
+    </Event>
+    <Event id="2939610257" event_id="48" type_id="1" period_id="1" min="4" sec="16" player_id="625775" team_id="244" outcome="1" x="37.3" y="16.4" timestamp="2026-05-18T18:10:06.598" timestamp_utc="2026-05-18T17:10:06.598" last_modified="2026-05-18T18:10:09" version="1779124207167">
+      <Q id="6427365243" qualifier_id="56" value="Back"/>
+      <Q id="6427365245" qualifier_id="140" value="18.4"/>
+      <Q id="6427365247" qualifier_id="141" value="28.6"/>
+      <Q id="6427365249" qualifier_id="212" value="21.5"/>
+      <Q id="6427365251" qualifier_id="213" value="2.75"/>
+    </Event>
+    <Event id="2939610275" event_id="49" type_id="1" period_id="1" min="4" sec="20" player_id="627127" team_id="244" outcome="0" x="20.0" y="25.9" timestamp="2026-05-18T18:10:10.758" timestamp_utc="2026-05-18T17:10:10.758" last_modified="2026-05-18T18:10:12" version="1779124211941">
+      <Q id="6427365335" qualifier_id="1"/>
+      <Q id="6427365325" qualifier_id="56" value="Center"/>
+      <Q id="6427365327" qualifier_id="140" value="58.4"/>
+      <Q id="6427365329" qualifier_id="141" value="25.0"/>
+      <Q id="6427365323" qualifier_id="155"/>
+      <Q id="6427365331" qualifier_id="212" value="40.3"/>
+      <Q id="6427365333" qualifier_id="213" value="6.27"/>
+    </Event>
+    <Event id="2939610285" event_id="39" type_id="50" period_id="1" min="4" sec="22" player_id="624620" team_id="417" outcome="1" x="41.6" y="85.6" timestamp="2026-05-18T18:10:12.494" timestamp_utc="2026-05-18T17:10:12.494" last_modified="2026-05-18T18:22:46" version="1779124965284">
+      <Q id="6427365379" qualifier_id="56" value="Back"/>
+      <Q id="6427365531" qualifier_id="233" value="50"/>
+      <Q id="6427365383" qualifier_id="286"/>
+    </Event>
+    <Event id="2939610301" event_id="50" type_id="7" period_id="1" min="4" sec="22" player_id="479433" team_id="244" outcome="1" x="58.4" y="14.4" timestamp="2026-05-18T18:10:12.495" timestamp_utc="2026-05-18T17:10:12.495" last_modified="2026-05-18T18:22:46" version="1779124965281">
+      <Q id="6427365491" qualifier_id="56" value="Right"/>
+      <Q id="6427365495" qualifier_id="178"/>
+      <Q id="6427365527" qualifier_id="233" value="39"/>
+      <Q id="6427365493" qualifier_id="285"/>
+    </Event>
+    <Event id="2939610329" event_id="51" type_id="1" period_id="1" min="4" sec="25" player_id="479433" team_id="244" outcome="1" x="58.5" y="26.8" timestamp="2026-05-18T18:10:15.693" timestamp_utc="2026-05-18T17:10:15.693" last_modified="2026-05-18T18:22:39" version="1779124959399">
+      <Q id="6427365633" qualifier_id="56" value="Center"/>
+      <Q id="6427365635" qualifier_id="140" value="55.2"/>
+      <Q id="6427365637" qualifier_id="141" value="36.1"/>
+      <Q id="6427365639" qualifier_id="212" value="7.2"/>
+      <Q id="6427365641" qualifier_id="213" value="2.07"/>
+    </Event>
+    <Event id="2939610397" event_id="52" type_id="1" period_id="1" min="4" sec="28" player_id="207884" team_id="244" outcome="1" x="60.7" y="39.7" timestamp="2026-05-18T18:10:18.534" timestamp_utc="2026-05-18T17:10:18.534" last_modified="2026-05-18T18:10:24" version="1779124220525">
+      <Q id="6427365987" qualifier_id="56" value="Center"/>
+      <Q id="6427365989" qualifier_id="140" value="78.3"/>
+      <Q id="6427365991" qualifier_id="141" value="73.5"/>
+      <Q id="6427365985" qualifier_id="155"/>
+      <Q id="6427365993" qualifier_id="212" value="29.5"/>
+      <Q id="6427365995" qualifier_id="213" value="0.89"/>
+    </Event>
+    <Event id="2939610409" event_id="53" type_id="1" period_id="1" min="4" sec="34" player_id="648131" team_id="244" outcome="1" x="91.0" y="89.6" timestamp="2026-05-18T18:10:24.437" timestamp_utc="2026-05-18T17:10:24.437" last_modified="2026-05-18T18:10:25" version="1779124224624">
+      <Q id="6427366067" qualifier_id="56" value="Left"/>
+      <Q id="6427366069" qualifier_id="140" value="85.2"/>
+      <Q id="6427366071" qualifier_id="141" value="90.2"/>
+      <Q id="6427366073" qualifier_id="212" value="6.1"/>
+      <Q id="6427366075" qualifier_id="213" value="3.07"/>
+    </Event>
+    <Event id="2939610427" event_id="54" type_id="1" period_id="1" min="4" sec="35" player_id="575855" team_id="244" outcome="1" x="85.2" y="90.2" timestamp="2026-05-18T18:10:25.829" timestamp_utc="2026-05-18T17:10:25.829" last_modified="2026-05-18T18:10:28" version="1779124226245">
+      <Q id="6427366167" qualifier_id="56" value="Left"/>
+      <Q id="6427366169" qualifier_id="140" value="79.3"/>
+      <Q id="6427366173" qualifier_id="141" value="82.3"/>
+      <Q id="6427366177" qualifier_id="212" value="8.2"/>
+      <Q id="6427366183" qualifier_id="213" value="3.86"/>
+    </Event>
+    <Event id="2939610445" event_id="55" type_id="1" period_id="1" min="4" sec="38" player_id="515742" team_id="244" outcome="1" x="75.4" y="74.4" timestamp="2026-05-18T18:10:28.437" timestamp_utc="2026-05-18T17:10:28.437" last_modified="2026-05-18T18:10:30" version="1779124228992">
+      <Q id="6427366281" qualifier_id="56" value="Center"/>
+      <Q id="6427366283" qualifier_id="140" value="79.3"/>
+      <Q id="6427366285" qualifier_id="141" value="62.1"/>
+      <Q id="6427366287" qualifier_id="212" value="9.3"/>
+      <Q id="6427366289" qualifier_id="213" value="5.17"/>
+    </Event>
+    <Event id="2939610447" event_id="56" type_id="50" period_id="1" min="4" sec="40" player_id="207884" team_id="244" outcome="1" x="76.0" y="65.2" timestamp="2026-05-18T18:10:30.637" timestamp_utc="2026-05-18T17:10:30.637" last_modified="2026-05-18T18:22:46" version="1779124965291">
+      <Q id="6427366299" qualifier_id="56" value="Center"/>
+      <Q id="6427367201" qualifier_id="233" value="40"/>
+      <Q id="6427366301" qualifier_id="286"/>
+    </Event>
+    <Event id="2939610461" event_id="40" type_id="7" period_id="1" min="4" sec="40" player_id="218339" team_id="417" outcome="1" x="24.0" y="34.8" timestamp="2026-05-18T18:10:30.638" timestamp_utc="2026-05-18T17:10:30.638" last_modified="2026-05-18T18:22:46" version="1779124965287">
+      <Q id="6427366411" qualifier_id="56" value="Back"/>
+      <Q id="6427366415" qualifier_id="178"/>
+      <Q id="6427367217" qualifier_id="233" value="56"/>
+      <Q id="6427366413" qualifier_id="285"/>
+    </Event>
+    <Event id="2939610469" event_id="41" type_id="1" period_id="1" min="4" sec="43" player_id="685390" team_id="417" outcome="0" x="26.4" y="19.8" timestamp="2026-05-18T18:10:32.862" timestamp_utc="2026-05-18T17:10:32.862" last_modified="2026-05-18T18:10:34" version="1779124233137">
+      <Q id="6427366437" qualifier_id="56" value="Back"/>
+      <Q id="6427366439" qualifier_id="140" value="30.9"/>
+      <Q id="6427366441" qualifier_id="141" value="25.6"/>
+      <Q id="6427366435" qualifier_id="155"/>
+      <Q id="6427366443" qualifier_id="212" value="6.2"/>
+      <Q id="6427366445" qualifier_id="213" value="0.70"/>
+    </Event>
+    <Event id="2939610489" event_id="57" type_id="1" period_id="1" min="4" sec="44" player_id="180662" team_id="244" outcome="1" x="56.1" y="88.4" timestamp="2026-05-18T18:10:34.221" timestamp_utc="2026-05-18T17:10:34.221" last_modified="2026-05-18T18:10:37" version="1779124234655">
+      <Q id="6427366555" qualifier_id="3"/>
+      <Q id="6427366557" qualifier_id="56" value="Left"/>
+      <Q id="6427366559" qualifier_id="140" value="66.4"/>
+      <Q id="6427366561" qualifier_id="141" value="81.2"/>
+      <Q id="6427366563" qualifier_id="212" value="11.9"/>
+      <Q id="6427366565" qualifier_id="213" value="5.86"/>
+    </Event>
+    <Event id="2939610491" event_id="58" type_id="50" period_id="1" min="4" sec="47" player_id="232091" team_id="244" outcome="1" x="75.0" y="77.4" timestamp="2026-05-18T18:10:37.013" timestamp_utc="2026-05-18T17:10:37.013" last_modified="2026-05-18T18:22:47" version="1779124965297">
+      <Q id="6427366575" qualifier_id="56" value="Center"/>
+      <Q id="6427366685" qualifier_id="233" value="42"/>
+      <Q id="6427366577" qualifier_id="286"/>
+    </Event>
+    <Event id="2939610505" event_id="42" type_id="7" period_id="1" min="4" sec="47" player_id="720682" team_id="417" outcome="1" x="25.0" y="22.6" timestamp="2026-05-18T18:10:37.014" timestamp_utc="2026-05-18T17:10:37.014" last_modified="2026-05-18T18:22:47" version="1779124965295">
+      <Q id="6427366643" qualifier_id="56" value="Back"/>
+      <Q id="6427366647" qualifier_id="178"/>
+      <Q id="6427366665" qualifier_id="233" value="58"/>
+      <Q id="6427366645" qualifier_id="285"/>
+    </Event>
+    <Event id="2939610511" event_id="43" type_id="1" period_id="1" min="4" sec="48" player_id="685390" team_id="417" outcome="0" x="23.1" y="7.4" timestamp="2026-05-18T18:10:38.598" timestamp_utc="2026-05-18T17:10:38.598" last_modified="2026-05-18T18:10:39" version="1779124239006">
+      <Q id="6427366691" qualifier_id="56" value="Back"/>
+      <Q id="6427366693" qualifier_id="140" value="32.9"/>
+      <Q id="6427366695" qualifier_id="141" value="25.2"/>
+      <Q id="6427366697" qualifier_id="212" value="15.9"/>
+      <Q id="6427366699" qualifier_id="213" value="0.87"/>
+    </Event>
+    <Event id="2939610547" event_id="59" type_id="1" period_id="1" min="4" sec="51" player_id="515742" team_id="244" outcome="1" x="60.5" y="82.7" timestamp="2026-05-18T18:10:41.245" timestamp_utc="2026-05-18T17:10:41.245" last_modified="2026-05-18T18:10:44" version="1779124241549">
+      <Q id="6427366887" qualifier_id="56" value="Left"/>
+      <Q id="6427366889" qualifier_id="140" value="66.0"/>
+      <Q id="6427366891" qualifier_id="141" value="88.0"/>
+      <Q id="6427366893" qualifier_id="212" value="6.8"/>
+      <Q id="6427366895" qualifier_id="213" value="0.56"/>
+    </Event>
+    <Event id="2939610561" event_id="60" type_id="1" period_id="1" min="4" sec="54" player_id="575855" team_id="244" outcome="1" x="67.5" y="87.4" timestamp="2026-05-18T18:10:44.085" timestamp_utc="2026-05-18T17:10:44.085" last_modified="2026-05-18T18:10:45" version="1779124244254">
+      <Q id="6427366963" qualifier_id="56" value="Left"/>
+      <Q id="6427366965" qualifier_id="140" value="59.8"/>
+      <Q id="6427366967" qualifier_id="141" value="82.9"/>
+      <Q id="6427366969" qualifier_id="212" value="8.6"/>
+      <Q id="6427366971" qualifier_id="213" value="3.50"/>
+    </Event>
+    <Event id="2939610597" event_id="61" type_id="1" period_id="1" min="4" sec="55" player_id="515742" team_id="244" outcome="1" x="58.7" y="76.1" timestamp="2026-05-18T18:10:45.389" timestamp_utc="2026-05-18T17:10:45.389" last_modified="2026-05-18T18:10:49" version="1779124246534">
+      <Q id="6427367173" qualifier_id="56" value="Back"/>
+      <Q id="6427367175" qualifier_id="140" value="44.3"/>
+      <Q id="6427367177" qualifier_id="141" value="52.7"/>
+      <Q id="6427367179" qualifier_id="212" value="22.0"/>
+      <Q id="6427367181" qualifier_id="213" value="3.95"/>
+    </Event>
+    <Event id="2939610651" event_id="62" type_id="1" period_id="1" min="5" sec="1" player_id="627127" team_id="244" outcome="1" x="47.8" y="52.2" timestamp="2026-05-18T18:10:50.909" timestamp_utc="2026-05-18T17:10:50.909" last_modified="2026-05-18T18:10:54" version="1779124251269">
+      <Q id="6427367467" qualifier_id="56" value="Left"/>
+      <Q id="6427367469" qualifier_id="140" value="58.6"/>
+      <Q id="6427367471" qualifier_id="141" value="81.2"/>
+      <Q id="6427367473" qualifier_id="212" value="22.7"/>
+      <Q id="6427367475" qualifier_id="213" value="1.05"/>
+    </Event>
+    <Event id="2939610669" event_id="63" type_id="1" period_id="1" min="5" sec="4" player_id="207884" team_id="244" outcome="1" x="64.9" y="75.1" timestamp="2026-05-18T18:10:54.821" timestamp_utc="2026-05-18T17:10:54.821" last_modified="2026-05-18T18:10:58" version="1779124257285">
+      <Q id="6427367577" qualifier_id="1"/>
+      <Q id="6427367567" qualifier_id="56" value="Right"/>
+      <Q id="6427367569" qualifier_id="140" value="84.5"/>
+      <Q id="6427367571" qualifier_id="141" value="20.4"/>
+      <Q id="6427367565" qualifier_id="155"/>
+      <Q id="6427367573" qualifier_id="212" value="42.5"/>
+      <Q id="6427367575" qualifier_id="213" value="5.22"/>
+    </Event>
+    <Event id="2939610699" event_id="64" type_id="1" period_id="1" min="5" sec="9" player_id="625775" team_id="244" outcome="1" x="81.9" y="23.9" timestamp="2026-05-18T18:10:58.885" timestamp_utc="2026-05-18T17:10:58.885" last_modified="2026-05-18T18:11:01" version="1779124259240">
+      <Q id="6427367703" qualifier_id="56" value="Center"/>
+      <Q id="6427367707" qualifier_id="140" value="81.6"/>
+      <Q id="6427367711" qualifier_id="141" value="31.2"/>
+      <Q id="6427367713" qualifier_id="212" value="5.0"/>
+      <Q id="6427367717" qualifier_id="213" value="1.63"/>
+    </Event>
+    <Event id="2939615629" event_id="134" type_id="1" period_id="1" min="5" sec="11" player_id="648131" team_id="244" outcome="0" x="77.4" y="25.9" timestamp="2026-05-18T18:11:01.036" timestamp_utc="2026-05-18T17:11:01.036" last_modified="2026-05-18T18:19:51" version="1779124791798">
+      <Q id="6427395441" qualifier_id="56" value="Center"/>
+      <Q id="6427395443" qualifier_id="140" value="88.5"/>
+      <Q id="6427395445" qualifier_id="141" value="52.8"/>
+      <Q id="6427395439" qualifier_id="155"/>
+      <Q id="6427395447" qualifier_id="212" value="21.7"/>
+      <Q id="6427395449" qualifier_id="213" value="1.00"/>
+    </Event>
+    <Event id="2939610721" event_id="65" type_id="43" period_id="1" min="5" sec="11" player_id="648131" team_id="244" outcome="1" x="0.0" y="0.0" timestamp="2026-05-18T18:11:01.308" timestamp_utc="2026-05-18T17:11:01.308" last_modified="2026-05-18T18:19:54" version="1779124768049">
+      <Q id="6427367823" qualifier_id="56" value="Center"/>
+      <Q id="6427367825" qualifier_id="140" value="91.0"/>
+      <Q id="6427367827" qualifier_id="141" value="59.7"/>
+      <Q id="6427395841" qualifier_id="144" value="1"/>
+      <Q id="6427389375" qualifier_id="154" value="0"/>
+      <Q id="6427367821" qualifier_id="155" value="0"/>
+      <Q id="6427389373" qualifier_id="210" value="13"/>
+      <Q id="6427367829" qualifier_id="212" value="21.6"/>
+      <Q id="6427367831" qualifier_id="213" value="1.03"/>
+    </Event>
+    <Event id="2939610725" event_id="44" type_id="44" period_id="1" min="5" sec="13" player_id="531784" team_id="417" outcome="1" x="11.5" y="47.2" timestamp="2026-05-18T18:11:03.476" timestamp_utc="2026-05-18T17:11:03.476" last_modified="2026-05-18T19:37:35" version="1779129455530">
+      <Q id="6427367837" qualifier_id="56" value="Back"/>
+      <Q id="6427367927" qualifier_id="233" value="66"/>
+      <Q id="6427367839" qualifier_id="285"/>
+    </Event>
+    <Event id="2939610737" event_id="66" type_id="44" period_id="1" min="5" sec="13" player_id="232091" team_id="244" outcome="0" x="88.5" y="52.8" timestamp="2026-05-18T18:11:03.477" timestamp_utc="2026-05-18T17:11:03.477" last_modified="2026-05-18T19:37:35" version="1779129455792">
+      <Q id="6427367897" qualifier_id="56" value="Center"/>
+      <Q id="6427367921" qualifier_id="233" value="44"/>
+      <Q id="6427367899" qualifier_id="286"/>
+    </Event>
+    <Event id="2939616285" event_id="92" type_id="12" period_id="1" min="5" sec="13" player_id="531784" team_id="417" outcome="1" x="11.5" y="47.2" timestamp="2026-05-18T18:11:03.692" timestamp_utc="2026-05-18T17:11:03.692" last_modified="2026-05-18T19:37:43" version="1779129463484">
+      <Q id="6427672691" qualifier_id="15"/>
+      <Q id="6427399057" qualifier_id="56" value="Back"/>
+      <Q id="6427399059" qualifier_id="140" value="6.1"/>
+      <Q id="6427399061" qualifier_id="141" value="37.1"/>
+      <Q id="6427399063" qualifier_id="212" value="8.9"/>
+      <Q id="6427399065" qualifier_id="213" value="4.02"/>
+    </Event>
+    <Event id="2939610739" event_id="67" type_id="43" period_id="1" min="5" sec="14" player_id="232091" team_id="244" outcome="1" x="0.0" y="0.0" timestamp="2026-05-18T18:11:04.277" timestamp_utc="2026-05-18T17:11:04.277" last_modified="2026-05-18T18:18:12" version="1779124692089">
+      <Q id="6427387771" qualifier_id="15" value="0"/>
+      <Q id="6427367903" qualifier_id="17" value="0"/>
+      <Q id="6427367901" qualifier_id="22" value="0"/>
+      <Q id="6427389395" qualifier_id="29" value="0"/>
+      <Q id="6427389399" qualifier_id="55" value="65"/>
+      <Q id="6427367905" qualifier_id="56" value="Center"/>
+      <Q id="6427389393" qualifier_id="73" value="0"/>
+      <Q id="6427389403" qualifier_id="102" value="62.7"/>
+      <Q id="6427389405" qualifier_id="103" value="4.2"/>
+      <Q id="6427389417" qualifier_id="144" value="13"/>
+      <Q id="6427389407" qualifier_id="146" value="93.0"/>
+      <Q id="6427389409" qualifier_id="147" value="56.9"/>
+      <Q id="6427387777" qualifier_id="153" value="0"/>
+      <Q id="6427389397" qualifier_id="154" value="0"/>
+      <Q id="6427389411" qualifier_id="230" value="98.9"/>
+      <Q id="6427389413" qualifier_id="231" value="50.2"/>
+      <Q id="6427387775" qualifier_id="328" value="0"/>
+    </Event>
+    <Event id="2939610751" event_id="68" type_id="15" period_id="1" min="5" sec="15" player_id="207884" team_id="244" outcome="1" x="90.6" y="61.2" timestamp="2026-05-18T18:11:05.354" timestamp_utc="2026-05-18T17:11:05.354" last_modified="2026-05-18T18:19:24" version="1779124764209">
+      <Q id="6427367971" qualifier_id="17"/>
+      <Q id="6427393753" qualifier_id="20"/>
+      <Q id="6427367969" qualifier_id="22"/>
+      <Q id="6427367973" qualifier_id="56" value="Center"/>
+      <Q id="6427393755" qualifier_id="76"/>
+      <Q id="6427393765" qualifier_id="82"/>
+      <Q id="6427393757" qualifier_id="102" value="54.6"/>
+      <Q id="6427393759" qualifier_id="103" value="19.0"/>
+      <Q id="6427393767" qualifier_id="146" value="94.2"/>
+      <Q id="6427393769" qualifier_id="147" value="58.7"/>
+      <Q id="6427393771" qualifier_id="230" value="98.0"/>
+      <Q id="6427393773" qualifier_id="231" value="52.0"/>
+      <Q id="6427393807" qualifier_id="233" value="45"/>
+      <Q id="6427393763" qualifier_id="458"/>
+    </Event>
+    <Event id="2939610741" event_id="45" type_id="10" period_id="1" min="5" sec="15" player_id="157851" team_id="417" outcome="1" x="5.8" y="41.3" timestamp="2026-05-18T18:11:05.454" timestamp_utc="2026-05-18T17:11:05.454" last_modified="2026-05-18T19:35:35" version="1779129335679">
+      <Q id="6427367919" qualifier_id="56" value="Back"/>
+      <Q id="6427367917" qualifier_id="94"/>
+      <Q id="6427393827" qualifier_id="233" value="68"/>
+    </Event>
+    <Event id="2939610775" event_id="69" type_id="1" period_id="1" min="5" sec="19" player_id="180662" team_id="244" outcome="0" x="74.1" y="80.2" timestamp="2026-05-18T18:11:09.100" timestamp_utc="2026-05-18T17:11:09.100" last_modified="2026-05-18T18:20:10" version="1779124810873">
+      <Q id="6427368105" qualifier_id="56" value="Center"/>
+      <Q id="6427368107" qualifier_id="140" value="75.8"/>
+      <Q id="6427368109" qualifier_id="141" value="77.2"/>
+      <Q id="6427368111" qualifier_id="212" value="2.7"/>
+      <Q id="6427368113" qualifier_id="213" value="5.43"/>
+    </Event>
+    <Event id="2939610771" event_id="46" type_id="49" period_id="1" min="5" sec="19" player_id="685390" team_id="417" outcome="1" x="22.5" y="26.4" timestamp="2026-05-18T18:11:09.357" timestamp_utc="2026-05-18T17:11:09.357" last_modified="2026-05-18T18:11:09" version="1779124269358"/>
+    <Event id="2939610787" event_id="47" type_id="1" period_id="1" min="5" sec="19" player_id="685390" team_id="417" outcome="0" x="22.5" y="26.4" timestamp="2026-05-18T18:11:09.470" timestamp_utc="2026-05-18T17:11:09.470" last_modified="2026-05-18T18:11:12" version="1779124272414">
+      <Q id="6427368209" qualifier_id="1"/>
+      <Q id="6427368199" qualifier_id="56" value="Right"/>
+      <Q id="6427368201" qualifier_id="140" value="67.0"/>
+      <Q id="6427368203" qualifier_id="141" value="8.9"/>
+      <Q id="6427368205" qualifier_id="212" value="48.2"/>
+      <Q id="6427368207" qualifier_id="213" value="6.03"/>
+    </Event>
+    <Event id="2939610833" event_id="70" type_id="12" period_id="1" min="5" sec="25" player_id="627127" team_id="244" outcome="1" x="28.9" y="80.5" timestamp="2026-05-18T18:11:15.593" timestamp_utc="2026-05-18T17:11:15.593" last_modified="2026-05-18T18:11:17" version="1779124276450">
+      <Q id="6427368445" qualifier_id="56" value="Back"/>
+      <Q id="6427368447" qualifier_id="140" value="33.2"/>
+      <Q id="6427368449" qualifier_id="141" value="100.0"/>
+      <Q id="6427368479" qualifier_id="167"/>
+      <Q id="6427368451" qualifier_id="212" value="15.3"/>
+      <Q id="6427368453" qualifier_id="213" value="1.27"/>
+    </Event>
+    <Event id="2939610815" event_id="48" type_id="5" period_id="1" min="5" sec="26" player_id="685390" team_id="417" outcome="1" x="66.5" y="-2.0" timestamp="2026-05-18T18:11:16.431" timestamp_utc="2026-05-18T17:11:16.431" last_modified="2026-05-18T19:36:49" version="1779129407845">
+      <Q id="6427368351" qualifier_id="56" value="Right"/>
+      <Q id="6427368473" qualifier_id="233" value="71"/>
+      <Q id="6427368353" qualifier_id="347"/>
+    </Event>
+    <Event id="2939610841" event_id="71" type_id="5" period_id="1" min="5" sec="26" player_id="627127" team_id="244" outcome="0" x="33.6" y="102.0" timestamp="2026-05-18T18:11:16.431" timestamp_utc="2026-05-18T17:11:16.431" last_modified="2026-05-18T18:11:17" version="1779124276877">
+      <Q id="6427368467" qualifier_id="56" value="Back"/>
+      <Q id="6427368489" qualifier_id="233" value="48"/>
+      <Q id="6427368469" qualifier_id="347"/>
+    </Event>
+    <Event id="2939610955" event_id="49" type_id="1" period_id="1" min="5" sec="42" player_id="157851" team_id="417" outcome="1" x="70.2" y="0.0" timestamp="2026-05-18T18:11:32.077" timestamp_utc="2026-05-18T17:11:32.077" last_modified="2026-05-18T18:11:33" version="1779124292535">
+      <Q id="6427369069" qualifier_id="56" value="Right"/>
+      <Q id="6427369067" qualifier_id="107"/>
+      <Q id="6427369071" qualifier_id="140" value="71.2"/>
+      <Q id="6427369073" qualifier_id="141" value="16.7"/>
+      <Q id="6427369075" qualifier_id="212" value="12.5"/>
+      <Q id="6427369077" qualifier_id="213" value="1.49"/>
+    </Event>
+    <Event id="2939610959" event_id="50" type_id="1" period_id="1" min="5" sec="43" player_id="445539" team_id="417" outcome="1" x="71.2" y="16.7" timestamp="2026-05-18T18:11:33.085" timestamp_utc="2026-05-18T17:11:33.085" last_modified="2026-05-18T18:11:34" version="1779124294066">
+      <Q id="6427369103" qualifier_id="56" value="Right"/>
+      <Q id="6427369105" qualifier_id="140" value="53.8"/>
+      <Q id="6427369107" qualifier_id="141" value="12.3"/>
+      <Q id="6427369109" qualifier_id="212" value="18.5"/>
+      <Q id="6427369111" qualifier_id="213" value="3.30"/>
+    </Event>
+    <Event id="2939610979" event_id="51" type_id="1" period_id="1" min="5" sec="44" player_id="531784" team_id="417" outcome="1" x="53.8" y="12.3" timestamp="2026-05-18T18:11:34.797" timestamp_utc="2026-05-18T17:11:34.797" last_modified="2026-05-18T18:11:36" version="1779124295174">
+      <Q id="6427369217" qualifier_id="56" value="Right"/>
+      <Q id="6427369219" qualifier_id="140" value="60.6"/>
+      <Q id="6427369221" qualifier_id="141" value="20.1"/>
+      <Q id="6427369223" qualifier_id="212" value="8.9"/>
+      <Q id="6427369225" qualifier_id="213" value="0.64"/>
+    </Event>
+    <Event id="2939616983" event_id="135" type_id="83" period_id="1" min="5" sec="46" player_id="207884" team_id="244" outcome="0" x="44.8" y="75.0" timestamp="2026-05-18T18:11:36.451" timestamp_utc="2026-05-18T17:11:36.451" last_modified="2026-05-18T18:21:50" version="1779124910241">
+      <Q id="6427403225" qualifier_id="399" value="685390"/>
+    </Event>
+    <Event id="2939610985" event_id="52" type_id="50" period_id="1" min="5" sec="46" player_id="685390" team_id="417" outcome="1" x="64.0" y="21.6" timestamp="2026-05-18T18:11:36.549" timestamp_utc="2026-05-18T17:11:36.549" last_modified="2026-05-18T18:11:39" version="1779124297811">
+      <Q id="6427369273" qualifier_id="56" value="Center"/>
+      <Q id="6427369309" qualifier_id="233" value="72"/>
+      <Q id="6427369275" qualifier_id="286"/>
+    </Event>
+    <Event id="2939610991" event_id="72" type_id="7" period_id="1" min="5" sec="46" player_id="515742" team_id="244" outcome="0" x="36.0" y="78.4" timestamp="2026-05-18T18:11:36.550" timestamp_utc="2026-05-18T17:11:36.550" last_modified="2026-05-18T18:22:06" version="1779124926655">
+      <Q id="6427369297" qualifier_id="56" value="Back"/>
+      <Q id="6427369301" qualifier_id="178"/>
+      <Q id="6427369303" qualifier_id="233" value="52"/>
+      <Q id="6427369299" qualifier_id="285"/>
+    </Event>
+    <Event id="2939610999" event_id="53" type_id="1" period_id="1" min="5" sec="48" player_id="720682" team_id="417" outcome="1" x="58.0" y="27.4" timestamp="2026-05-18T18:11:38.189" timestamp_utc="2026-05-18T17:11:38.189" last_modified="2026-05-18T18:11:39" version="1779124298599">
+      <Q id="6427369323" qualifier_id="56" value="Center"/>
+      <Q id="6427369325" qualifier_id="140" value="66.4"/>
+      <Q id="6427369327" qualifier_id="141" value="25.0"/>
+      <Q id="6427369329" qualifier_id="212" value="9.0"/>
+      <Q id="6427369331" qualifier_id="213" value="6.10"/>
+    </Event>
+    <Event id="2939611005" event_id="54" type_id="1" period_id="1" min="5" sec="49" player_id="445539" team_id="417" outcome="1" x="66.4" y="25.6" timestamp="2026-05-18T18:11:39.270" timestamp_utc="2026-05-18T17:11:39.270" last_modified="2026-05-18T18:11:40" version="1779124299917">
+      <Q id="6427369363" qualifier_id="56" value="Center"/>
+      <Q id="6427369365" qualifier_id="140" value="67.4"/>
+      <Q id="6427369367" qualifier_id="141" value="41.6"/>
+      <Q id="6427369369" qualifier_id="212" value="10.9"/>
+      <Q id="6427369371" qualifier_id="213" value="1.47"/>
+    </Event>
+    <Event id="2939611041" event_id="55" type_id="1" period_id="1" min="5" sec="50" player_id="61778" team_id="417" outcome="1" x="67.4" y="41.6" timestamp="2026-05-18T18:11:40.797" timestamp_utc="2026-05-18T17:11:40.797" last_modified="2026-05-18T18:11:45" version="1779124301525">
+      <Q id="6427369597" qualifier_id="1"/>
+      <Q id="6427369587" qualifier_id="56" value="Right"/>
+      <Q id="6427369589" qualifier_id="140" value="92.5"/>
+      <Q id="6427369591" qualifier_id="141" value="9.4"/>
+      <Q id="6427369585" qualifier_id="155"/>
+      <Q id="6427369593" qualifier_id="212" value="34.3"/>
+      <Q id="6427369595" qualifier_id="213" value="5.59"/>
+    </Event>
+    <Event id="2939611047" event_id="56" type_id="1" period_id="1" min="5" sec="55" player_id="157851" team_id="417" outcome="1" x="96.2" y="8.0" timestamp="2026-05-18T18:11:44.981" timestamp_utc="2026-05-18T17:11:44.981" last_modified="2026-05-18T18:11:46" version="1779124305197">
+      <Q id="6427369617" qualifier_id="56" value="Right"/>
+      <Q id="6427369619" qualifier_id="140" value="91.3"/>
+      <Q id="6427369621" qualifier_id="141" value="11.6"/>
+      <Q id="6427369623" qualifier_id="212" value="5.7"/>
+      <Q id="6427369625" qualifier_id="213" value="2.70"/>
+    </Event>
+    <Event id="2939611051" event_id="73" type_id="45" period_id="1" min="5" sec="56" player_id="515742" team_id="244" outcome="0" x="9.8" y="85.6" timestamp="2026-05-18T18:11:46.245" timestamp_utc="2026-05-18T17:11:46.245" last_modified="2026-05-18T18:22:48" version="1779124965302">
+      <Q id="6427369643" qualifier_id="56" value="Back"/>
+      <Q id="6427369697" qualifier_id="233" value="57"/>
+      <Q id="6427369645" qualifier_id="285"/>
+    </Event>
+    <Event id="2939611057" event_id="57" type_id="3" period_id="1" min="5" sec="56" player_id="685390" team_id="417" outcome="1" x="90.2" y="14.4" timestamp="2026-05-18T18:11:46.245" timestamp_utc="2026-05-18T17:11:46.245" last_modified="2026-05-18T18:22:47" version="1779124965300">
+      <Q id="6427369671" qualifier_id="56" value="Right"/>
+      <Q id="6427369689" qualifier_id="233" value="73"/>
+      <Q id="6427369673" qualifier_id="286"/>
+    </Event>
+    <Event id="2939611063" event_id="58" type_id="1" period_id="1" min="5" sec="58" player_id="685390" team_id="417" outcome="0" x="87.5" y="29.7" timestamp="2026-05-18T18:11:48.157" timestamp_utc="2026-05-18T17:11:48.157" last_modified="2026-05-18T18:11:50" version="1779124310059">
+      <Q id="6427369705" qualifier_id="56" value="Center"/>
+      <Q id="6427369707" qualifier_id="140" value="86.6"/>
+      <Q id="6427369709" qualifier_id="141" value="33.1"/>
+      <Q id="6427369711" qualifier_id="212" value="2.5"/>
+      <Q id="6427369713" qualifier_id="213" value="1.96"/>
+      <Q id="6427369749" qualifier_id="233" value="74"/>
+      <Q id="6427369743" qualifier_id="236"/>
+      <Q id="6427369747" qualifier_id="286"/>
+    </Event>
+    <Event id="2939611071" event_id="74" type_id="74" period_id="1" min="5" sec="58" player_id="207884" team_id="244" outcome="1" x="13.4" y="66.9" timestamp="2026-05-18T18:11:48.158" timestamp_utc="2026-05-18T17:11:48.158" last_modified="2026-05-18T19:37:39" version="1779129458929">
+      <Q id="6427369735" qualifier_id="56" value="Back"/>
+      <Q id="6427369753" qualifier_id="233" value="58"/>
+      <Q id="6427369737" qualifier_id="285"/>
+    </Event>
+    <Event id="2939611069" event_id="59" type_id="6" period_id="1" min="5" sec="59" player_id="685390" team_id="417" outcome="1" x="89.2" y="30.2" timestamp="2026-05-18T18:11:49.317" timestamp_utc="2026-05-18T17:11:49.317" last_modified="2026-05-18T18:11:52" version="1779124311290">
+      <Q id="6427369777" qualifier_id="56" value="Center"/>
+      <Q id="6427369779" qualifier_id="75"/>
+      <Q id="6427369789" qualifier_id="233" value="75"/>
+    </Event>
+    <Event id="2939611075" event_id="75" type_id="6" period_id="1" min="5" sec="59" player_id="207884" team_id="244" outcome="0" x="10.8" y="69.8" timestamp="2026-05-18T18:11:49.317" timestamp_utc="2026-05-18T17:11:49.317" last_modified="2026-05-18T18:22:45" version="1779124965275">
+      <Q id="6427369781" qualifier_id="56" value="Back"/>
+      <Q id="6427369783" qualifier_id="73"/>
+      <Q id="6427369791" qualifier_id="233" value="59"/>
+    </Event>
+    <Event id="2939611331" event_id="60" type_id="1" period_id="1" min="6" sec="37" player_id="164593" team_id="417" outcome="1" x="99.5" y="0.5" timestamp="2026-05-18T18:12:26.951" timestamp_utc="2026-05-18T17:12:26.951" last_modified="2026-05-18T18:13:47" version="1779124427581">
+      <Q id="6427371281" qualifier_id="1"/>
+      <Q id="6427371263" qualifier_id="2"/>
+      <Q id="6427371265" qualifier_id="6"/>
+      <Q id="6427371271" qualifier_id="56" value="Center"/>
+      <Q id="6427371273" qualifier_id="140" value="93.1"/>
+      <Q id="6427371275" qualifier_id="141" value="62.1"/>
+      <Q id="6427371267" qualifier_id="155"/>
+      <Q id="6427371277" qualifier_id="212" value="42.4"/>
+      <Q id="6427371279" qualifier_id="213" value="1.73"/>
+      <Q id="6427371269" qualifier_id="223"/>
+    </Event>
+    <Event id="2939611977" event_id="75" type_id="61" period_id="1" min="6" sec="37" player_id="531784" team_id="417" outcome="1" x="91.6" y="54.5" timestamp="2026-05-18T18:12:27.602" timestamp_utc="2026-05-18T17:12:27.602" last_modified="2026-05-19T16:18:53" version="1779203933387">
+      <Q id="6427374827" qualifier_id="56" value="Center"/>
+    </Event>
+    <Event id="2939611353" event_id="76" type_id="43" period_id="1" min="6" sec="40" player_id="479433" team_id="244" outcome="1" x="0.0" y="0.0" timestamp="2026-05-18T18:12:30.325" timestamp_utc="2026-05-18T17:12:30.325" last_modified="2026-05-18T18:12:45" version="1779124356315">
+      <Q id="6427371503" qualifier_id="13" value="0"/>
+      <Q id="6427371507" qualifier_id="56" value="Back"/>
+      <Q id="6427372147" qualifier_id="144" value="4"/>
+      <Q id="6427371509" qualifier_id="152" value="0"/>
+      <Q id="6427371547" qualifier_id="233" value="61"/>
+      <Q id="6427371511" qualifier_id="285" value="0"/>
+      <Q id="6427371505" qualifier_id="294" value="0"/>
+    </Event>
+    <Event id="2939611337" event_id="61" type_id="43" period_id="1" min="6" sec="40" player_id="61812" team_id="417" outcome="1" x="0.0" y="0.0" timestamp="2026-05-18T18:12:30.326" timestamp_utc="2026-05-18T17:12:30.326" last_modified="2026-05-18T18:13:50" version="1779124365803">
+      <Q id="6427371381" qualifier_id="13" value="0"/>
+      <Q id="6427371385" qualifier_id="56" value="Center"/>
+      <Q id="6427375633" qualifier_id="144" value="4"/>
+      <Q id="6427371387" qualifier_id="152" value="0"/>
+      <Q id="6427371389" qualifier_id="286" value="0"/>
+      <Q id="6427371383" qualifier_id="294" value="0"/>
+    </Event>
+    <Event id="2939611451" event_id="62" type_id="5" period_id="1" min="6" sec="52" player_id="61812" team_id="417" outcome="0" x="80.2" y="102.0" timestamp="2026-05-18T18:12:42.524" timestamp_utc="2026-05-18T17:12:42.524" last_modified="2026-05-18T19:36:49" version="1779129407855">
+      <Q id="6427371961" qualifier_id="56" value="Left"/>
+      <Q id="6427372243" qualifier_id="233" value="77"/>
+      <Q id="6427371963" qualifier_id="347"/>
+    </Event>
+    <Event id="2939611503" event_id="77" type_id="5" period_id="1" min="6" sec="52" player_id="479433" team_id="244" outcome="1" x="19.8" y="-2.0" timestamp="2026-05-18T18:12:42.524" timestamp_utc="2026-05-18T17:12:42.524" last_modified="2026-05-18T19:36:49" version="1779129407852">
+      <Q id="6427372233" qualifier_id="56" value="Back"/>
+      <Q id="6427372239" qualifier_id="233" value="62"/>
+      <Q id="6427372235" qualifier_id="347"/>
+    </Event>
+    <Event id="2939611519" event_id="78" type_id="1" period_id="1" min="6" sec="58" player_id="240166" team_id="244" outcome="1" x="18.8" y="0.0" timestamp="2026-05-18T18:12:48.747" timestamp_utc="2026-05-18T17:12:48.747" last_modified="2026-05-18T18:12:50" version="1779124369855">
+      <Q id="6427372317" qualifier_id="1"/>
+      <Q id="6427372307" qualifier_id="56" value="Back"/>
+      <Q id="6427372305" qualifier_id="107"/>
+      <Q id="6427372309" qualifier_id="140" value="39.6"/>
+      <Q id="6427372311" qualifier_id="141" value="21.5"/>
+      <Q id="6427372313" qualifier_id="212" value="26.9"/>
+      <Q id="6427372315" qualifier_id="213" value="0.63"/>
+    </Event>
+    <Event id="2939611525" event_id="79" type_id="1" period_id="1" min="7" sec="0" player_id="232091" team_id="244" outcome="0" x="37.7" y="22.4" timestamp="2026-05-18T18:12:50.723" timestamp_utc="2026-05-18T17:12:50.723" last_modified="2026-05-18T18:12:51" version="1779124371155">
+      <Q id="6427372339" qualifier_id="3"/>
+      <Q id="6427372343" qualifier_id="56" value="Back"/>
+      <Q id="6427372345" qualifier_id="140" value="45.4"/>
+      <Q id="6427372347" qualifier_id="141" value="25.6"/>
+      <Q id="6427372341" qualifier_id="168"/>
+      <Q id="6427372349" qualifier_id="212" value="8.4"/>
+      <Q id="6427372351" qualifier_id="213" value="0.26"/>
+    </Event>
+    <Event id="2939611537" event_id="63" type_id="1" period_id="1" min="7" sec="1" player_id="624620" team_id="417" outcome="0" x="55.7" y="84.4" timestamp="2026-05-18T18:12:51.340" timestamp_utc="2026-05-18T17:12:51.340" last_modified="2026-05-18T18:12:52" version="1779124372108">
+      <Q id="6427372419" qualifier_id="56" value="Left"/>
+      <Q id="6427372421" qualifier_id="140" value="62.2"/>
+      <Q id="6427372423" qualifier_id="141" value="86.9"/>
+      <Q id="6427372425" qualifier_id="212" value="7.0"/>
+      <Q id="6427372427" qualifier_id="213" value="0.24"/>
+    </Event>
+    <Event id="2939611559" event_id="80" type_id="1" period_id="1" min="7" sec="3" player_id="232091" team_id="244" outcome="0" x="36.0" y="25.6" timestamp="2026-05-18T18:12:53.179" timestamp_utc="2026-05-18T17:12:53.179" last_modified="2026-05-18T18:12:54" version="1779124374019">
+      <Q id="6427372547" qualifier_id="1"/>
+      <Q id="6427372537" qualifier_id="56" value="Center"/>
+      <Q id="6427372539" qualifier_id="140" value="59.2"/>
+      <Q id="6427372541" qualifier_id="141" value="42.2"/>
+      <Q id="6427372535" qualifier_id="157"/>
+      <Q id="6427372543" qualifier_id="212" value="26.8"/>
+      <Q id="6427372545" qualifier_id="213" value="0.43"/>
+    </Event>
+    <Event id="2939611579" event_id="64" type_id="1" period_id="1" min="7" sec="4" player_id="531784" team_id="417" outcome="1" x="40.9" y="64.9" timestamp="2026-05-18T18:12:54.644" timestamp_utc="2026-05-18T17:12:54.644" last_modified="2026-05-18T18:12:55" version="1779124374814">
+      <Q id="6427372649" qualifier_id="3"/>
+      <Q id="6427372651" qualifier_id="56" value="Center"/>
+      <Q id="6427372653" qualifier_id="140" value="51.7"/>
+      <Q id="6427372655" qualifier_id="141" value="65.2"/>
+      <Q id="6427372657" qualifier_id="212" value="11.3"/>
+      <Q id="6427372659" qualifier_id="213" value="0.02"/>
+    </Event>
+    <Event id="2939611581" event_id="65" type_id="49" period_id="1" min="7" sec="5" player_id="720682" team_id="417" outcome="1" x="53.0" y="66.6" timestamp="2026-05-18T18:12:55.444" timestamp_utc="2026-05-18T17:12:55.444" last_modified="2026-05-18T18:12:55" version="1779124375445"/>
+    <Event id="2939611633" event_id="66" type_id="1" period_id="1" min="7" sec="6" player_id="720682" team_id="417" outcome="1" x="53.0" y="66.6" timestamp="2026-05-18T18:12:55.997" timestamp_utc="2026-05-18T17:12:55.997" last_modified="2026-05-18T18:13:00" version="1779124376773">
+      <Q id="6427372919" qualifier_id="56" value="Center"/>
+      <Q id="6427372921" qualifier_id="140" value="65.0"/>
+      <Q id="6427372923" qualifier_id="141" value="34.2"/>
+      <Q id="6427372925" qualifier_id="212" value="25.4"/>
+      <Q id="6427372927" qualifier_id="213" value="5.23"/>
+    </Event>
+    <Event id="2939611631" event_id="81" type_id="83" period_id="1" min="7" sec="10" player_id="575855" team_id="244" outcome="0" x="34.4" y="79.1" timestamp="2026-05-18T18:13:00.475" timestamp_utc="2026-05-18T17:13:00.475" last_modified="2026-05-18T18:13:20" version="1779124400136">
+      <Q id="6427373057" qualifier_id="399" value="685390"/>
+    </Event>
+    <Event id="2939611641" event_id="67" type_id="1" period_id="1" min="7" sec="10" player_id="685390" team_id="417" outcome="0" x="61.2" y="22.7" timestamp="2026-05-18T18:13:00.668" timestamp_utc="2026-05-18T17:13:00.668" last_modified="2026-05-18T18:13:04" version="1779124384243">
+      <Q id="6427372969" qualifier_id="56" value="Right"/>
+      <Q id="6427372971" qualifier_id="140" value="63.3"/>
+      <Q id="6427372973" qualifier_id="141" value="16.2"/>
+      <Q id="6427372975" qualifier_id="212" value="4.9"/>
+      <Q id="6427372977" qualifier_id="213" value="5.18"/>
+      <Q id="6427373179" qualifier_id="233" value="82"/>
+      <Q id="6427373171" qualifier_id="236"/>
+      <Q id="6427373175" qualifier_id="286"/>
+    </Event>
+    <Event id="2939611687" event_id="82" type_id="74" period_id="1" min="7" sec="10" player_id="575855" team_id="244" outcome="1" x="36.7" y="83.8" timestamp="2026-05-18T18:13:00.669" timestamp_utc="2026-05-18T17:13:00.669" last_modified="2026-05-18T18:22:41" version="1779124961436">
+      <Q id="6427373163" qualifier_id="56" value="Back"/>
+      <Q id="6427373187" qualifier_id="233" value="67"/>
+      <Q id="6427373165" qualifier_id="285"/>
+    </Event>
+    <Event id="2939611725" event_id="68" type_id="1" period_id="1" min="7" sec="13" player_id="685390" team_id="417" outcome="1" x="54.9" y="8.9" timestamp="2026-05-18T18:13:02.956" timestamp_utc="2026-05-18T17:13:02.956" last_modified="2026-05-18T18:13:08" version="1779124384133">
+      <Q id="6427373409" qualifier_id="56" value="Back"/>
+      <Q id="6427373411" qualifier_id="140" value="38.6"/>
+      <Q id="6427373413" qualifier_id="141" value="11.4"/>
+      <Q id="6427373415" qualifier_id="212" value="17.2"/>
+      <Q id="6427373417" qualifier_id="213" value="3.04"/>
+    </Event>
+    <Event id="2939611743" event_id="69" type_id="1" period_id="1" min="7" sec="18" player_id="531784" team_id="417" outcome="1" x="56.8" y="11.4" timestamp="2026-05-18T18:13:08.580" timestamp_utc="2026-05-18T17:13:08.580" last_modified="2026-05-18T18:13:10" version="1779124389157">
+      <Q id="6427373503" qualifier_id="56" value="Right"/>
+      <Q id="6427373505" qualifier_id="140" value="61.1"/>
+      <Q id="6427373507" qualifier_id="141" value="1.9"/>
+      <Q id="6427373509" qualifier_id="212" value="7.9"/>
+      <Q id="6427373511" qualifier_id="213" value="5.32"/>
+    </Event>
+    <Event id="2939611755" event_id="70" type_id="1" period_id="1" min="7" sec="20" player_id="685390" team_id="417" outcome="0" x="61.1" y="1.9" timestamp="2026-05-18T18:13:10.204" timestamp_utc="2026-05-18T17:13:10.204" last_modified="2026-05-18T18:13:11" version="1779124391668">
+      <Q id="6427373561" qualifier_id="56" value="Center"/>
+      <Q id="6427373563" qualifier_id="140" value="70.0"/>
+      <Q id="6427373565" qualifier_id="141" value="31.6"/>
+      <Q id="6427373567" qualifier_id="212" value="22.3"/>
+      <Q id="6427373569" qualifier_id="213" value="1.14"/>
+    </Event>
+    <Event id="2939611767" event_id="83" type_id="49" period_id="1" min="7" sec="22" player_id="180662" team_id="244" outcome="1" x="33.9" y="62.3" timestamp="2026-05-18T18:13:12.619" timestamp_utc="2026-05-18T17:13:12.619" last_modified="2026-05-18T18:13:12" version="1779124392620"/>
+    <Event id="2939611793" event_id="84" type_id="1" period_id="1" min="7" sec="23" player_id="180662" team_id="244" outcome="1" x="32.2" y="64.0" timestamp="2026-05-18T18:13:13.243" timestamp_utc="2026-05-18T17:13:13.243" last_modified="2026-05-18T18:13:14" version="1779124393404">
+      <Q id="6427373769" qualifier_id="56" value="Back"/>
+      <Q id="6427373771" qualifier_id="140" value="40.2"/>
+      <Q id="6427373773" qualifier_id="141" value="68.2"/>
+      <Q id="6427373767" qualifier_id="155"/>
+      <Q id="6427373775" qualifier_id="212" value="8.9"/>
+      <Q id="6427373777" qualifier_id="213" value="0.33"/>
+    </Event>
+    <Event id="2939611817" event_id="85" type_id="1" period_id="1" min="7" sec="25" player_id="515742" team_id="244" outcome="0" x="43.0" y="72.0" timestamp="2026-05-18T18:13:14.866" timestamp_utc="2026-05-18T17:13:14.866" last_modified="2026-05-18T18:13:17" version="1779124397075">
+      <Q id="6427373857" qualifier_id="3"/>
+      <Q id="6427373859" qualifier_id="56" value="Center"/>
+      <Q id="6427373861" qualifier_id="140" value="56.7"/>
+      <Q id="6427373863" qualifier_id="141" value="72.9"/>
+      <Q id="6427373865" qualifier_id="212" value="14.4"/>
+      <Q id="6427373867" qualifier_id="213" value="0.04"/>
+    </Event>
+    <Event id="2939611827" event_id="71" type_id="1" period_id="1" min="7" sec="25" player_id="720682" team_id="417" outcome="1" x="54.7" y="21.2" timestamp="2026-05-18T18:13:15.604" timestamp_utc="2026-05-18T17:13:15.604" last_modified="2026-05-18T18:13:18" version="1779124397028">
+      <Q id="6427373947" qualifier_id="56" value="Back"/>
+      <Q id="6427373949" qualifier_id="140" value="32.1"/>
+      <Q id="6427373951" qualifier_id="141" value="8.8"/>
+      <Q id="6427373953" qualifier_id="212" value="25.2"/>
+      <Q id="6427373955" qualifier_id="213" value="3.48"/>
+    </Event>
+    <Event id="2939611839" event_id="72" type_id="43" period_id="1" min="7" sec="28" player_id="531784" team_id="417" outcome="1" x="0.0" y="0.0" timestamp="2026-05-18T18:13:17.956" timestamp_utc="2026-05-18T17:13:17.956" last_modified="2026-05-18T18:13:21" version="1779124397957">
+      <Q id="6427374007" qualifier_id="56" value="Back"/>
+      <Q id="6427374215" qualifier_id="144" value="3"/>
+      <Q id="6427374009" qualifier_id="285" value="0"/>
+    </Event>
+    <Event id="2939611849" event_id="73" type_id="12" period_id="1" min="7" sec="29" player_id="531784" team_id="417" outcome="1" x="32.1" y="8.8" timestamp="2026-05-18T18:13:19.036" timestamp_utc="2026-05-18T17:13:19.036" last_modified="2026-05-18T18:13:20" version="1779124399563">
+      <Q id="6427374061" qualifier_id="56" value="Back"/>
+      <Q id="6427374063" qualifier_id="140" value="35.2"/>
+      <Q id="6427374065" qualifier_id="141" value="0.0"/>
+      <Q id="6427374133" qualifier_id="167"/>
+      <Q id="6427374067" qualifier_id="212" value="7.6"/>
+      <Q id="6427374069" qualifier_id="213" value="5.15"/>
+    </Event>
+    <Event id="2939611859" event_id="74" type_id="5" period_id="1" min="7" sec="29" player_id="531784" team_id="417" outcome="0" x="34.8" y="-1.2" timestamp="2026-05-18T18:13:19.549" timestamp_utc="2026-05-18T17:13:19.549" last_modified="2026-05-18T18:22:05" version="1779124925216">
+      <Q id="6427374129" qualifier_id="56" value="Back"/>
+      <Q id="6427374175" qualifier_id="233" value="86"/>
+      <Q id="6427374131" qualifier_id="347"/>
+    </Event>
+    <Event id="2939611861" event_id="86" type_id="5" period_id="1" min="7" sec="29" player_id="515742" team_id="244" outcome="1" x="65.2" y="101.2" timestamp="2026-05-18T18:13:19.549" timestamp_utc="2026-05-18T17:13:19.549" last_modified="2026-05-18T19:36:49" version="1779129407859">
+      <Q id="6427374135" qualifier_id="56" value="Left"/>
+      <Q id="6427374163" qualifier_id="233" value="74"/>
+      <Q id="6427374137" qualifier_id="347"/>
+    </Event>
+    <Event id="2939611911" event_id="87" type_id="1" period_id="1" min="7" sec="35" player_id="575855" team_id="244" outcome="1" x="64.9" y="100.0" timestamp="2026-05-18T18:13:25.146" timestamp_utc="2026-05-18T17:13:25.146" last_modified="2026-05-18T18:13:27" version="1779124405769">
+      <Q id="6427374453" qualifier_id="56" value="Center"/>
+      <Q id="6427374451" qualifier_id="107"/>
+      <Q id="6427374455" qualifier_id="140" value="65.2"/>
+      <Q id="6427374457" qualifier_id="141" value="72.1"/>
+      <Q id="6427374459" qualifier_id="212" value="20.1"/>
+      <Q id="6427374461" qualifier_id="213" value="4.73"/>
+    </Event>
+    <Event id="2939611925" event_id="88" type_id="1" period_id="1" min="7" sec="37" player_id="207884" team_id="244" outcome="1" x="66.0" y="72.9" timestamp="2026-05-18T18:13:27.810" timestamp_utc="2026-05-18T17:13:27.810" last_modified="2026-05-18T18:18:05" version="1779124685707">
+      <Q id="6427374587" qualifier_id="56" value="Left"/>
+      <Q id="6427374589" qualifier_id="140" value="58.2"/>
+      <Q id="6427374591" qualifier_id="141" value="88.4"/>
+      <Q id="6427374585" qualifier_id="155"/>
+      <Q id="6427374593" qualifier_id="212" value="13.3"/>
+      <Q id="6427374595" qualifier_id="213" value="2.23"/>
+    </Event>
+    <Event id="2939611959" event_id="89" type_id="1" period_id="1" min="7" sec="41" player_id="575855" team_id="244" outcome="1" x="55.3" y="89.1" timestamp="2026-05-18T18:13:31.578" timestamp_utc="2026-05-18T17:13:31.578" last_modified="2026-05-18T18:18:04" version="1779124684091">
+      <Q id="6427374725" qualifier_id="3"/>
+      <Q id="6427374729" qualifier_id="56" value="Back"/>
+      <Q id="6427374733" qualifier_id="140" value="41.7"/>
+      <Q id="6427374735" qualifier_id="141" value="87.2"/>
+      <Q id="6427374737" qualifier_id="212" value="14.3"/>
+      <Q id="6427374739" qualifier_id="213" value="3.23"/>
+    </Event>
+    <Event id="2939611967" event_id="90" type_id="1" period_id="1" min="7" sec="43" player_id="180662" team_id="244" outcome="1" x="37.8" y="82.9" timestamp="2026-05-18T18:13:33.202" timestamp_utc="2026-05-18T17:13:33.202" last_modified="2026-05-18T18:13:34" version="1779124413442">
+      <Q id="6427374767" qualifier_id="56" value="Back"/>
+      <Q id="6427374769" qualifier_id="140" value="39.8"/>
+      <Q id="6427374771" qualifier_id="141" value="76.4"/>
+      <Q id="6427374773" qualifier_id="212" value="4.9"/>
+      <Q id="6427374775" qualifier_id="213" value="5.16"/>
+    </Event>
+    <Event id="2939611987" event_id="91" type_id="1" period_id="1" min="7" sec="44" player_id="207884" team_id="244" outcome="1" x="39.8" y="76.4" timestamp="2026-05-18T18:13:33.970" timestamp_utc="2026-05-18T17:13:33.970" last_modified="2026-05-18T18:13:35" version="1779124414100">
+      <Q id="6427374885" qualifier_id="56" value="Back"/>
+      <Q id="6427374887" qualifier_id="140" value="41.8"/>
+      <Q id="6427374889" qualifier_id="141" value="84.8"/>
+      <Q id="6427374891" qualifier_id="212" value="6.1"/>
+      <Q id="6427374893" qualifier_id="213" value="1.22"/>
+    </Event>
+    <Event id="2939612033" event_id="92" type_id="1" period_id="1" min="7" sec="45" player_id="575855" team_id="244" outcome="1" x="51.2" y="85.4" timestamp="2026-05-18T18:13:35.850" timestamp_utc="2026-05-18T17:13:35.850" last_modified="2026-05-18T18:13:42" version="1779124416016">
+      <Q id="6427375161" qualifier_id="56" value="Left"/>
+      <Q id="6427375163" qualifier_id="140" value="59.0"/>
+      <Q id="6427375165" qualifier_id="141" value="85.4"/>
+      <Q id="6427375167" qualifier_id="212" value="8.2"/>
+      <Q id="6427375169" qualifier_id="213" value="0.00"/>
+    </Event>
+    <Event id="2939612079" event_id="93" type_id="1" period_id="1" min="7" sec="52" player_id="648131" team_id="244" outcome="1" x="56.9" y="83.0" timestamp="2026-05-18T18:13:42.762" timestamp_utc="2026-05-18T17:13:42.762" last_modified="2026-05-18T18:13:46" version="1779124423246">
+      <Q id="6427375423" qualifier_id="56" value="Back"/>
+      <Q id="6427375425" qualifier_id="140" value="48.7"/>
+      <Q id="6427375427" qualifier_id="141" value="51.3"/>
+      <Q id="6427375429" qualifier_id="212" value="23.2"/>
+      <Q id="6427375431" qualifier_id="213" value="4.33"/>
+    </Event>
+    <Event id="2939612101" event_id="94" type_id="1" period_id="1" min="7" sec="56" player_id="627127" team_id="244" outcome="1" x="48.2" y="46.4" timestamp="2026-05-18T18:13:46.074" timestamp_utc="2026-05-18T17:13:46.074" last_modified="2026-05-18T18:13:49" version="1779124426450">
+      <Q id="6427375579" qualifier_id="56" value="Center"/>
+      <Q id="6427375581" qualifier_id="140" value="55.8"/>
+      <Q id="6427375583" qualifier_id="141" value="26.7"/>
+      <Q id="6427375585" qualifier_id="212" value="15.6"/>
+      <Q id="6427375587" qualifier_id="213" value="5.25"/>
+    </Event>
+    <Event id="2939612111" event_id="95" type_id="1" period_id="1" min="7" sec="59" player_id="240166" team_id="244" outcome="1" x="59.1" y="27.7" timestamp="2026-05-18T18:13:49.466" timestamp_utc="2026-05-18T17:13:49.466" last_modified="2026-05-18T18:13:51" version="1779124429778">
+      <Q id="6427375635" qualifier_id="56" value="Center"/>
+      <Q id="6427375637" qualifier_id="140" value="53.3"/>
+      <Q id="6427375639" qualifier_id="141" value="32.4"/>
+      <Q id="6427375641" qualifier_id="212" value="6.9"/>
+      <Q id="6427375643" qualifier_id="213" value="2.66"/>
+    </Event>
+    <Event id="2939612139" event_id="96" type_id="1" period_id="1" min="8" sec="1" player_id="627127" team_id="244" outcome="1" x="53.3" y="32.4" timestamp="2026-05-18T18:13:50.969" timestamp_utc="2026-05-18T17:13:50.969" last_modified="2026-05-18T18:13:54" version="1779124431163">
+      <Q id="6427375793" qualifier_id="56" value="Center"/>
+      <Q id="6427375795" qualifier_id="140" value="53.6"/>
+      <Q id="6427375797" qualifier_id="141" value="30.1"/>
+      <Q id="6427375799" qualifier_id="212" value="1.6"/>
+      <Q id="6427375801" qualifier_id="213" value="4.91"/>
+    </Event>
+    <Event id="2939612187" event_id="97" type_id="1" period_id="1" min="8" sec="4" player_id="240166" team_id="244" outcome="1" x="56.8" y="18.9" timestamp="2026-05-18T18:13:54.754" timestamp_utc="2026-05-18T17:13:54.754" last_modified="2026-05-18T18:13:59" version="1779124435147">
+      <Q id="6427376055" qualifier_id="56" value="Right"/>
+      <Q id="6427376057" qualifier_id="140" value="68.1"/>
+      <Q id="6427376059" qualifier_id="141" value="4.1"/>
+      <Q id="6427376061" qualifier_id="212" value="15.6"/>
+      <Q id="6427376063" qualifier_id="213" value="5.58"/>
+    </Event>
+    <Event id="2939612189" event_id="98" type_id="1" period_id="1" min="8" sec="6" player_id="207884" team_id="244" outcome="0" x="67.0" y="5.6" timestamp="2026-05-18T18:13:56.827" timestamp_utc="2026-05-18T17:13:56.827" last_modified="2026-05-18T18:21:04" version="1779124864736">
+      <Q id="6427376077" qualifier_id="56" value="Right"/>
+      <Q id="6427376079" qualifier_id="140" value="67.9"/>
+      <Q id="6427376081" qualifier_id="141" value="6.1"/>
+      <Q id="6427376083" qualifier_id="212" value="1.0"/>
+      <Q id="6427376085" qualifier_id="213" value="0.35"/>
+      <Q id="6427376091" qualifier_id="233" value="76"/>
+      <Q id="6427376089" qualifier_id="236"/>
+      <Q id="6427376095" qualifier_id="286"/>
+    </Event>
+    <Event id="2939612153" event_id="76" type_id="74" period_id="1" min="8" sec="6" player_id="164593" team_id="417" outcome="1" x="32.1" y="93.9" timestamp="2026-05-18T18:13:56.828" timestamp_utc="2026-05-18T17:13:56.828" last_modified="2026-05-18T19:37:39" version="1779129459203">
+      <Q id="6427375865" qualifier_id="56" value="Back"/>
+      <Q id="6427376109" qualifier_id="233" value="98"/>
+      <Q id="6427375867" qualifier_id="285"/>
+    </Event>
+    <Event id="2939612245" event_id="99" type_id="1" period_id="1" min="8" sec="11" player_id="627127" team_id="244" outcome="1" x="50.4" y="13.5" timestamp="2026-05-18T18:14:01.489" timestamp_utc="2026-05-18T17:14:01.489" last_modified="2026-05-18T18:14:06" version="1779124442580">
+      <Q id="6427376385" qualifier_id="56" value="Back"/>
+      <Q id="6427376387" qualifier_id="140" value="47.5"/>
+      <Q id="6427376389" qualifier_id="141" value="49.6"/>
+      <Q id="6427376391" qualifier_id="212" value="24.7"/>
+      <Q id="6427376393" qualifier_id="213" value="1.69"/>
+    </Event>
+    <Event id="2939612279" event_id="100" type_id="1" period_id="1" min="8" sec="16" player_id="180662" team_id="244" outcome="1" x="51.9" y="53.6" timestamp="2026-05-18T18:14:06.841" timestamp_utc="2026-05-18T17:14:06.841" last_modified="2026-05-18T18:14:11" version="1779124447843">
+      <Q id="6427376585" qualifier_id="56" value="Center"/>
+      <Q id="6427376587" qualifier_id="140" value="65.2"/>
+      <Q id="6427376589" qualifier_id="141" value="26.4"/>
+      <Q id="6427376591" qualifier_id="212" value="23.2"/>
+      <Q id="6427376593" qualifier_id="213" value="5.36"/>
+    </Event>
+    <Event id="2939612281" event_id="101" type_id="1" period_id="1" min="8" sec="21" player_id="207884" team_id="244" outcome="0" x="65.0" y="26.2" timestamp="2026-05-18T18:14:11.017" timestamp_utc="2026-05-18T17:14:11.017" last_modified="2026-05-18T18:17:52" version="1779124672848">
+      <Q id="6427376609" qualifier_id="56" value="Center"/>
+      <Q id="6427376611" qualifier_id="140" value="69.1"/>
+      <Q id="6427376613" qualifier_id="141" value="28.3"/>
+      <Q id="6427376615" qualifier_id="212" value="4.5"/>
+      <Q id="6427376617" qualifier_id="213" value="0.32"/>
+      <Q id="6427388215" qualifier_id="233" value="77"/>
+      <Q id="6427388213" qualifier_id="236"/>
+      <Q id="6427388219" qualifier_id="286"/>
+    </Event>
+    <Event id="2939612289" event_id="77" type_id="74" period_id="1" min="8" sec="21" player_id="720682" team_id="417" outcome="1" x="30.9" y="71.7" timestamp="2026-05-18T18:14:11.018" timestamp_utc="2026-05-18T17:14:11.018" last_modified="2026-05-18T19:37:39" version="1779129459464">
+      <Q id="6427376645" qualifier_id="56" value="Back"/>
+      <Q id="6427388239" qualifier_id="233" value="101"/>
+      <Q id="6427388183" qualifier_id="285"/>
+    </Event>
+    <Event id="2939612297" event_id="78" type_id="43" period_id="1" min="8" sec="23" player_id="720682" team_id="417" outcome="1" x="0.0" y="0.0" timestamp="2026-05-18T18:14:13.379" timestamp_utc="2026-05-18T17:14:13.379" last_modified="2026-05-18T18:14:17" version="1779124453380">
+      <Q id="6427376679" qualifier_id="56" value="Back"/>
+      <Q id="6427376883" qualifier_id="144" value="56"/>
+    </Event>
+    <Event id="2939612305" event_id="102" type_id="1" period_id="1" min="8" sec="24" player_id="240166" team_id="244" outcome="1" x="73.7" y="11.0" timestamp="2026-05-18T18:14:13.993" timestamp_utc="2026-05-18T17:14:13.993" last_modified="2026-05-18T18:14:15" version="1779124454131">
+      <Q id="6427376731" qualifier_id="56" value="Right"/>
+      <Q id="6427376733" qualifier_id="140" value="67.0"/>
+      <Q id="6427376735" qualifier_id="141" value="15.5"/>
+      <Q id="6427376737" qualifier_id="212" value="7.7"/>
+      <Q id="6427376739" qualifier_id="213" value="2.73"/>
+    </Event>
+    <Event id="2939612329" event_id="103" type_id="1" period_id="1" min="8" sec="25" player_id="207884" team_id="244" outcome="1" x="67.0" y="15.5" timestamp="2026-05-18T18:14:14.937" timestamp_utc="2026-05-18T17:14:14.937" last_modified="2026-05-18T18:14:17" version="1779124455291">
+      <Q id="6427376867" qualifier_id="56" value="Right"/>
+      <Q id="6427376869" qualifier_id="140" value="84.0"/>
+      <Q id="6427376871" qualifier_id="141" value="10.1"/>
+      <Q id="6427376873" qualifier_id="212" value="18.2"/>
+      <Q id="6427376875" qualifier_id="213" value="6.08"/>
+    </Event>
+    <Event id="2939612379" event_id="104" type_id="1" period_id="1" min="8" sec="27" player_id="240166" team_id="244" outcome="1" x="85.4" y="9.8" keypass="1" timestamp="2026-05-18T18:14:17.097" timestamp_utc="2026-05-18T17:14:17.097" last_modified="2026-05-18T18:17:34" version="1779124653954">
+      <Q id="6427377129" qualifier_id="56" value="Center"/>
+      <Q id="6427377131" qualifier_id="140" value="79.6"/>
+      <Q id="6427377133" qualifier_id="141" value="33.7"/>
+      <Q id="6427387099" qualifier_id="210" value="15"/>
+      <Q id="6427377135" qualifier_id="212" value="17.4"/>
+      <Q id="6427377137" qualifier_id="213" value="1.93"/>
+    </Event>
+    <Event id="2939612387" event_id="105" type_id="15" period_id="1" min="8" sec="31" player_id="625775" team_id="244" outcome="1" x="78.1" y="34.9" timestamp="2026-05-18T18:14:20.937" timestamp_utc="2026-05-18T17:14:20.937" last_modified="2026-05-18T18:17:38" version="1779124657995">
+      <Q id="6427377171" qualifier_id="18"/>
+      <Q id="6427377169" qualifier_id="22"/>
+      <Q id="6427387103" qualifier_id="29"/>
+      <Q id="6427387105" qualifier_id="55" value="104"/>
+      <Q id="6427377175" qualifier_id="56" value="Center"/>
+      <Q id="6427386781" qualifier_id="72"/>
+      <Q id="6427387101" qualifier_id="78"/>
+      <Q id="6427387109" qualifier_id="102" value="49.7"/>
+      <Q id="6427387111" qualifier_id="103" value="14.6"/>
+      <Q id="6427387115" qualifier_id="146" value="99.9"/>
+      <Q id="6427387117" qualifier_id="147" value="48.7"/>
+      <Q id="6427387113" qualifier_id="215"/>
+      <Q id="6427387165" qualifier_id="233" value="79"/>
+    </Event>
+    <Event id="2939612391" event_id="79" type_id="10" period_id="1" min="8" sec="31" player_id="565487" team_id="417" outcome="1" x="1.9" y="53.1" timestamp="2026-05-18T18:14:21.037" timestamp_utc="2026-05-18T17:14:21.037" last_modified="2026-05-18T18:17:34" version="1779124653968">
+      <Q id="6427377195" qualifier_id="56" value="Back"/>
+      <Q id="6427377189" qualifier_id="173"/>
+      <Q id="6427377371" qualifier_id="179"/>
+      <Q id="6427377193" qualifier_id="182"/>
+      <Q id="6427387169" qualifier_id="233" value="105"/>
+    </Event>
+    <Event id="2939612439" event_id="106" type_id="5" period_id="1" min="8" sec="34" player_id="240166" team_id="244" outcome="1" x="92.2" y="-2.0" timestamp="2026-05-18T18:14:24.369" timestamp_utc="2026-05-18T17:14:24.369" last_modified="2026-05-18T19:36:50" version="1779129407862">
+      <Q id="6427377471" qualifier_id="56" value="Right"/>
+      <Q id="6427391579" qualifier_id="233" value="80"/>
+      <Q id="6427377473" qualifier_id="347"/>
+    </Event>
+    <Event id="2939612753" event_id="80" type_id="5" period_id="1" min="8" sec="34" player_id="565487" team_id="417" outcome="0" x="7.8" y="102.0" timestamp="2026-05-18T18:14:24.369" timestamp_utc="2026-05-18T17:14:24.369" last_modified="2026-05-18T19:36:50" version="1779129407865">
+      <Q id="6427379339" qualifier_id="56" value="Back"/>
+      <Q id="6427391599" qualifier_id="233" value="106"/>
+      <Q id="6427379341" qualifier_id="347"/>
+    </Event>
+    <Event id="2939612453" event_id="107" type_id="1" period_id="1" min="8" sec="38" player_id="240166" team_id="244" outcome="1" x="94.0" y="0.0" timestamp="2026-05-18T18:14:28.361" timestamp_utc="2026-05-18T17:14:28.361" last_modified="2026-05-18T18:14:30" version="1779124468595">
+      <Q id="6427377533" qualifier_id="56" value="Right"/>
+      <Q id="6427377531" qualifier_id="107"/>
+      <Q id="6427377535" qualifier_id="140" value="78.4"/>
+      <Q id="6427377537" qualifier_id="141" value="10.7"/>
+      <Q id="6427377539" qualifier_id="212" value="18.5"/>
+      <Q id="6427377541" qualifier_id="213" value="2.66"/>
+    </Event>
+    <Event id="2939612489" event_id="108" type_id="1" period_id="1" min="8" sec="40" player_id="207884" team_id="244" outcome="1" x="80.3" y="12.0" timestamp="2026-05-18T18:14:30.489" timestamp_utc="2026-05-18T17:14:30.489" last_modified="2026-05-18T18:14:35" version="1779124470739">
+      <Q id="6427377731" qualifier_id="56" value="Right"/>
+      <Q id="6427377733" qualifier_id="140" value="82.9"/>
+      <Q id="6427377735" qualifier_id="141" value="10.0"/>
+      <Q id="6427377737" qualifier_id="212" value="3.0"/>
+      <Q id="6427377739" qualifier_id="213" value="5.82"/>
+    </Event>
+    <Event id="2939612537" event_id="109" type_id="1" period_id="1" min="8" sec="45" player_id="240166" team_id="244" outcome="1" x="81.5" y="12.3" timestamp="2026-05-18T18:14:35.473" timestamp_utc="2026-05-18T17:14:35.473" last_modified="2026-05-18T18:14:38" version="1779124475950">
+      <Q id="6427377999" qualifier_id="56" value="Right"/>
+      <Q id="6427378001" qualifier_id="140" value="70.8"/>
+      <Q id="6427378003" qualifier_id="141" value="19.2"/>
+      <Q id="6427378005" qualifier_id="212" value="12.2"/>
+      <Q id="6427378007" qualifier_id="213" value="2.75"/>
+    </Event>
+    <Event id="2939612577" event_id="110" type_id="1" period_id="1" min="8" sec="49" player_id="627127" team_id="244" outcome="1" x="68.4" y="23.3" timestamp="2026-05-18T18:14:38.873" timestamp_utc="2026-05-18T17:14:38.873" last_modified="2026-05-18T18:14:42" version="1779124479538">
+      <Q id="6427378197" qualifier_id="56" value="Center"/>
+      <Q id="6427378199" qualifier_id="140" value="57.6"/>
+      <Q id="6427378203" qualifier_id="141" value="39.2"/>
+      <Q id="6427378205" qualifier_id="212" value="15.7"/>
+      <Q id="6427378207" qualifier_id="213" value="2.38"/>
+    </Event>
+    <Event id="2939612613" event_id="111" type_id="1" period_id="1" min="8" sec="52" player_id="180662" team_id="244" outcome="1" x="61.2" y="44.9" timestamp="2026-05-18T18:14:42.761" timestamp_utc="2026-05-18T17:14:42.761" last_modified="2026-05-18T18:14:46" version="1779124483131">
+      <Q id="6427378431" qualifier_id="56" value="Center"/>
+      <Q id="6427378433" qualifier_id="140" value="63.1"/>
+      <Q id="6427378435" qualifier_id="141" value="67.6"/>
+      <Q id="6427378437" qualifier_id="212" value="15.6"/>
+      <Q id="6427378439" qualifier_id="213" value="1.44"/>
+    </Event>
+    <Event id="2939612655" event_id="112" type_id="1" period_id="1" min="8" sec="56" player_id="575855" team_id="244" outcome="1" x="62.7" y="78.8" timestamp="2026-05-18T18:14:46.082" timestamp_utc="2026-05-18T17:14:46.082" last_modified="2026-05-18T18:14:51" version="1779124486482">
+      <Q id="6427378683" qualifier_id="56" value="Center"/>
+      <Q id="6427378685" qualifier_id="140" value="55.3"/>
+      <Q id="6427378687" qualifier_id="141" value="69.6"/>
+      <Q id="6427378689" qualifier_id="212" value="10.0"/>
+      <Q id="6427378691" qualifier_id="213" value="3.82"/>
+    </Event>
+    <Event id="2939612667" event_id="113" type_id="1" period_id="1" min="9" sec="1" player_id="515742" team_id="244" outcome="1" x="58.5" y="62.9" timestamp="2026-05-18T18:14:51.329" timestamp_utc="2026-05-18T17:14:51.329" last_modified="2026-05-18T18:14:52" version="1779124491754">
+      <Q id="6427378751" qualifier_id="56" value="Center"/>
+      <Q id="6427378753" qualifier_id="140" value="50.1"/>
+      <Q id="6427378755" qualifier_id="141" value="48.2"/>
+      <Q id="6427378757" qualifier_id="212" value="13.3"/>
+      <Q id="6427378759" qualifier_id="213" value="3.99"/>
+    </Event>
+    <Event id="2939612691" event_id="114" type_id="1" period_id="1" min="9" sec="2" player_id="180662" team_id="244" outcome="1" x="50.3" y="48.2" timestamp="2026-05-18T18:14:52.672" timestamp_utc="2026-05-18T17:14:52.672" last_modified="2026-05-18T18:14:55" version="1779124492948">
+      <Q id="6427378913" qualifier_id="56" value="Center"/>
+      <Q id="6427378915" qualifier_id="140" value="55.1"/>
+      <Q id="6427378917" qualifier_id="141" value="60.9"/>
+      <Q id="6427378919" qualifier_id="212" value="10.0"/>
+      <Q id="6427378921" qualifier_id="213" value="1.04"/>
+    </Event>
+    <Event id="2939612747" event_id="115" type_id="1" period_id="1" min="9" sec="5" player_id="515742" team_id="244" outcome="1" x="57.7" y="67.9" timestamp="2026-05-18T18:14:55.224" timestamp_utc="2026-05-18T17:14:55.224" last_modified="2026-05-18T18:15:00" version="1779124495592">
+      <Q id="6427379283" qualifier_id="56" value="Left"/>
+      <Q id="6427379285" qualifier_id="140" value="72.3"/>
+      <Q id="6427379287" qualifier_id="141" value="83.5"/>
+      <Q id="6427379289" qualifier_id="212" value="18.6"/>
+      <Q id="6427379291" qualifier_id="213" value="0.61"/>
+    </Event>
+    <Event id="2939612755" event_id="116" type_id="1" period_id="1" min="9" sec="10" player_id="575855" team_id="244" outcome="0" x="75.4" y="79.9" timestamp="2026-05-18T18:15:00.032" timestamp_utc="2026-05-18T17:15:00.032" last_modified="2026-05-18T19:37:25" version="1779129445744">
+      <Q id="6427390523" qualifier_id="2"/>
+      <Q id="6427379347" qualifier_id="56" value="Center"/>
+      <Q id="6427379625" qualifier_id="140" value="77.6"/>
+      <Q id="6427379627" qualifier_id="141" value="77.3"/>
+      <Q id="6427379629" qualifier_id="212" value="2.9"/>
+      <Q id="6427379631" qualifier_id="213" value="5.63"/>
+      <Q id="6427671405" qualifier_id="233" value="81"/>
+      <Q id="6427667127" qualifier_id="236"/>
+      <Q id="6427667129" qualifier_id="286"/>
+    </Event>
+    <Event id="2939612763" event_id="81" type_id="12" period_id="1" min="9" sec="10" player_id="685390" team_id="417" outcome="1" x="22.4" y="22.7" timestamp="2026-05-18T18:15:00.132" timestamp_utc="2026-05-18T17:15:00.132" last_modified="2026-05-18T19:37:28" version="1779129448162">
+      <Q id="6427379379" qualifier_id="56" value="Back"/>
+      <Q id="6427671367" qualifier_id="185"/>
+      <Q id="6427671417" qualifier_id="233" value="116"/>
+    </Event>
+    <Event id="2939612841" event_id="117" type_id="1" period_id="1" min="9" sec="16" player_id="180662" team_id="244" outcome="1" x="56.8" y="81.1" timestamp="2026-05-18T18:15:06.024" timestamp_utc="2026-05-18T17:15:06.024" last_modified="2026-05-18T18:15:08" version="1779124506386">
+      <Q id="6427379807" qualifier_id="56" value="Left"/>
+      <Q id="6427379811" qualifier_id="140" value="63.5"/>
+      <Q id="6427379815" qualifier_id="141" value="92.0"/>
+      <Q id="6427379817" qualifier_id="212" value="10.2"/>
+      <Q id="6427379819" qualifier_id="213" value="0.81"/>
+    </Event>
+    <Event id="2939612867" event_id="118" type_id="1" period_id="1" min="9" sec="19" player_id="575855" team_id="244" outcome="1" x="57.9" y="89.1" timestamp="2026-05-18T18:15:09.408" timestamp_utc="2026-05-18T17:15:09.408" last_modified="2026-05-18T18:15:12" version="1779124509880">
+      <Q id="6427379931" qualifier_id="56" value="Back"/>
+      <Q id="6427379933" qualifier_id="140" value="48.8"/>
+      <Q id="6427379935" qualifier_id="141" value="60.6"/>
+      <Q id="6427379937" qualifier_id="212" value="21.6"/>
+      <Q id="6427379939" qualifier_id="213" value="4.25"/>
+    </Event>
+    <Event id="2939612939" event_id="119" type_id="1" period_id="1" min="9" sec="22" player_id="627127" team_id="244" outcome="1" x="45.0" y="57.2" timestamp="2026-05-18T18:15:12.184" timestamp_utc="2026-05-18T17:15:12.184" last_modified="2026-05-18T18:15:17" version="1779124513395">
+      <Q id="6427380269" qualifier_id="56" value="Back"/>
+      <Q id="6427380271" qualifier_id="140" value="22.4"/>
+      <Q id="6427380273" qualifier_id="141" value="62.1"/>
+      <Q id="6427380275" qualifier_id="212" value="24.0"/>
+      <Q id="6427380277" qualifier_id="213" value="3.00"/>
+    </Event>
+    <Event id="2939612983" event_id="120" type_id="1" period_id="1" min="9" sec="28" player_id="578592" team_id="244" outcome="1" x="20.8" y="59.9" timestamp="2026-05-18T18:15:18.160" timestamp_utc="2026-05-18T17:15:18.160" last_modified="2026-05-18T18:15:24" version="1779124518802">
+      <Q id="6427380573" qualifier_id="56" value="Back"/>
+      <Q id="6427380575" qualifier_id="140" value="24.6"/>
+      <Q id="6427380577" qualifier_id="141" value="28.6"/>
+      <Q id="6427380579" qualifier_id="212" value="21.7"/>
+      <Q id="6427380581" qualifier_id="213" value="4.90"/>
+    </Event>
+    <Event id="2939613013" event_id="121" type_id="1" period_id="1" min="9" sec="34" player_id="627127" team_id="244" outcome="0" x="32.6" y="21.3" timestamp="2026-05-18T18:15:23.976" timestamp_utc="2026-05-18T17:15:23.976" last_modified="2026-05-18T18:15:27" version="1779124526945">
+      <Q id="6427380749" qualifier_id="56" value="Center"/>
+      <Q id="6427380751" qualifier_id="140" value="57.0"/>
+      <Q id="6427380753" qualifier_id="141" value="44.3"/>
+      <Q id="6427380747" qualifier_id="155"/>
+      <Q id="6427380755" qualifier_id="212" value="30.0"/>
+      <Q id="6427380757" qualifier_id="213" value="0.55"/>
+    </Event>
+    <Event id="2939613007" event_id="82" type_id="44" period_id="1" min="9" sec="36" player_id="61812" team_id="417" outcome="1" x="43.0" y="55.7" timestamp="2026-05-18T18:15:26.232" timestamp_utc="2026-05-18T17:15:26.232" last_modified="2026-05-18T19:37:46" version="1779129466123">
+      <Q id="6427380717" qualifier_id="56" value="Back"/>
+      <Q id="6427380887" qualifier_id="233" value="122"/>
+      <Q id="6427380721" qualifier_id="285"/>
+    </Event>
+    <Event id="2939613019" event_id="122" type_id="44" period_id="1" min="9" sec="36" player_id="232091" team_id="244" outcome="0" x="57.0" y="44.3" timestamp="2026-05-18T18:15:26.233" timestamp_utc="2026-05-18T17:15:26.233" last_modified="2026-05-18T19:37:46" version="1779129466142">
+      <Q id="6427380801" qualifier_id="56" value="Center"/>
+      <Q id="6427380893" qualifier_id="233" value="82"/>
+      <Q id="6427380803" qualifier_id="286"/>
+    </Event>
+    <Event id="2939613029" event_id="83" type_id="1" period_id="1" min="9" sec="36" player_id="61812" team_id="417" outcome="0" x="43.0" y="55.7" timestamp="2026-05-18T18:15:26.498" timestamp_utc="2026-05-18T17:15:26.498" last_modified="2026-05-18T19:37:46" version="1779129466159">
+      <Q id="6427380855" qualifier_id="3"/>
+      <Q id="6427380857" qualifier_id="56" value="Back"/>
+      <Q id="6427380859" qualifier_id="140" value="48.2"/>
+      <Q id="6427380861" qualifier_id="141" value="44.2"/>
+      <Q id="6427380863" qualifier_id="212" value="9.5"/>
+      <Q id="6427380865" qualifier_id="213" value="5.32"/>
+    </Event>
+    <Event id="2939613053" event_id="123" type_id="1" period_id="1" min="9" sec="38" player_id="207884" team_id="244" outcome="1" x="50.8" y="52.8" timestamp="2026-05-18T18:15:28.496" timestamp_utc="2026-05-18T17:15:28.496" last_modified="2026-05-18T18:15:31" version="1779124528636">
+      <Q id="6427380963" qualifier_id="56" value="Center"/>
+      <Q id="6427380965" qualifier_id="140" value="53.0"/>
+      <Q id="6427380967" qualifier_id="141" value="49.0"/>
+      <Q id="6427380969" qualifier_id="212" value="3.5"/>
+      <Q id="6427380971" qualifier_id="213" value="5.44"/>
+    </Event>
+    <Event id="2939613075" event_id="124" type_id="1" period_id="1" min="9" sec="41" player_id="232091" team_id="244" outcome="1" x="54.3" y="38.5" timestamp="2026-05-18T18:15:31.329" timestamp_utc="2026-05-18T17:15:31.329" last_modified="2026-05-18T18:15:34" version="1779124531644">
+      <Q id="6427381071" qualifier_id="56" value="Back"/>
+      <Q id="6427381073" qualifier_id="140" value="36.2"/>
+      <Q id="6427381075" qualifier_id="141" value="38.8"/>
+      <Q id="6427381077" qualifier_id="212" value="19.0"/>
+      <Q id="6427381079" qualifier_id="213" value="3.13"/>
+    </Event>
+    <Event id="2939613071" event_id="84" type_id="83" period_id="1" min="9" sec="44" player_id="61812" team_id="417" outcome="0" x="49.3" y="64.9" timestamp="2026-05-18T18:15:33.890" timestamp_utc="2026-05-18T17:15:33.890" last_modified="2026-05-18T18:15:36" version="1779124536386">
+      <Q id="6427381253" qualifier_id="399" value="515742"/>
+    </Event>
+    <Event id="2939613095" event_id="125" type_id="1" period_id="1" min="9" sec="44" player_id="515742" team_id="244" outcome="1" x="39.2" y="35.1" timestamp="2026-05-18T18:15:34.104" timestamp_utc="2026-05-18T17:15:34.104" last_modified="2026-05-18T18:15:36" version="1779124534776">
+      <Q id="6427381235" qualifier_id="56" value="Right"/>
+      <Q id="6427381237" qualifier_id="140" value="54.0"/>
+      <Q id="6427381239" qualifier_id="141" value="10.9"/>
+      <Q id="6427381241" qualifier_id="212" value="22.6"/>
+      <Q id="6427381243" qualifier_id="213" value="5.47"/>
+    </Event>
+    <Event id="2939613109" event_id="126" type_id="1" period_id="1" min="9" sec="46" player_id="240166" team_id="244" outcome="1" x="56.8" y="6.8" timestamp="2026-05-18T18:15:36.696" timestamp_utc="2026-05-18T17:15:36.696" last_modified="2026-05-18T18:15:39" version="1779124536924">
+      <Q id="6427381307" qualifier_id="56" value="Right"/>
+      <Q id="6427381309" qualifier_id="140" value="65.0"/>
+      <Q id="6427381311" qualifier_id="141" value="9.5"/>
+      <Q id="6427381313" qualifier_id="212" value="8.8"/>
+      <Q id="6427381315" qualifier_id="213" value="0.21"/>
+    </Event>
+    <Event id="2939613117" event_id="127" type_id="1" period_id="1" min="9" sec="49" player_id="625775" team_id="244" outcome="0" x="67.9" y="12.5" timestamp="2026-05-18T18:15:38.920" timestamp_utc="2026-05-18T17:15:38.920" last_modified="2026-05-18T18:15:40" version="1779124540544">
+      <Q id="6427381351" qualifier_id="56" value="Right"/>
+      <Q id="6427381353" qualifier_id="140" value="74.6"/>
+      <Q id="6427381355" qualifier_id="141" value="15.2"/>
+      <Q id="6427381357" qualifier_id="212" value="7.3"/>
+      <Q id="6427381359" qualifier_id="213" value="0.26"/>
+    </Event>
+    <Event id="2939613161" event_id="85" type_id="12" period_id="1" min="9" sec="51" player_id="61812" team_id="417" outcome="1" x="19.0" y="89.0" timestamp="2026-05-18T18:15:41.211" timestamp_utc="2026-05-18T17:15:41.211" last_modified="2026-05-18T18:15:45" version="1779124541708">
+      <Q id="6427381577" qualifier_id="56" value="Back"/>
+      <Q id="6427381579" qualifier_id="140" value="30.4"/>
+      <Q id="6427381581" qualifier_id="141" value="94.1"/>
+      <Q id="6427381583" qualifier_id="212" value="12.5"/>
+      <Q id="6427381585" qualifier_id="213" value="0.28"/>
+    </Event>
+    <Event id="2939613163" event_id="86" type_id="50" period_id="1" min="9" sec="55" player_id="164593" team_id="417" outcome="1" x="30.4" y="93.4" timestamp="2026-05-18T18:15:44.930" timestamp_utc="2026-05-18T17:15:44.930" last_modified="2026-05-18T18:15:49" version="1779124547780">
+      <Q id="6427381587" qualifier_id="56" value="Back"/>
+      <Q id="6427381755" qualifier_id="233" value="128"/>
+      <Q id="6427381589" qualifier_id="285"/>
+    </Event>
+    <Event id="2939613175" event_id="128" type_id="7" period_id="1" min="9" sec="55" player_id="625775" team_id="244" outcome="1" x="69.7" y="6.6" timestamp="2026-05-18T18:15:44.931" timestamp_utc="2026-05-18T17:15:44.931" last_modified="2026-05-18T18:15:50" version="1779124547788">
+      <Q id="6427381683" qualifier_id="56" value="Right"/>
+      <Q id="6427381681" qualifier_id="167"/>
+      <Q id="6427381687" qualifier_id="178"/>
+      <Q id="6427381723" qualifier_id="233" value="86"/>
+      <Q id="6427381727" qualifier_id="286"/>
+    </Event>
+    <Event id="2939613203" event_id="129" type_id="5" period_id="1" min="9" sec="56" player_id="625775" team_id="244" outcome="0" x="64.5" y="-1.5" timestamp="2026-05-18T18:15:46.409" timestamp_utc="2026-05-18T17:15:46.409" last_modified="2026-05-18T19:36:50" version="1779129407880">
+      <Q id="6427381851" qualifier_id="56" value="Right"/>
+      <Q id="6427382259" qualifier_id="233" value="87"/>
+      <Q id="6427381853" qualifier_id="347"/>
+    </Event>
+    <Event id="2939613275" event_id="87" type_id="5" period_id="1" min="9" sec="56" player_id="164593" team_id="417" outcome="1" x="35.5" y="101.5" timestamp="2026-05-18T18:15:46.409" timestamp_utc="2026-05-18T17:15:46.409" last_modified="2026-05-18T19:36:50" version="1779129407876">
+      <Q id="6427382205" qualifier_id="56" value="Back"/>
+      <Q id="6427382251" qualifier_id="233" value="129"/>
+      <Q id="6427382207" qualifier_id="347"/>
+    </Event>
+    <Event id="2939613291" event_id="88" type_id="1" period_id="1" min="10" sec="8" player_id="624620" team_id="417" outcome="0" x="30.0" y="100.0" timestamp="2026-05-18T18:15:57.882" timestamp_utc="2026-05-18T17:15:57.882" last_modified="2026-05-18T18:15:59" version="1779124559705">
+      <Q id="6427382319" qualifier_id="1"/>
+      <Q id="6427382309" qualifier_id="56" value="Left"/>
+      <Q id="6427382307" qualifier_id="107"/>
+      <Q id="6427382311" qualifier_id="140" value="58.5"/>
+      <Q id="6427382313" qualifier_id="141" value="88.9"/>
+      <Q id="6427382315" qualifier_id="212" value="31.2"/>
+      <Q id="6427382317" qualifier_id="213" value="5.99"/>
+    </Event>
+    <Event id="2939623555" event_id="150" type_id="1" period_id="1" min="10" sec="10" player_id="627127" team_id="244" outcome="1" x="20.1" y="16.2" timestamp="2026-05-18T18:16:00.737" timestamp_utc="2026-05-18T17:16:00.737" last_modified="2026-05-18T18:34:15" version="1779125650622">
+      <Q id="6427448919" qualifier_id="56" value="Back"/>
+      <Q id="6427448921" qualifier_id="140" value="28.3"/>
+      <Q id="6427448923" qualifier_id="141" value="15.8"/>
+      <Q id="6427448925" qualifier_id="212" value="8.6"/>
+      <Q id="6427448927" qualifier_id="213" value="6.25"/>
+    </Event>
+    <Event id="2939613307" event_id="130" type_id="1" period_id="1" min="10" sec="11" player_id="232091" team_id="244" outcome="0" x="40.2" y="17.1" timestamp="2026-05-18T18:16:01.823" timestamp_utc="2026-05-18T17:16:01.823" last_modified="2026-05-18T18:33:43" version="1779125623719">
+      <Q id="6427382427" qualifier_id="1"/>
+      <Q id="6427382417" qualifier_id="56" value="Right"/>
+      <Q id="6427382419" qualifier_id="140" value="61.5"/>
+      <Q id="6427382421" qualifier_id="141" value="0.0"/>
+      <Q id="6427382415" qualifier_id="157"/>
+      <Q id="6427382423" qualifier_id="212" value="25.8"/>
+      <Q id="6427382425" qualifier_id="213" value="5.76"/>
+    </Event>
+    <Event id="2939613309" event_id="131" type_id="5" period_id="1" min="10" sec="12" player_id="627127" team_id="244" outcome="0" x="62.7" y="-1.8" timestamp="2026-05-18T18:16:02.506" timestamp_utc="2026-05-18T17:16:02.506" last_modified="2026-05-18T19:36:51" version="1779129407888">
+      <Q id="6427382431" qualifier_id="56" value="Right"/>
+      <Q id="6427385327" qualifier_id="233" value="89"/>
+      <Q id="6427382433" qualifier_id="347"/>
+    </Event>
+    <Event id="2939613811" event_id="89" type_id="5" period_id="1" min="10" sec="12" player_id="624620" team_id="417" outcome="1" x="37.3" y="101.8" timestamp="2026-05-18T18:16:02.506" timestamp_utc="2026-05-18T17:16:02.506" last_modified="2026-05-18T19:36:51" version="1779129407884">
+      <Q id="6427385287" qualifier_id="56" value="Back"/>
+      <Q id="6427385311" qualifier_id="233" value="131"/>
+      <Q id="6427385289" qualifier_id="347"/>
+    </Event>
+    <Event id="2939625167" event_id="137" type_id="1" period_id="1" min="10" sec="26" player_id="61812" team_id="417" outcome="1" x="20.9" y="100.0" timestamp="2026-05-18T18:16:16.266" timestamp_utc="2026-05-18T17:16:16.266" last_modified="2026-05-18T18:34:52" version="1779125692530">
+      <Q id="6427452645" qualifier_id="56" value="Back"/>
+      <Q id="6427452643" qualifier_id="107"/>
+      <Q id="6427452647" qualifier_id="140" value="19.1"/>
+      <Q id="6427452649" qualifier_id="141" value="81.2"/>
+      <Q id="6427452651" qualifier_id="212" value="13.7"/>
+      <Q id="6427452653" qualifier_id="213" value="4.57"/>
+    </Event>
+    <Event id="2939625197" event_id="141" type_id="1" period_id="1" min="10" sec="28" player_id="531784" team_id="417" outcome="1" x="36.6" y="20.9" timestamp="2026-05-18T18:16:18.338" timestamp_utc="2026-05-18T17:16:18.338" last_modified="2026-05-18T18:35:39" version="1779125738935">
+      <Q id="6427455847" qualifier_id="56" value="Right"/>
+      <Q id="6427455849" qualifier_id="140" value="64.2"/>
+      <Q id="6427455851" qualifier_id="141" value="1.9"/>
+      <Q id="6427455853" qualifier_id="212" value="31.7"/>
+      <Q id="6427455855" qualifier_id="213" value="5.86"/>
+    </Event>
+    <Event id="2939625165" event_id="136" type_id="1" period_id="1" min="10" sec="35" player_id="157851" team_id="417" outcome="1" x="64.7" y="7.2" timestamp="2026-05-18T18:16:25.090" timestamp_utc="2026-05-18T17:16:25.090" last_modified="2026-05-18T18:36:20" version="1779125780219">
+      <Q id="6427458173" qualifier_id="56" value="Back"/>
+      <Q id="6427458175" qualifier_id="140" value="39.7"/>
+      <Q id="6427458177" qualifier_id="141" value="10.7"/>
+      <Q id="6427458179" qualifier_id="212" value="26.4"/>
+      <Q id="6427458181" qualifier_id="213" value="3.05"/>
+    </Event>
+    <Event id="2939625203" event_id="142" type_id="1" period_id="1" min="10" sec="36" player_id="531784" team_id="417" outcome="0" x="31.5" y="18.2" timestamp="2026-05-18T18:16:26.498" timestamp_utc="2026-05-18T17:16:26.498" last_modified="2026-05-18T18:36:52" version="1779125812735">
+      <Q id="6427461131" qualifier_id="1"/>
+      <Q id="6427461121" qualifier_id="56" value="Right"/>
+      <Q id="6427461123" qualifier_id="140" value="64.7"/>
+      <Q id="6427461125" qualifier_id="141" value="6.8"/>
+      <Q id="6427461127" qualifier_id="212" value="35.7"/>
+      <Q id="6427461129" qualifier_id="213" value="6.06"/>
+    </Event>
+    <Event id="2939623563" event_id="151" type_id="8" period_id="1" min="10" sec="44" player_id="515742" team_id="244" outcome="1" x="35.3" y="93.2" timestamp="2026-05-18T18:16:33.993" timestamp_utc="2026-05-18T17:16:33.993" last_modified="2026-05-18T19:37:41" version="1779129461036">
+      <Q id="6427462397" qualifier_id="56" value="Back"/>
+    </Event>
+    <Event id="2939623739" event_id="189" type_id="5" period_id="1" min="10" sec="45" player_id="515742" team_id="244" outcome="0" x="36.0" y="101.0" timestamp="2026-05-18T18:16:35.572" timestamp_utc="2026-05-18T17:16:35.572" last_modified="2026-05-18T19:36:51" version="1779129407898">
+      <Q id="6427463099" qualifier_id="56" value="Back"/>
+      <Q id="6427464529" qualifier_id="233" value="121"/>
+      <Q id="6427463101" qualifier_id="347"/>
+    </Event>
+    <Event id="2939625103" event_id="121" type_id="5" period_id="1" min="10" sec="45" player_id="624620" team_id="417" outcome="1" x="64.0" y="-1.0" timestamp="2026-05-18T18:16:35.572" timestamp_utc="2026-05-18T17:16:35.572" last_modified="2026-05-18T19:36:51" version="1779129407892">
+      <Q id="6427464447" qualifier_id="56" value="Right"/>
+      <Q id="6427464469" qualifier_id="233" value="189"/>
+      <Q id="6427464449" qualifier_id="347"/>
+    </Event>
+    <Event id="2939625159" event_id="135" type_id="1" period_id="1" min="10" sec="50" player_id="531784" team_id="417" outcome="1" x="63.4" y="0.0" timestamp="2026-05-18T18:16:39.955" timestamp_utc="2026-05-18T17:16:39.955" last_modified="2026-05-18T18:38:15" version="1779125895023">
+      <Q id="6427467387" qualifier_id="56" value="Right"/>
+      <Q id="6427467385" qualifier_id="107"/>
+      <Q id="6427467391" qualifier_id="140" value="73.4"/>
+      <Q id="6427467395" qualifier_id="141" value="14.8"/>
+      <Q id="6427467399" qualifier_id="212" value="15.4"/>
+      <Q id="6427467403" qualifier_id="213" value="0.82"/>
+    </Event>
+    <Event id="2939625179" event_id="139" type_id="61" period_id="1" min="11" sec="0" player_id="445539" team_id="417" outcome="0" x="60.1" y="8.8" timestamp="2026-05-18T18:16:50.746" timestamp_utc="2026-05-18T17:16:50.746" last_modified="2026-05-18T18:40:14" version="1779126014562">
+      <Q id="6427468357" qualifier_id="56" value="Right"/>
+    </Event>
+    <Event id="2939623737" event_id="188" type_id="1" period_id="1" min="11" sec="1" player_id="648131" team_id="244" outcome="1" x="36.8" y="88.7" timestamp="2026-05-18T18:16:51.540" timestamp_utc="2026-05-18T17:16:51.540" last_modified="2026-05-18T18:41:04" version="1779126064718">
+      <Q id="6427467895" qualifier_id="56" value="Back"/>
+      <Q id="6427469779" qualifier_id="140" value="29.8"/>
+      <Q id="6427469781" qualifier_id="141" value="78.5"/>
+      <Q id="6427469783" qualifier_id="212" value="10.1"/>
+      <Q id="6427469785" qualifier_id="213" value="3.90"/>
+    </Event>
+    <Event id="2939623567" event_id="152" type_id="49" period_id="1" min="11" sec="2" player_id="180662" team_id="244" outcome="1" x="32.3" y="69.1" timestamp="2026-05-18T18:16:52.025" timestamp_utc="2026-05-18T17:16:52.025" last_modified="2026-05-18T18:41:23" version="1779126083167"/>
+    <Event id="2939613833" event_id="132" type_id="43" period_id="1" min="11" sec="2" team_id="244" outcome="1" x="0.0" y="0.0" timestamp="2026-05-18T18:16:52.058" timestamp_utc="2026-05-18T17:16:52.058" last_modified="2026-05-18T18:27:59" version="1779124621916">
+      <Q id="6427425799" qualifier_id="144" value="27"/>
+      <Q id="6427385403" qualifier_id="201" value="0"/>
+      <Q id="6427385405" qualifier_id="203" value="0"/>
+      <Q id="6427385427" qualifier_id="233" value="90"/>
+    </Event>
+    <Event id="2939625169" event_id="138" type_id="43" period_id="1" min="11" sec="2" player_id="531784" team_id="417" outcome="1" x="0.0" y="0.0" timestamp="2026-05-18T18:16:52.506" timestamp_utc="2026-05-18T17:16:52.506" last_modified="2026-05-18T18:40:57" version="1779126018947">
+      <Q id="6427480299" qualifier_id="144" value="49"/>
+    </Event>
+    <Event id="2939625155" event_id="134" type_id="43" period_id="1" min="11" sec="2" player_id="531784" team_id="417" outcome="1" x="0.0" y="0.0" timestamp="2026-05-18T18:16:52.786" timestamp_utc="2026-05-18T17:16:52.786" last_modified="2026-05-18T18:40:55" version="1779126020376">
+      <Q id="6427472149" qualifier_id="56" value="Center"/>
+      <Q id="6427472151" qualifier_id="140" value="55.0"/>
+      <Q id="6427472153" qualifier_id="141" value="35.0"/>
+      <Q id="6427480123" qualifier_id="144" value="1"/>
+      <Q id="6427472155" qualifier_id="212" value="23.5"/>
+      <Q id="6427472157" qualifier_id="213" value="2.76"/>
+    </Event>
+    <Event id="2939623571" event_id="154" type_id="1" period_id="1" min="11" sec="3" player_id="180662" team_id="244" outcome="1" x="25.4" y="71.6" timestamp="2026-05-18T18:16:53.100" timestamp_utc="2026-05-18T17:16:53.100" last_modified="2026-05-18T18:41:44" version="1779126104081">
+      <Q id="6427484275" qualifier_id="56" value="Back"/>
+      <Q id="6427484277" qualifier_id="140" value="43.6"/>
+      <Q id="6427484279" qualifier_id="141" value="61.1"/>
+      <Q id="6427484281" qualifier_id="212" value="20.4"/>
+      <Q id="6427484283" qualifier_id="213" value="5.93"/>
+    </Event>
+    <Event id="2939623569" event_id="153" type_id="4" period_id="1" min="11" sec="5" player_id="625775" team_id="244" outcome="1" x="37.4" y="56.4" timestamp="2026-05-18T18:16:55.057" timestamp_utc="2026-05-18T17:16:55.057" last_modified="2026-05-18T19:22:25" version="1779128545700">
+      <Q id="6427485343" qualifier_id="13"/>
+      <Q id="6427485345" qualifier_id="56" value="Back"/>
+      <Q id="6427485347" qualifier_id="152"/>
+      <Q id="6427487039" qualifier_id="233" value="119"/>
+      <Q id="6427485349" qualifier_id="265"/>
+      <Q id="6427485351" qualifier_id="286"/>
+    </Event>
+    <Event id="2939625081" event_id="119" type_id="4" period_id="1" min="11" sec="5" player_id="720682" team_id="417" outcome="0" x="62.6" y="43.6" timestamp="2026-05-18T18:16:55.058" timestamp_utc="2026-05-18T17:16:55.058" last_modified="2026-05-18T19:22:26" version="1779128545705">
+      <Q id="6427486989" qualifier_id="13"/>
+      <Q id="6427486991" qualifier_id="56" value="Center"/>
+      <Q id="6427486993" qualifier_id="152"/>
+      <Q id="6427487073" qualifier_id="233" value="153"/>
+      <Q id="6427486995" qualifier_id="265"/>
+      <Q id="6427486997" qualifier_id="285"/>
+    </Event>
+    <Event id="2939623577" event_id="155" type_id="1" period_id="1" min="11" sec="6" player_id="207884" team_id="244" outcome="1" x="26.2" y="52.8" timestamp="2026-05-18T18:16:56.134" timestamp_utc="2026-05-18T17:16:56.134" last_modified="2026-05-18T19:10:35" version="1779127835693">
+      <Q id="6427489499" qualifier_id="5"/>
+      <Q id="6427489275" qualifier_id="56" value="Back"/>
+      <Q id="6427489277" qualifier_id="140" value="35.6"/>
+      <Q id="6427489279" qualifier_id="141" value="74.4"/>
+      <Q id="6427489501" qualifier_id="152"/>
+      <Q id="6427489817" qualifier_id="189"/>
+      <Q id="6427489281" qualifier_id="212" value="17.7"/>
+      <Q id="6427489283" qualifier_id="213" value="0.98"/>
+    </Event>
+    <Event id="2939623581" event_id="156" type_id="1" period_id="1" min="11" sec="19" player_id="515742" team_id="244" outcome="1" x="34.5" y="73.8" timestamp="2026-05-18T18:17:09.172" timestamp_utc="2026-05-18T17:17:09.172" last_modified="2026-05-18T18:44:09" version="1779126249117">
+      <Q id="6427491515" qualifier_id="56" value="Back"/>
+      <Q id="6427491517" qualifier_id="140" value="44.0"/>
+      <Q id="6427491519" qualifier_id="141" value="92.2"/>
+      <Q id="6427491521" qualifier_id="212" value="16.0"/>
+      <Q id="6427491523" qualifier_id="213" value="0.90"/>
+    </Event>
+    <Event id="2939623587" event_id="157" type_id="1" period_id="1" min="11" sec="20" player_id="575855" team_id="244" outcome="1" x="46.7" y="91.2" timestamp="2026-05-18T18:17:10.204" timestamp_utc="2026-05-18T17:17:10.204" last_modified="2026-05-18T18:44:15" version="1779126255659">
+      <Q id="6427492163" qualifier_id="56" value="Back"/>
+      <Q id="6427492165" qualifier_id="140" value="39.3"/>
+      <Q id="6427492167" qualifier_id="141" value="74.4"/>
+      <Q id="6427492169" qualifier_id="212" value="13.8"/>
+      <Q id="6427492171" qualifier_id="213" value="4.12"/>
+    </Event>
+    <Event id="2939623591" event_id="158" type_id="1" period_id="1" min="11" sec="21" player_id="515742" team_id="244" outcome="1" x="41.3" y="78.9" timestamp="2026-05-18T18:17:11.238" timestamp_utc="2026-05-18T17:17:11.238" last_modified="2026-05-18T18:44:29" version="1779126269829">
+      <Q id="6427492813" qualifier_id="56" value="Back"/>
+      <Q id="6427492815" qualifier_id="140" value="26.2"/>
+      <Q id="6427492817" qualifier_id="141" value="58.9"/>
+      <Q id="6427492819" qualifier_id="212" value="20.9"/>
+      <Q id="6427492821" qualifier_id="213" value="3.85"/>
+    </Event>
+    <Event id="2939623595" event_id="159" type_id="1" period_id="1" min="11" sec="24" player_id="180662" team_id="244" outcome="1" x="29.2" y="64.4" timestamp="2026-05-18T18:17:14.264" timestamp_utc="2026-05-18T17:17:14.264" last_modified="2026-05-18T18:44:38" version="1779126278267">
+      <Q id="6427493751" qualifier_id="56" value="Back"/>
+      <Q id="6427493753" qualifier_id="140" value="27.8"/>
+      <Q id="6427493755" qualifier_id="141" value="17.6"/>
+      <Q id="6427493757" qualifier_id="212" value="31.9"/>
+      <Q id="6427493759" qualifier_id="213" value="4.67"/>
+    </Event>
+    <Event id="2939623601" event_id="160" type_id="1" period_id="1" min="11" sec="28" player_id="627127" team_id="244" outcome="0" x="27.2" y="18.0" timestamp="2026-05-18T18:17:18.293" timestamp_utc="2026-05-18T17:17:18.293" last_modified="2026-05-18T18:44:56" version="1779126296301">
+      <Q id="6427498951" qualifier_id="1"/>
+      <Q id="6427498941" qualifier_id="56" value="Center"/>
+      <Q id="6427498943" qualifier_id="140" value="77.1"/>
+      <Q id="6427498945" qualifier_id="141" value="22.9"/>
+      <Q id="6427498947" qualifier_id="212" value="52.5"/>
+      <Q id="6427498949" qualifier_id="213" value="0.06"/>
+    </Event>
+    <Event id="2939625139" event_id="130" type_id="49" period_id="1" min="11" sec="30" player_id="624620" team_id="417" outcome="1" x="22.1" y="77.7" timestamp="2026-05-18T18:17:20.145" timestamp_utc="2026-05-18T17:17:20.145" last_modified="2026-05-18T18:45:18" version="1779126318568"/>
+    <Event id="2939625141" event_id="131" type_id="4" period_id="1" min="11" sec="36" player_id="624620" team_id="417" outcome="1" x="62.2" y="69.3" timestamp="2026-05-18T18:17:26.297" timestamp_utc="2026-05-18T17:17:26.297" last_modified="2026-05-18T19:22:26" version="1779128545710">
+      <Q id="6427502613" qualifier_id="13"/>
+      <Q id="6427502617" qualifier_id="56" value="Center"/>
+      <Q id="6427502619" qualifier_id="152"/>
+      <Q id="6427503937" qualifier_id="233" value="161"/>
+      <Q id="6427502621" qualifier_id="286"/>
+      <Q id="6427502615" qualifier_id="295"/>
+    </Event>
+    <Event id="2939623605" event_id="161" type_id="4" period_id="1" min="11" sec="36" player_id="515742" team_id="244" outcome="0" x="37.8" y="30.7" timestamp="2026-05-18T18:17:26.298" timestamp_utc="2026-05-18T17:17:26.298" last_modified="2026-05-18T19:37:51" version="1779129471699">
+      <Q id="6427503923" qualifier_id="13"/>
+      <Q id="6427503925" qualifier_id="56" value="Back"/>
+      <Q id="6427503927" qualifier_id="152"/>
+      <Q id="6427503941" qualifier_id="233" value="131"/>
+      <Q id="6427503931" qualifier_id="285"/>
+      <Q id="6427673137" qualifier_id="295"/>
+    </Event>
+    <Event id="2939625101" event_id="120" type_id="1" period_id="1" min="11" sec="56" player_id="624620" team_id="417" outcome="1" x="66.0" y="76.9" timestamp="2026-05-18T18:17:46.690" timestamp_utc="2026-05-18T17:17:46.690" last_modified="2026-05-18T18:46:48" version="1779126408779">
+      <Q id="6427506891" qualifier_id="5"/>
+      <Q id="6427506713" qualifier_id="56" value="Left"/>
+      <Q id="6427506715" qualifier_id="140" value="50.6"/>
+      <Q id="6427506717" qualifier_id="141" value="81.8"/>
+      <Q id="6427506893" qualifier_id="152"/>
+      <Q id="6427506923" qualifier_id="189"/>
+      <Q id="6427506719" qualifier_id="212" value="16.5"/>
+      <Q id="6427506721" qualifier_id="213" value="2.94"/>
+    </Event>
+    <Event id="2939625111" event_id="124" type_id="1" period_id="1" min="11" sec="58" player_id="720682" team_id="417" outcome="1" x="48.7" y="83.6" timestamp="2026-05-18T18:17:48.273" timestamp_utc="2026-05-18T17:17:48.273" last_modified="2026-05-18T18:47:34" version="1779126454746">
+      <Q id="6427509659" qualifier_id="56" value="Center"/>
+      <Q id="6427509661" qualifier_id="140" value="51.6"/>
+      <Q id="6427509663" qualifier_id="141" value="73.8"/>
+      <Q id="6427509763" qualifier_id="189"/>
+      <Q id="6427509665" qualifier_id="212" value="7.3"/>
+      <Q id="6427509667" qualifier_id="213" value="5.14"/>
+    </Event>
+    <Event id="2939625185" event_id="140" type_id="1" period_id="1" min="12" sec="2" player_id="218339" team_id="417" outcome="1" x="49.1" y="78.9" timestamp="2026-05-18T18:17:51.978" timestamp_utc="2026-05-18T17:17:51.978" last_modified="2026-05-18T18:47:42" version="1779126461932">
+      <Q id="6427510321" qualifier_id="1"/>
+      <Q id="6427510311" qualifier_id="56" value="Back"/>
+      <Q id="6427510313" qualifier_id="140" value="45.9"/>
+      <Q id="6427510315" qualifier_id="141" value="18.6"/>
+      <Q id="6427510307" qualifier_id="155"/>
+      <Q id="6427510309" qualifier_id="196"/>
+      <Q id="6427510317" qualifier_id="212" value="41.1"/>
+      <Q id="6427510319" qualifier_id="213" value="4.63"/>
+    </Event>
+    <Event id="2939625113" event_id="125" type_id="1" period_id="1" min="12" sec="8" player_id="531784" team_id="417" outcome="1" x="41.2" y="10.1" timestamp="2026-05-18T18:17:58.425" timestamp_utc="2026-05-18T17:17:58.425" last_modified="2026-05-18T18:48:09" version="1779126489581">
+      <Q id="6427512101" qualifier_id="56" value="Back"/>
+      <Q id="6427512103" qualifier_id="140" value="22.5"/>
+      <Q id="6427512105" qualifier_id="141" value="37.0"/>
+      <Q id="6427512107" qualifier_id="212" value="26.8"/>
+      <Q id="6427512109" qualifier_id="213" value="2.39"/>
+    </Event>
+    <Event id="2939625117" event_id="127" type_id="1" period_id="1" min="12" sec="13" player_id="61812" team_id="417" outcome="1" x="36.6" y="39.9" timestamp="2026-05-18T18:18:03.722" timestamp_utc="2026-05-18T17:18:03.722" last_modified="2026-05-18T18:48:31" version="1779126511698">
+      <Q id="6427513327" qualifier_id="56" value="Back"/>
+      <Q id="6427513329" qualifier_id="140" value="15.1"/>
+      <Q id="6427513331" qualifier_id="141" value="40.1"/>
+      <Q id="6427513333" qualifier_id="212" value="22.6"/>
+      <Q id="6427513335" qualifier_id="213" value="3.14"/>
+    </Event>
+    <Event id="2939625105" event_id="122" type_id="1" period_id="1" min="12" sec="15" player_id="565487" team_id="417" outcome="1" x="13.2" y="41.7" timestamp="2026-05-18T18:18:04.977" timestamp_utc="2026-05-18T17:18:04.977" last_modified="2026-05-18T18:49:00" version="1779126539977">
+      <Q id="6427515083" qualifier_id="1"/>
+      <Q id="6427515073" qualifier_id="56" value="Left"/>
+      <Q id="6427515075" qualifier_id="140" value="69.1"/>
+      <Q id="6427515077" qualifier_id="141" value="85.4"/>
+      <Q id="6427515071" qualifier_id="157"/>
+      <Q id="6427515079" qualifier_id="212" value="65.8"/>
+      <Q id="6427515081" qualifier_id="213" value="0.47"/>
+    </Event>
+    <Event id="2939625125" event_id="128" type_id="1" period_id="1" min="12" sec="15" player_id="624620" team_id="417" outcome="0" x="66.8" y="84.6" timestamp="2026-05-18T18:18:05.857" timestamp_utc="2026-05-18T17:18:05.857" last_modified="2026-05-18T18:49:15" version="1779126555281">
+      <Q id="6427515995" qualifier_id="3"/>
+      <Q id="6427515997" qualifier_id="56" value="Center"/>
+      <Q id="6427515999" qualifier_id="140" value="79.8"/>
+      <Q id="6427516001" qualifier_id="141" value="72.8"/>
+      <Q id="6427516003" qualifier_id="212" value="15.8"/>
+      <Q id="6427516005" qualifier_id="213" value="5.75"/>
+    </Event>
+    <Event id="2939623607" event_id="162" type_id="1" period_id="1" min="12" sec="20" player_id="627127" team_id="244" outcome="0" x="21.4" y="25.8" timestamp="2026-05-18T18:18:10.353" timestamp_utc="2026-05-18T17:18:10.353" last_modified="2026-05-18T19:11:45" version="1779127905641">
+      <Q id="6427584743" qualifier_id="1"/>
+      <Q id="6427516589" qualifier_id="56" value="Back"/>
+      <Q id="6427516591" qualifier_id="140" value="39.7"/>
+      <Q id="6427516593" qualifier_id="141" value="23.5"/>
+      <Q id="6427584741" qualifier_id="157"/>
+      <Q id="6427516595" qualifier_id="212" value="19.3"/>
+      <Q id="6427516597" qualifier_id="213" value="6.20"/>
+    </Event>
+    <Event id="2939623611" event_id="163" type_id="45" period_id="1" min="12" sec="23" player_id="232091" team_id="244" outcome="0" x="39.0" y="28.1" timestamp="2026-05-18T18:18:13.657" timestamp_utc="2026-05-18T17:18:13.657" last_modified="2026-05-18T19:22:29" version="1779128547488">
+      <Q id="6427520327" qualifier_id="56" value="Back"/>
+      <Q id="6427520373" qualifier_id="233" value="143"/>
+      <Q id="6427520329" qualifier_id="285"/>
+    </Event>
+    <Event id="2939625207" event_id="143" type_id="3" period_id="1" min="12" sec="23" player_id="61778" team_id="417" outcome="1" x="61.0" y="71.9" timestamp="2026-05-18T18:18:13.657" timestamp_utc="2026-05-18T17:18:13.657" last_modified="2026-05-18T19:22:28" version="1779128547481">
+      <Q id="6427519239" qualifier_id="56" value="Center"/>
+      <Q id="6427520331" qualifier_id="233" value="163"/>
+      <Q id="6427519243" qualifier_id="286"/>
+    </Event>
+    <Event id="2939625209" event_id="144" type_id="1" period_id="1" min="12" sec="25" player_id="61778" team_id="417" outcome="1" x="55.0" y="72.2" timestamp="2026-05-18T18:18:15.825" timestamp_utc="2026-05-18T17:18:15.825" last_modified="2026-05-18T18:50:43" version="1779126643089">
+      <Q id="6427521981" qualifier_id="56" value="Left"/>
+      <Q id="6427521983" qualifier_id="140" value="67.7"/>
+      <Q id="6427521985" qualifier_id="141" value="90.4"/>
+      <Q id="6427521987" qualifier_id="212" value="18.2"/>
+      <Q id="6427521989" qualifier_id="213" value="0.75"/>
+    </Event>
+    <Event id="2939625109" event_id="123" type_id="3" period_id="1" min="12" sec="28" player_id="624620" team_id="417" outcome="0" x="79.8" y="85.8" timestamp="2026-05-18T18:18:18.122" timestamp_utc="2026-05-18T17:18:18.122" last_modified="2026-05-18T19:22:27" version="1779128546333">
+      <Q id="6427523287" qualifier_id="56" value="Left"/>
+      <Q id="6427524403" qualifier_id="233" value="164"/>
+      <Q id="6427523289" qualifier_id="286"/>
+    </Event>
+    <Event id="2939623613" event_id="164" type_id="7" period_id="1" min="12" sec="28" player_id="232091" team_id="244" outcome="1" x="20.2" y="14.2" timestamp="2026-05-18T18:18:18.123" timestamp_utc="2026-05-18T17:18:18.123" last_modified="2026-05-18T19:22:26" version="1779128546329">
+      <Q id="6427524361" qualifier_id="56" value="Back"/>
+      <Q id="6427524385" qualifier_id="233" value="123"/>
+      <Q id="6427524363" qualifier_id="285"/>
+    </Event>
+    <Event id="2939623617" event_id="165" type_id="6" period_id="1" min="12" sec="30" player_id="232091" team_id="244" outcome="0" x="0.0" y="9.2" timestamp="2026-05-18T18:18:20.569" timestamp_utc="2026-05-18T17:18:20.569" last_modified="2026-05-18T19:36:24" version="1779129384303">
+      <Q id="6427526543" qualifier_id="56" value="Back"/>
+      <Q id="6427526545" qualifier_id="73"/>
+      <Q id="6427526591" qualifier_id="233" value="126"/>
+    </Event>
+    <Event id="2939625115" event_id="126" type_id="6" period_id="1" min="12" sec="30" player_id="624620" team_id="417" outcome="1" x="100.0" y="90.8" timestamp="2026-05-18T18:18:20.569" timestamp_utc="2026-05-18T17:18:20.569" last_modified="2026-05-18T19:36:24" version="1779129384297">
+      <Q id="6427526131" qualifier_id="56" value="Left"/>
+      <Q id="6427526133" qualifier_id="73"/>
+      <Q id="6427526559" qualifier_id="233" value="165"/>
+    </Event>
+    <Event id="2939625131" event_id="129" type_id="1" period_id="1" min="12" sec="55" player_id="61778" team_id="417" outcome="1" x="99.6" y="99.3" timestamp="2026-05-18T18:18:44.986" timestamp_utc="2026-05-18T17:18:44.986" last_modified="2026-05-18T18:54:20" version="1779126860438">
+      <Q id="6427528645" qualifier_id="6"/>
+      <Q id="6427528213" qualifier_id="56" value="Center"/>
+      <Q id="6427528215" qualifier_id="140" value="94.7"/>
+      <Q id="6427528217" qualifier_id="141" value="77.5"/>
+      <Q id="6427528219" qualifier_id="212" value="15.7"/>
+      <Q id="6427528221" qualifier_id="213" value="4.38"/>
+    </Event>
+    <Event id="2939625147" event_id="132" type_id="1" period_id="1" min="12" sec="59" player_id="218339" team_id="417" outcome="1" x="94.9" y="84.6" timestamp="2026-05-18T18:18:49.458" timestamp_utc="2026-05-18T17:18:49.458" last_modified="2026-05-18T18:52:51" version="1779126771751">
+      <Q id="6427529809" qualifier_id="56" value="Left"/>
+      <Q id="6427529811" qualifier_id="140" value="86.0"/>
+      <Q id="6427529813" qualifier_id="141" value="94.6"/>
+      <Q id="6427529815" qualifier_id="212" value="11.6"/>
+      <Q id="6427529817" qualifier_id="213" value="2.51"/>
+    </Event>
+    <Event id="2939640141" event_id="231" type_id="1" period_id="1" min="13" sec="0" player_id="61778" team_id="417" outcome="1" x="84.1" y="92.3" timestamp="2026-05-18T18:18:50.458" timestamp_utc="2026-05-18T17:18:50.458" last_modified="2026-05-18T18:53:55" version="1779126816532">
+      <Q id="6427533567" qualifier_id="56" value="Center"/>
+      <Q id="6427533569" qualifier_id="140" value="91.7"/>
+      <Q id="6427533571" qualifier_id="141" value="59.1"/>
+      <Q id="6427533573" qualifier_id="212" value="23.9"/>
+      <Q id="6427533575" qualifier_id="213" value="5.05"/>
+    </Event>
+    <Event id="2939640257" event_id="234" type_id="1" period_id="1" min="13" sec="1" player_id="685390" team_id="417" outcome="0" x="90.9" y="64.4" timestamp="2026-05-18T18:18:51.458" timestamp_utc="2026-05-18T17:18:51.458" last_modified="2026-05-18T18:54:23" version="1779126863767">
+      <Q id="6427534139" qualifier_id="56" value="Center"/>
+      <Q id="6427534141" qualifier_id="140" value="84.5"/>
+      <Q id="6427534143" qualifier_id="141" value="42.4"/>
+      <Q id="6427534145" qualifier_id="212" value="16.4"/>
+      <Q id="6427534147" qualifier_id="213" value="4.29"/>
+    </Event>
+    <Event id="2939623625" event_id="166" type_id="12" period_id="1" min="13" sec="2" player_id="625775" team_id="244" outcome="1" x="12.2" y="45.2" timestamp="2026-05-18T18:18:51.893" timestamp_utc="2026-05-18T17:18:51.893" last_modified="2026-05-18T18:54:47" version="1779126887866">
+      <Q id="6427535919" qualifier_id="56" value="Back"/>
+      <Q id="6427535921" qualifier_id="140" value="24.2"/>
+      <Q id="6427535923" qualifier_id="141" value="28.2"/>
+      <Q id="6427535925" qualifier_id="212" value="17.1"/>
+      <Q id="6427535927" qualifier_id="213" value="5.54"/>
+    </Event>
+    <Event id="2939623629" event_id="167" type_id="81" period_id="1" min="13" sec="3" team_id="244" outcome="1" x="20.4" y="39.4" timestamp="2026-05-18T18:18:52.932" timestamp_utc="2026-05-18T17:18:52.932" last_modified="2026-05-18T18:55:03" version="1779126903723">
+      <Q id="6427536631" qualifier_id="380"/>
+    </Event>
+    <Event id="2939623635" event_id="168" type_id="68" period_id="1" min="13" sec="4" team_id="244" outcome="1" x="23.4" y="30.3" timestamp="2026-05-18T18:18:53.971" timestamp_utc="2026-05-18T17:18:53.971" last_modified="2026-05-18T19:13:00" version="1779127980433">
+      <Q id="6427588661" qualifier_id="354"/>
+    </Event>
+    <Event id="2939641399" event_id="240" type_id="68" period_id="1" min="13" sec="5" team_id="417" outcome="0" x="80.2" y="58.5" timestamp="2026-05-18T18:18:54.971" timestamp_utc="2026-05-18T17:18:54.971" last_modified="2026-05-18T18:56:46" version="1779127006854"/>
+    <Event id="2939623639" event_id="169" type_id="1" period_id="1" min="13" sec="12" player_id="627127" team_id="244" outcome="1" x="18.5" y="39.5" timestamp="2026-05-18T18:19:02.006" timestamp_utc="2026-05-18T17:19:02.006" last_modified="2026-05-18T18:57:02" version="1779127022310">
+      <Q id="6427542117" qualifier_id="56" value="Back"/>
+      <Q id="6427542119" qualifier_id="140" value="19.4"/>
+      <Q id="6427542121" qualifier_id="141" value="7.2"/>
+      <Q id="6427542123" qualifier_id="212" value="22.0"/>
+      <Q id="6427542125" qualifier_id="213" value="4.76"/>
+    </Event>
+    <Event id="2939623643" event_id="170" type_id="1" period_id="1" min="13" sec="19" player_id="240166" team_id="244" outcome="1" x="23.9" y="12.7" timestamp="2026-05-18T18:19:09.046" timestamp_utc="2026-05-18T17:19:09.046" last_modified="2026-05-18T19:13:18" version="1779127997940">
+      <Q id="6427543513" qualifier_id="56" value="Back"/>
+      <Q id="6427543515" qualifier_id="140" value="9.3"/>
+      <Q id="6427543517" qualifier_id="141" value="46.4"/>
+      <Q id="6427543519" qualifier_id="212" value="27.6"/>
+      <Q id="6427543521" qualifier_id="213" value="2.16"/>
+    </Event>
+    <Event id="2939623647" event_id="171" type_id="1" period_id="1" min="13" sec="25" player_id="578592" team_id="244" outcome="1" x="8.8" y="49.9" timestamp="2026-05-18T18:19:15.066" timestamp_utc="2026-05-18T17:19:15.066" last_modified="2026-05-18T18:57:50" version="1779127070813">
+      <Q id="6427544291" qualifier_id="56" value="Back"/>
+      <Q id="6427544293" qualifier_id="140" value="15.7"/>
+      <Q id="6427544295" qualifier_id="141" value="75.0"/>
+      <Q id="6427544297" qualifier_id="212" value="18.5"/>
+      <Q id="6427544299" qualifier_id="213" value="1.17"/>
+    </Event>
+    <Event id="2939623655" event_id="172" type_id="1" period_id="1" min="13" sec="26" player_id="180662" team_id="244" outcome="1" x="6.8" y="69.1" timestamp="2026-05-18T18:19:16.105" timestamp_utc="2026-05-18T17:19:16.105" last_modified="2026-05-18T18:58:30" version="1779127110076">
+      <Q id="6427546035" qualifier_id="56" value="Back"/>
+      <Q id="6427546037" qualifier_id="140" value="19.9"/>
+      <Q id="6427546039" qualifier_id="141" value="93.6"/>
+      <Q id="6427546041" qualifier_id="212" value="21.6"/>
+      <Q id="6427546043" qualifier_id="213" value="0.88"/>
+    </Event>
+    <Event id="2939623663" event_id="173" type_id="1" period_id="1" min="13" sec="30" player_id="575855" team_id="244" outcome="1" x="21.2" y="89.9" timestamp="2026-05-18T18:19:20.124" timestamp_utc="2026-05-18T17:19:20.124" last_modified="2026-05-18T18:58:44" version="1779127124070">
+      <Q id="6427546409" qualifier_id="56" value="Back"/>
+      <Q id="6427546411" qualifier_id="140" value="38.7"/>
+      <Q id="6427546413" qualifier_id="141" value="78.1"/>
+      <Q id="6427546415" qualifier_id="212" value="20.1"/>
+      <Q id="6427546417" qualifier_id="213" value="5.87"/>
+    </Event>
+    <Event id="2939642631" event_id="243" type_id="83" period_id="1" min="13" sec="34" player_id="531784" team_id="417" outcome="0" x="67.3" y="7.1" timestamp="2026-05-18T18:19:24.158" timestamp_utc="2026-05-18T17:19:24.158" last_modified="2026-05-18T18:59:35" version="1779127175832">
+      <Q id="6427548653" qualifier_id="399" value="648131"/>
+    </Event>
+    <Event id="2939642673" event_id="244" type_id="83" period_id="1" min="13" sec="34" player_id="531784" team_id="417" outcome="0" x="55.8" y="10.6" timestamp="2026-05-18T18:19:24.158" timestamp_utc="2026-05-18T17:19:24.158" last_modified="2026-05-18T18:59:33" version="1779127173496">
+      <Q id="6427548537" qualifier_id="399" value="648131"/>
+    </Event>
+    <Event id="2939623669" event_id="174" type_id="1" period_id="1" min="13" sec="36" player_id="648131" team_id="244" outcome="0" x="13.2" y="96.7" timestamp="2026-05-18T18:19:26.158" timestamp_utc="2026-05-18T17:19:26.158" last_modified="2026-05-18T19:13:42" version="1779128021916">
+      <Q id="6427547593" qualifier_id="56" value="Back"/>
+      <Q id="6427547595" qualifier_id="140" value="31.8"/>
+      <Q id="6427547597" qualifier_id="141" value="100.0"/>
+      <Q id="6427547599" qualifier_id="212" value="19.8"/>
+      <Q id="6427547601" qualifier_id="213" value="0.16"/>
+    </Event>
+    <Event id="2939623675" event_id="175" type_id="5" period_id="1" min="13" sec="37" player_id="625775" team_id="244" outcome="0" x="25.3" y="101.5" timestamp="2026-05-18T18:19:27.162" timestamp_utc="2026-05-18T17:19:27.162" last_modified="2026-05-18T19:36:52" version="1779129407905">
+      <Q id="6427551043" qualifier_id="56" value="Back"/>
+      <Q id="6427590907" qualifier_id="233" value="247"/>
+      <Q id="6427551045" qualifier_id="347"/>
+    </Event>
+    <Event id="2939649833" event_id="247" type_id="5" period_id="1" min="13" sec="37" player_id="720682" team_id="417" outcome="1" x="74.7" y="-1.5" timestamp="2026-05-18T18:19:27.162" timestamp_utc="2026-05-18T17:19:27.162" last_modified="2026-05-18T19:14:56" version="1779128096178">
+      <Q id="6427590869" qualifier_id="56" value="Right"/>
+      <Q id="6427590873" qualifier_id="233" value="175"/>
+      <Q id="6427590871" qualifier_id="347"/>
+    </Event>
+    <Event id="2939649947" event_id="248" type_id="1" period_id="1" min="13" sec="38" player_id="157851" team_id="417" outcome="1" x="67.4" y="0.0" timestamp="2026-05-18T18:19:28.162" timestamp_utc="2026-05-18T17:19:28.162" last_modified="2026-05-18T19:14:58" version="1779128098445">
+      <Q id="6427593715" qualifier_id="56" value="Center"/>
+      <Q id="6427593713" qualifier_id="107"/>
+      <Q id="6427593717" qualifier_id="140" value="74.4"/>
+      <Q id="6427593719" qualifier_id="141" value="26.8"/>
+      <Q id="6427593721" qualifier_id="212" value="20.7"/>
+      <Q id="6427593723" qualifier_id="213" value="1.21"/>
+    </Event>
+    <Event id="2939650059" event_id="249" type_id="1" period_id="1" min="13" sec="38" player_id="445539" team_id="417" outcome="1" x="82.2" y="13.7" timestamp="2026-05-18T18:19:28.262" timestamp_utc="2026-05-18T17:19:28.262" last_modified="2026-05-18T19:32:27" version="1779129147632">
+      <Q id="6427596135" qualifier_id="56" value="Center"/>
+      <Q id="6427596137" qualifier_id="140" value="79.5"/>
+      <Q id="6427596139" qualifier_id="141" value="24.6"/>
+      <Q id="6427596255" qualifier_id="189"/>
+      <Q id="6427596141" qualifier_id="212" value="7.9"/>
+      <Q id="6427596143" qualifier_id="213" value="1.94"/>
+    </Event>
+    <Event id="2939650119" event_id="250" type_id="1" period_id="1" min="13" sec="38" player_id="61778" team_id="417" outcome="0" x="71.7" y="33.6" timestamp="2026-05-18T18:19:28.362" timestamp_utc="2026-05-18T17:19:28.362" last_modified="2026-05-18T19:32:30" version="1779129150248">
+      <Q id="6427600601" qualifier_id="56" value="Center"/>
+      <Q id="6427600603" qualifier_id="140" value="88.3"/>
+      <Q id="6427600605" qualifier_id="141" value="29.1"/>
+      <Q id="6427600599" qualifier_id="155"/>
+      <Q id="6427600607" qualifier_id="212" value="17.7"/>
+      <Q id="6427600609" qualifier_id="213" value="6.11"/>
+    </Event>
+    <Event id="2939623681" event_id="176" type_id="12" period_id="1" min="13" sec="39" player_id="180662" team_id="244" outcome="1" x="12.5" y="70.5" timestamp="2026-05-18T18:19:29.541" timestamp_utc="2026-05-18T17:19:29.541" last_modified="2026-05-18T19:15:01" version="1779128101593">
+      <Q id="6427567719" qualifier_id="15"/>
+      <Q id="6427567619" qualifier_id="56" value="Back"/>
+      <Q id="6427567621" qualifier_id="140" value="22.4"/>
+      <Q id="6427567623" qualifier_id="141" value="84.2"/>
+      <Q id="6427567625" qualifier_id="212" value="14.0"/>
+      <Q id="6427567627" qualifier_id="213" value="0.73"/>
+    </Event>
+    <Event id="2939650209" event_id="251" type_id="1" period_id="1" min="13" sec="40" player_id="445539" team_id="417" outcome="1" x="89.9" y="25.8" timestamp="2026-05-18T18:19:30.162" timestamp_utc="2026-05-18T17:19:30.162" last_modified="2026-05-18T19:17:12" version="1779128231886">
+      <Q id="6427603049" qualifier_id="3"/>
+      <Q id="6427603051" qualifier_id="56" value="Center"/>
+      <Q id="6427603053" qualifier_id="140" value="83.5"/>
+      <Q id="6427603055" qualifier_id="141" value="28.9"/>
+      <Q id="6427603057" qualifier_id="212" value="7.0"/>
+      <Q id="6427603059" qualifier_id="213" value="2.84"/>
+    </Event>
+    <Event id="2939650285" event_id="252" type_id="1" period_id="1" min="13" sec="41" player_id="61778" team_id="417" outcome="0" x="78.6" y="33.1" timestamp="2026-05-18T18:19:31.162" timestamp_utc="2026-05-18T17:19:31.162" last_modified="2026-05-18T19:17:32" version="1779128252643">
+      <Q id="6427604201" qualifier_id="56" value="Center"/>
+      <Q id="6427604203" qualifier_id="140" value="85.9"/>
+      <Q id="6427604205" qualifier_id="141" value="30.9"/>
+      <Q id="6427604207" qualifier_id="212" value="7.8"/>
+      <Q id="6427604209" qualifier_id="213" value="6.09"/>
+    </Event>
+    <Event id="2939650329" event_id="253" type_id="61" period_id="1" min="13" sec="42" player_id="445539" team_id="417" outcome="1" x="85.3" y="30.1" timestamp="2026-05-18T18:19:32.162" timestamp_utc="2026-05-18T17:19:32.162" last_modified="2026-05-18T19:18:00" version="1779128280669">
+      <Q id="6427606069" qualifier_id="56" value="Center"/>
+    </Event>
+    <Event id="2939623683" event_id="177" type_id="61" period_id="1" min="13" sec="43" player_id="180662" team_id="244" outcome="1" x="12.7" y="69.7" timestamp="2026-05-18T18:19:33.572" timestamp_utc="2026-05-18T17:19:33.572" last_modified="2026-05-18T19:18:48" version="1779128328375">
+      <Q id="6427583933" qualifier_id="56" value="Back"/>
+    </Event>
+    <Event id="2939653125" event_id="254" type_id="1" period_id="1" min="13" sec="45" player_id="157851" team_id="417" outcome="0" x="92.2" y="8.8" timestamp="2026-05-18T18:19:35.162" timestamp_utc="2026-05-18T17:19:35.162" last_modified="2026-05-18T19:19:19" version="1779128359131">
+      <Q id="6427609815" qualifier_id="56" value="Center"/>
+      <Q id="6427609817" qualifier_id="140" value="90.3"/>
+      <Q id="6427609819" qualifier_id="141" value="30.7"/>
+      <Q id="6427609821" qualifier_id="212" value="15.0"/>
+      <Q id="6427609823" qualifier_id="213" value="1.70"/>
+    </Event>
+    <Event id="2939623689" event_id="178" type_id="12" period_id="1" min="13" sec="46" player_id="180662" team_id="244" outcome="1" x="8.8" y="62.0" timestamp="2026-05-18T18:19:36.619" timestamp_utc="2026-05-18T17:19:36.619" last_modified="2026-05-18T19:19:41" version="1779128380943">
+      <Q id="6427584893" qualifier_id="56" value="Back"/>
+      <Q id="6427584895" qualifier_id="140" value="7.7"/>
+      <Q id="6427584897" qualifier_id="141" value="82.4"/>
+      <Q id="6427584899" qualifier_id="212" value="13.9"/>
+      <Q id="6427584901" qualifier_id="213" value="1.65"/>
+    </Event>
+    <Event id="2939653481" event_id="257" type_id="1" period_id="1" min="13" sec="47" player_id="157851" team_id="417" outcome="0" x="92.3" y="7.0" timestamp="2026-05-18T18:19:37.162" timestamp_utc="2026-05-18T17:19:37.162" last_modified="2026-05-18T19:20:35" version="1779128435764">
+      <Q id="6427612211" qualifier_id="2"/>
+      <Q id="6427612215" qualifier_id="56" value="Right"/>
+      <Q id="6427612217" qualifier_id="140" value="93.0"/>
+      <Q id="6427612219" qualifier_id="141" value="10.5"/>
+      <Q id="6427612221" qualifier_id="212" value="2.5"/>
+      <Q id="6427612223" qualifier_id="213" value="1.27"/>
+      <Q id="6427614167" qualifier_id="233" value="179"/>
+      <Q id="6427614165" qualifier_id="236"/>
+      <Q id="6427614171" qualifier_id="286"/>
+    </Event>
+    <Event id="2939623695" event_id="179" type_id="12" period_id="1" min="13" sec="47" player_id="515742" team_id="244" outcome="1" x="7.0" y="89.5" timestamp="2026-05-18T18:19:37.262" timestamp_utc="2026-05-18T17:19:37.262" last_modified="2026-05-18T19:37:47" version="1779129467323">
+      <Q id="6427585879" qualifier_id="56" value="Back"/>
+      <Q id="6427585877" qualifier_id="185"/>
+      <Q id="6427614199" qualifier_id="233" value="257"/>
+    </Event>
+    <Event id="2939623697" event_id="180" type_id="6" period_id="1" min="13" sec="48" player_id="515742" team_id="244" outcome="0" x="1.8" y="79.6" timestamp="2026-05-18T18:19:38.057" timestamp_utc="2026-05-18T17:19:38.057" last_modified="2026-05-18T19:36:25" version="1779129384311">
+      <Q id="6427588555" qualifier_id="56" value="Back"/>
+      <Q id="6427588557" qualifier_id="73"/>
+      <Q id="6427615461" qualifier_id="233" value="260"/>
+    </Event>
+    <Event id="2939654163" event_id="260" type_id="6" period_id="1" min="13" sec="48" player_id="157851" team_id="417" outcome="1" x="98.2" y="20.4" timestamp="2026-05-18T18:19:38.057" timestamp_utc="2026-05-18T17:19:38.057" last_modified="2026-05-18T19:36:24" version="1779129384307">
+      <Q id="6427615425" qualifier_id="56" value="Right"/>
+      <Q id="6427615427" qualifier_id="73"/>
+      <Q id="6427615447" qualifier_id="233" value="180"/>
+    </Event>
+    <Event id="2939623469" event_id="100" type_id="1" period_id="1" min="13" sec="48" player_id="164593" team_id="417" outcome="1" x="99.8" y="0.5" keypass="1" timestamp="2026-05-18T18:19:38.635" timestamp_utc="2026-05-18T17:19:38.635" last_modified="2026-05-19T16:25:35" version="1779204334928">
+      <Q id="6427439843" qualifier_id="1"/>
+      <Q id="6427447091" qualifier_id="6"/>
+      <Q id="6427439833" qualifier_id="56" value="Center"/>
+      <Q id="6427439835" qualifier_id="140" value="81.6"/>
+      <Q id="6427439837" qualifier_id="141" value="54.6"/>
+      <Q id="6427454519" qualifier_id="154"/>
+      <Q id="6427454517" qualifier_id="210" value="13"/>
+      <Q id="6427439839" qualifier_id="212" value="41.5"/>
+      <Q id="6427439841" qualifier_id="213" value="2.05"/>
+    </Event>
+    <Event id="2939623473" event_id="101" type_id="13" period_id="1" min="13" sec="49" player_id="685390" team_id="417" outcome="1" x="81.6" y="54.6" timestamp="2026-05-18T18:19:39.756" timestamp_utc="2026-05-18T17:19:39.756" last_modified="2026-05-19T16:25:38" version="1779204338641">
+      <Q id="6427439863" qualifier_id="18"/>
+      <Q id="6427453971" qualifier_id="20"/>
+      <Q id="6427454585" qualifier_id="25"/>
+      <Q id="6427454589" qualifier_id="29"/>
+      <Q id="6427454593" qualifier_id="55" value="100"/>
+      <Q id="6427439865" qualifier_id="56" value="Center"/>
+      <Q id="6428768849" qualifier_id="83"/>
+      <Q id="6427454597" qualifier_id="102" value="58.5"/>
+      <Q id="6427454599" qualifier_id="103" value="13.9"/>
+      <Q id="6427454591" qualifier_id="154"/>
+      <Q id="6427454605" qualifier_id="230" value="98.1"/>
+      <Q id="6427454607" qualifier_id="231" value="48.4"/>
+      <Q id="6427454601" qualifier_id="328"/>
+    </Event>
+    <Event id="2939613817" event_id="90" type_id="27" period_id="1" min="13" sec="50" team_id="417" outcome="1" x="0.0" y="0.0" timestamp="2026-05-18T18:19:39.893" timestamp_utc="2026-05-18T17:19:39.893" last_modified="2026-05-18T18:31:09" version="1779125468651">
+      <Q id="6427385307" qualifier_id="201"/>
+      <Q id="6427385309" qualifier_id="203"/>
+      <Q id="6427431069" qualifier_id="233" value="148"/>
+      <Q id="6427431597" qualifier_id="299"/>
+    </Event>
+    <Event id="2939621909" event_id="148" type_id="27" period_id="1" min="13" sec="50" team_id="244" outcome="1" x="0.0" y="0.0" timestamp="2026-05-18T18:19:39.893" timestamp_utc="2026-05-18T17:19:39.893" last_modified="2026-05-18T19:39:54" version="1779129594639">
+      <Q id="6427681337" qualifier_id="200"/>
+      <Q id="6427681339" qualifier_id="203"/>
+      <Q id="6427431075" qualifier_id="233" value="90"/>
+      <Q id="6427431569" qualifier_id="299"/>
+    </Event>
+    <Event id="2939623073" event_id="98" type_id="28" period_id="1" min="13" sec="50" team_id="417" outcome="1" x="0.0" y="0.0" timestamp="2026-05-18T18:31:12.678" timestamp_utc="2026-05-18T17:31:12.678" last_modified="2026-05-18T18:31:57" version="1779125517631">
+      <Q id="6427437517" qualifier_id="55" value="90"/>
+      <Q id="6427440285" qualifier_id="233" value="149"/>
+      <Q id="6427437515" qualifier_id="299"/>
+    </Event>
+    <Event id="2939623173" event_id="149" type_id="28" period_id="1" min="13" sec="50" team_id="244" outcome="1" x="0.0" y="0.0" timestamp="2026-05-18T18:31:12.678" timestamp_utc="2026-05-18T17:31:12.678" last_modified="2026-05-18T18:31:58" version="1779125517634">
+      <Q id="6427438065" qualifier_id="55" value="148"/>
+      <Q id="6427440301" qualifier_id="233" value="98"/>
+      <Q id="6427438061" qualifier_id="299"/>
+    </Event>
+    <Event id="2939623417" event_id="99" type_id="43" period_id="1" min="14" sec="22" player_id="164593" team_id="417" outcome="1" x="0.0" y="0.0" timestamp="2026-05-18T18:31:44.997" timestamp_utc="2026-05-18T17:31:44.997" last_modified="2026-05-18T18:33:38" version="1779125504998">
+      <Q id="6427439437" qualifier_id="56" value="Right"/>
+      <Q id="6427446831" qualifier_id="144" value="50"/>
+      <Q id="6427439439" qualifier_id="286" value="0"/>
+    </Event>
+    <Event id="2939623763" event_id="102" type_id="5" period_id="1" min="14" sec="29" player_id="685390" team_id="417" outcome="0" x="101.0" y="57.1" timestamp="2026-05-18T18:31:51.996" timestamp_utc="2026-05-18T17:31:51.996" last_modified="2026-05-18T19:36:52" version="1779129407914">
+      <Q id="6427441109" qualifier_id="56" value="Center"/>
+      <Q id="6427619113" qualifier_id="233" value="195"/>
+      <Q id="6427441111" qualifier_id="346"/>
+    </Event>
+    <Event id="2939623779" event_id="195" type_id="5" period_id="1" min="14" sec="29" team_id="244" outcome="1" x="-1.0" y="42.9" timestamp="2026-05-18T18:31:51.996" timestamp_utc="2026-05-18T17:31:51.996" last_modified="2026-05-18T19:36:52" version="1779129407910">
+      <Q id="6427619041" qualifier_id="56" value="Back"/>
+      <Q id="6427619075" qualifier_id="233" value="102"/>
+      <Q id="6427619043" qualifier_id="346"/>
+    </Event>
+    <Event id="2939623703" event_id="181" type_id="1" period_id="1" min="14" sec="37" player_id="578592" team_id="244" outcome="1" x="4.0" y="52.6" timestamp="2026-05-18T18:32:00.092" timestamp_utc="2026-05-18T17:32:00.092" last_modified="2026-05-18T19:16:14" version="1779128174833">
+      <Q id="6427599475" qualifier_id="56" value="Back"/>
+      <Q id="6427599473" qualifier_id="124"/>
+      <Q id="6427599477" qualifier_id="140" value="14.0"/>
+      <Q id="6427599479" qualifier_id="141" value="28.0"/>
+      <Q id="6427599481" qualifier_id="212" value="19.8"/>
+      <Q id="6427599483" qualifier_id="213" value="5.27"/>
+      <Q id="6427599487" qualifier_id="237"/>
+    </Event>
+    <Event id="2939623705" event_id="182" type_id="1" period_id="1" min="14" sec="40" player_id="240166" team_id="244" outcome="1" x="26.9" y="26.8" timestamp="2026-05-18T18:32:03.124" timestamp_utc="2026-05-18T17:32:03.124" last_modified="2026-05-18T19:16:35" version="1779128195860">
+      <Q id="6427600839" qualifier_id="56" value="Back"/>
+      <Q id="6427600841" qualifier_id="140" value="38.7"/>
+      <Q id="6427600843" qualifier_id="141" value="22.3"/>
+      <Q id="6427600845" qualifier_id="212" value="12.8"/>
+      <Q id="6427600847" qualifier_id="213" value="6.04"/>
+    </Event>
+    <Event id="2939623709" event_id="183" type_id="1" period_id="1" min="14" sec="40" player_id="515742" team_id="244" outcome="1" x="41.3" y="19.0" timestamp="2026-05-18T18:32:03.171" timestamp_utc="2026-05-18T17:32:03.171" last_modified="2026-05-18T19:16:41" version="1779128201755">
+      <Q id="6427601231" qualifier_id="1"/>
+      <Q id="6427601221" qualifier_id="56" value="Left"/>
+      <Q id="6427601223" qualifier_id="140" value="70.1"/>
+      <Q id="6427601225" qualifier_id="141" value="79.5"/>
+      <Q id="6427601217" qualifier_id="155"/>
+      <Q id="6427601219" qualifier_id="196"/>
+      <Q id="6427601227" qualifier_id="212" value="51.1"/>
+      <Q id="6427601229" qualifier_id="213" value="0.94"/>
+    </Event>
+    <Event id="2939623791" event_id="198" type_id="1" period_id="1" min="14" sec="45" player_id="648131" team_id="244" outcome="0" x="82.3" y="85.0" timestamp="2026-05-18T18:32:08.314" timestamp_utc="2026-05-18T17:32:08.314" last_modified="2026-05-18T18:32:12" version="1779125529602">
+      <Q id="6427441185" qualifier_id="2"/>
+      <Q id="6427441189" qualifier_id="56" value="Center"/>
+      <Q id="6427441191" qualifier_id="140" value="86.9"/>
+      <Q id="6427441193" qualifier_id="141" value="49.7"/>
+      <Q id="6427441187" qualifier_id="155"/>
+      <Q id="6427441195" qualifier_id="212" value="24.5"/>
+      <Q id="6427441197" qualifier_id="213" value="4.91"/>
+    </Event>
+    <Event id="2939623771" event_id="103" type_id="12" period_id="1" min="14" sec="47" player_id="720682" team_id="417" outcome="1" x="9.3" y="51.0" timestamp="2026-05-18T18:32:10.348" timestamp_utc="2026-05-18T17:32:10.348" last_modified="2026-05-18T18:32:13" version="1779125530908">
+      <Q id="6427441153" qualifier_id="15"/>
+      <Q id="6427441141" qualifier_id="56" value="Back"/>
+      <Q id="6427441143" qualifier_id="140" value="20.6"/>
+      <Q id="6427441145" qualifier_id="141" value="75.3"/>
+      <Q id="6427441147" qualifier_id="212" value="20.3"/>
+      <Q id="6427441149" qualifier_id="213" value="0.95"/>
+    </Event>
+    <Event id="2939623813" event_id="199" type_id="50" period_id="1" min="14" sec="50" player_id="240166" team_id="244" outcome="1" x="87.5" y="24.8" timestamp="2026-05-18T18:32:13.443" timestamp_utc="2026-05-18T17:32:13.443" last_modified="2026-05-18T18:32:15" version="1779125533858">
+      <Q id="6427441325" qualifier_id="56" value="Center"/>
+      <Q id="6427441397" qualifier_id="233" value="104"/>
+      <Q id="6427441327" qualifier_id="286"/>
+    </Event>
+    <Event id="2939623817" event_id="104" type_id="7" period_id="1" min="14" sec="50" player_id="164593" team_id="417" outcome="0" x="12.6" y="75.2" timestamp="2026-05-18T18:32:13.444" timestamp_utc="2026-05-18T17:32:13.444" last_modified="2026-05-18T18:32:16" version="1779125535372">
+      <Q id="6427441337" qualifier_id="56" value="Back"/>
+      <Q id="6427441341" qualifier_id="178"/>
+      <Q id="6427441381" qualifier_id="233" value="199"/>
+      <Q id="6427441339" qualifier_id="285"/>
+    </Event>
+    <Event id="2939623885" event_id="200" type_id="1" period_id="1" min="14" sec="53" player_id="625775" team_id="244" outcome="1" x="81.5" y="11.0" timestamp="2026-05-18T18:32:15.650" timestamp_utc="2026-05-18T17:32:15.650" last_modified="2026-05-18T18:32:17" version="1779125535914">
+      <Q id="6427441691" qualifier_id="56" value="Right"/>
+      <Q id="6427441693" qualifier_id="140" value="90.6"/>
+      <Q id="6427441695" qualifier_id="141" value="18.9"/>
+      <Q id="6427441697" qualifier_id="212" value="11.0"/>
+      <Q id="6427441699" qualifier_id="213" value="0.51"/>
+    </Event>
+    <Event id="2939623943" event_id="201" type_id="1" period_id="1" min="14" sec="54" player_id="240166" team_id="244" outcome="1" x="97.0" y="24.7" timestamp="2026-05-18T18:32:17.522" timestamp_utc="2026-05-18T17:32:17.522" last_modified="2026-05-18T18:32:21" version="1779125541810">
+      <Q id="6427441991" qualifier_id="2"/>
+      <Q id="6427441995" qualifier_id="56" value="Center"/>
+      <Q id="6427441997" qualifier_id="140" value="94.8"/>
+      <Q id="6427441999" qualifier_id="141" value="70.3"/>
+      <Q id="6427441993" qualifier_id="155"/>
+      <Q id="6427442001" qualifier_id="212" value="31.1"/>
+      <Q id="6427442003" qualifier_id="213" value="1.65"/>
+    </Event>
+    <Event id="2939623947" event_id="202" type_id="1" period_id="1" min="14" sec="59" player_id="648131" team_id="244" outcome="1" x="91.6" y="73.2" timestamp="2026-05-18T18:32:21.816" timestamp_utc="2026-05-18T17:32:21.816" last_modified="2026-05-18T18:35:30" version="1779125730528">
+      <Q id="6427455267" qualifier_id="56" value="Center"/>
+      <Q id="6427455269" qualifier_id="140" value="74.4"/>
+      <Q id="6427455271" qualifier_id="141" value="72.4"/>
+      <Q id="6427455273" qualifier_id="212" value="18.1"/>
+      <Q id="6427455275" qualifier_id="213" value="3.17"/>
+    </Event>
+    <Event id="2939623983" event_id="203" type_id="1" period_id="1" min="15" sec="2" player_id="207884" team_id="244" outcome="0" x="95.8" y="73.5" timestamp="2026-05-18T18:32:24.730" timestamp_utc="2026-05-18T17:32:24.730" last_modified="2026-05-18T18:32:26" version="1779125546058">
+      <Q id="6427442225" qualifier_id="2"/>
+      <Q id="6427442229" qualifier_id="56" value="Center"/>
+      <Q id="6427442231" qualifier_id="140" value="89.6"/>
+      <Q id="6427442233" qualifier_id="141" value="49.0"/>
+      <Q id="6427442227" qualifier_id="155"/>
+      <Q id="6427442235" qualifier_id="212" value="17.9"/>
+      <Q id="6427442237" qualifier_id="213" value="4.34"/>
+    </Event>
+    <Event id="2939624117" event_id="105" type_id="12" period_id="1" min="15" sec="3" player_id="624620" team_id="417" outcome="1" x="8.5" y="53.1" timestamp="2026-05-18T18:32:26.404" timestamp_utc="2026-05-18T17:32:26.404" last_modified="2026-05-18T18:32:42" version="1779125551189">
+      <Q id="6427443079" qualifier_id="56" value="Center"/>
+      <Q id="6427443081" qualifier_id="140" value="68.3"/>
+      <Q id="6427443083" qualifier_id="141" value="27.9"/>
+      <Q id="6427443085" qualifier_id="212" value="65.1"/>
+      <Q id="6427443087" qualifier_id="213" value="6.02"/>
+    </Event>
+    <Event id="2939624059" event_id="204" type_id="43" period_id="1" min="15" sec="10" player_id="180662" team_id="244" outcome="1" x="0.0" y="0.0" timestamp="2026-05-18T18:32:33.490" timestamp_utc="2026-05-18T17:32:33.490" last_modified="2026-05-18T19:17:48" version="1779125553491">
+      <Q id="6427605351" qualifier_id="144" value="49"/>
+    </Event>
+    <Event id="2939624085" event_id="205" type_id="1" period_id="1" min="15" sec="11" player_id="180662" team_id="244" outcome="1" x="35.2" y="71.5" timestamp="2026-05-18T18:32:34.074" timestamp_utc="2026-05-18T17:32:34.074" last_modified="2026-05-18T18:32:37" version="1779125556434">
+      <Q id="6427442841" qualifier_id="56" value="Back"/>
+      <Q id="6427442843" qualifier_id="140" value="49.3"/>
+      <Q id="6427442845" qualifier_id="141" value="54.6"/>
+      <Q id="6427442847" qualifier_id="212" value="18.7"/>
+      <Q id="6427442849" qualifier_id="213" value="5.62"/>
+    </Event>
+    <Event id="2939624111" event_id="206" type_id="1" period_id="1" min="15" sec="14" player_id="515742" team_id="244" outcome="1" x="48.9" y="55.4" timestamp="2026-05-18T18:32:37.458" timestamp_utc="2026-05-18T17:32:37.458" last_modified="2026-05-18T18:32:40" version="1779125557860">
+      <Q id="6427443019" qualifier_id="56" value="Left"/>
+      <Q id="6427443021" qualifier_id="140" value="56.5"/>
+      <Q id="6427443023" qualifier_id="141" value="82.3"/>
+      <Q id="6427443025" qualifier_id="212" value="20.0"/>
+      <Q id="6427443027" qualifier_id="213" value="1.16"/>
+    </Event>
+    <Event id="2939624115" event_id="207" type_id="1" period_id="1" min="15" sec="18" player_id="575855" team_id="244" outcome="1" x="58.8" y="82.0" timestamp="2026-05-18T18:32:40.810" timestamp_utc="2026-05-18T17:32:40.810" last_modified="2026-05-18T18:32:41" version="1779125560907">
+      <Q id="6427443067" qualifier_id="56" value="Left"/>
+      <Q id="6427443069" qualifier_id="140" value="63.0"/>
+      <Q id="6427443071" qualifier_id="141" value="85.9"/>
+      <Q id="6427443073" qualifier_id="212" value="5.1"/>
+      <Q id="6427443075" qualifier_id="213" value="0.54"/>
+    </Event>
+    <Event id="2939624119" event_id="208" type_id="1" period_id="1" min="15" sec="19" player_id="207884" team_id="244" outcome="0" x="63.0" y="85.9" timestamp="2026-05-18T18:32:41.697" timestamp_utc="2026-05-18T17:32:41.697" last_modified="2026-05-18T18:32:42" version="1779125562002">
+      <Q id="6427443089" qualifier_id="56" value="Center"/>
+      <Q id="6427443091" qualifier_id="140" value="62.6"/>
+      <Q id="6427443093" qualifier_id="141" value="78.8"/>
+      <Q id="6427443095" qualifier_id="212" value="4.8"/>
+      <Q id="6427443097" qualifier_id="213" value="4.63"/>
+    </Event>
+    <Event id="2939624121" event_id="106" type_id="8" period_id="1" min="15" sec="19" player_id="720682" team_id="417" outcome="1" x="37.4" y="21.2" timestamp="2026-05-18T18:32:41.907" timestamp_utc="2026-05-18T17:32:41.907" last_modified="2026-05-18T19:37:41" version="1779129461297">
+      <Q id="6427443099" qualifier_id="56" value="Back"/>
+    </Event>
+    <Event id="2939624131" event_id="107" type_id="8" period_id="1" min="15" sec="20" player_id="218339" team_id="417" outcome="1" x="32.3" y="19.8" timestamp="2026-05-18T18:32:42.924" timestamp_utc="2026-05-18T17:32:42.924" last_modified="2026-05-18T19:35:33" version="1779129333297">
+      <Q id="6427443145" qualifier_id="56" value="Back"/>
+    </Event>
+    <Event id="2939623787" event_id="197" type_id="61" period_id="1" min="15" sec="21" player_id="648131" team_id="244" outcome="1" x="65.4" y="71.8" timestamp="2026-05-18T18:32:44.622" timestamp_utc="2026-05-18T17:32:44.622" last_modified="2026-05-18T19:38:34" version="1779129514359">
+      <Q id="6427608423" qualifier_id="56" value="Center"/>
+    </Event>
+    <Event id="2939624157" event_id="108" type_id="1" period_id="1" min="15" sec="22" player_id="685390" team_id="417" outcome="1" x="32.9" y="21.9" timestamp="2026-05-18T18:32:44.740" timestamp_utc="2026-05-18T17:32:44.740" last_modified="2026-05-18T19:35:37" version="1779129337703">
+      <Q id="6427443325" qualifier_id="56" value="Back"/>
+      <Q id="6427443327" qualifier_id="140" value="31.7"/>
+      <Q id="6427443329" qualifier_id="141" value="7.7"/>
+      <Q id="6427443331" qualifier_id="212" value="9.7"/>
+      <Q id="6427443333" qualifier_id="213" value="4.58"/>
+    </Event>
+    <Event id="2939624165" event_id="109" type_id="49" period_id="1" min="15" sec="23" player_id="157851" team_id="417" outcome="1" x="31.7" y="7.6" timestamp="2026-05-18T18:32:46.643" timestamp_utc="2026-05-18T17:32:46.643" last_modified="2026-05-18T19:35:38" version="1779129337923"/>
+    <Event id="2939624189" event_id="110" type_id="1" period_id="1" min="15" sec="24" player_id="157851" team_id="417" outcome="0" x="31.7" y="7.6" timestamp="2026-05-18T18:32:46.934" timestamp_utc="2026-05-18T17:32:46.934" last_modified="2026-05-18T19:35:40" version="1779129340298">
+      <Q id="6427443527" qualifier_id="1"/>
+      <Q id="6427443517" qualifier_id="56" value="Center"/>
+      <Q id="6427443519" qualifier_id="140" value="64.0"/>
+      <Q id="6427443521" qualifier_id="141" value="30.4"/>
+      <Q id="6427443515" qualifier_id="155"/>
+      <Q id="6427443523" qualifier_id="212" value="37.3"/>
+      <Q id="6427443525" qualifier_id="213" value="0.43"/>
+    </Event>
+    <Event id="2939623785" event_id="196" type_id="8" period_id="1" min="15" sec="25" player_id="180662" team_id="244" outcome="1" x="36.0" y="69.6" timestamp="2026-05-18T18:32:48.591" timestamp_utc="2026-05-18T17:32:48.591" last_modified="2026-05-18T19:37:45" version="1779129464971">
+      <Q id="6427610963" qualifier_id="56" value="Back"/>
+    </Event>
+    <Event id="2939624217" event_id="111" type_id="43" period_id="1" min="15" sec="27" player_id="445539" team_id="417" outcome="1" x="0.0" y="0.0" timestamp="2026-05-18T18:32:49.651" timestamp_utc="2026-05-18T17:32:49.651" last_modified="2026-05-18T19:20:07" version="1779125575337">
+      <Q id="6427443649" qualifier_id="56" value="Center"/>
+      <Q id="6427443653" qualifier_id="140" value="58.5"/>
+      <Q id="6427443657" qualifier_id="141" value="33.9"/>
+      <Q id="6427612341" qualifier_id="144" value="1"/>
+      <Q id="6427443661" qualifier_id="212" value="6.2"/>
+      <Q id="6427443665" qualifier_id="213" value="2.75"/>
+    </Event>
+    <Event id="2939624233" event_id="112" type_id="1" period_id="1" min="15" sec="28" player_id="61778" team_id="417" outcome="0" x="56.3" y="31.3" timestamp="2026-05-18T18:32:51.443" timestamp_utc="2026-05-18T17:32:51.443" last_modified="2026-05-18T18:32:52" version="1779125572371">
+      <Q id="6427443741" qualifier_id="56" value="Center"/>
+      <Q id="6427443747" qualifier_id="140" value="83.0"/>
+      <Q id="6427443753" qualifier_id="141" value="35.7"/>
+      <Q id="6427443759" qualifier_id="212" value="28.2"/>
+      <Q id="6427443763" qualifier_id="213" value="0.11"/>
+    </Event>
+    <Event id="2939624259" event_id="209" type_id="59" period_id="1" min="15" sec="31" player_id="578592" team_id="244" outcome="1" x="23.0" y="75.0" timestamp="2026-05-18T18:32:54.073" timestamp_utc="2026-05-18T17:32:54.073" last_modified="2026-05-18T18:32:54" version="1779125574075">
+      <Q id="6427443927" qualifier_id="56" value="Back"/>
+    </Event>
+    <Event id="2939624481" event_id="210" type_id="12" period_id="1" min="15" sec="31" player_id="578592" team_id="244" outcome="1" x="23.0" y="75.0" timestamp="2026-05-18T18:32:54.617" timestamp_utc="2026-05-18T17:32:54.617" last_modified="2026-05-18T18:33:14" version="1779125576123">
+      <Q id="6427445167" qualifier_id="56" value="Left"/>
+      <Q id="6427445169" qualifier_id="140" value="75.2"/>
+      <Q id="6427445171" qualifier_id="141" value="84.1"/>
+      <Q id="6427445173" qualifier_id="212" value="55.2"/>
+      <Q id="6427445175" qualifier_id="213" value="0.11"/>
+    </Event>
+    <Event id="2939624381" event_id="113" type_id="1" period_id="1" min="15" sec="33" player_id="531784" team_id="417" outcome="1" x="21.5" y="33.3" timestamp="2026-05-18T18:32:56.588" timestamp_utc="2026-05-18T17:32:56.588" last_modified="2026-05-18T18:33:04" version="1779125577821">
+      <Q id="6427444517" qualifier_id="3"/>
+      <Q id="6427444519" qualifier_id="56" value="Back"/>
+      <Q id="6427444521" qualifier_id="140" value="8.7"/>
+      <Q id="6427444523" qualifier_id="141" value="51.8"/>
+      <Q id="6427444525" qualifier_id="212" value="18.4"/>
+      <Q id="6427444527" qualifier_id="213" value="2.39"/>
+    </Event>
+    <Event id="2939624387" event_id="114" type_id="49" period_id="1" min="15" sec="41" player_id="565487" team_id="417" outcome="1" x="9.5" y="50.0" timestamp="2026-05-18T18:33:04.019" timestamp_utc="2026-05-18T17:33:04.019" last_modified="2026-05-18T18:33:04" version="1779125584020"/>
+    <Event id="2939624411" event_id="115" type_id="1" period_id="1" min="15" sec="41" player_id="565487" team_id="417" outcome="1" x="9.5" y="50.0" timestamp="2026-05-18T18:33:04.171" timestamp_utc="2026-05-18T17:33:04.171" last_modified="2026-05-18T18:33:08" version="1779125584652">
+      <Q id="6427444699" qualifier_id="56" value="Back"/>
+      <Q id="6427444701" qualifier_id="140" value="22.7"/>
+      <Q id="6427444703" qualifier_id="141" value="32.8"/>
+      <Q id="6427444705" qualifier_id="212" value="18.1"/>
+      <Q id="6427444707" qualifier_id="213" value="5.58"/>
+    </Event>
+    <Event id="2939624461" event_id="116" type_id="1" period_id="1" min="15" sec="45" player_id="531784" team_id="417" outcome="0" x="22.7" y="32.8" timestamp="2026-05-18T18:33:08.068" timestamp_utc="2026-05-18T17:33:08.068" last_modified="2026-05-18T18:33:12" version="1779125592164">
+      <Q id="6427445021" qualifier_id="1"/>
+      <Q id="6427445011" qualifier_id="56" value="Center"/>
+      <Q id="6427445013" qualifier_id="140" value="87.9"/>
+      <Q id="6427445015" qualifier_id="141" value="29.8"/>
+      <Q id="6427445009" qualifier_id="155"/>
+      <Q id="6427445017" qualifier_id="212" value="68.5"/>
+      <Q id="6427445019" qualifier_id="213" value="6.25"/>
+    </Event>
+    <Event id="2939624485" event_id="211" type_id="49" period_id="1" min="15" sec="51" player_id="578592" team_id="244" outcome="1" x="12.1" y="67.9" timestamp="2026-05-18T18:33:14.561" timestamp_utc="2026-05-18T17:33:14.561" last_modified="2026-05-18T18:33:14" version="1779125594562"/>
+    <Event id="2939624555" event_id="212" type_id="1" period_id="1" min="15" sec="52" player_id="578592" team_id="244" outcome="1" x="12.7" y="67.3" timestamp="2026-05-18T18:33:15.617" timestamp_utc="2026-05-18T17:33:15.617" last_modified="2026-05-18T18:33:19" version="1779125596034">
+      <Q id="6427445497" qualifier_id="56" value="Back"/>
+      <Q id="6427445499" qualifier_id="140" value="27.3"/>
+      <Q id="6427445501" qualifier_id="141" value="39.1"/>
+      <Q id="6427445503" qualifier_id="212" value="24.6"/>
+      <Q id="6427445505" qualifier_id="213" value="5.39"/>
+    </Event>
+    <Event id="2939624595" event_id="213" type_id="1" period_id="1" min="15" sec="57" player_id="627127" team_id="244" outcome="1" x="31.7" y="37.1" timestamp="2026-05-18T18:33:19.761" timestamp_utc="2026-05-18T17:33:19.761" last_modified="2026-05-18T18:33:24" version="1779125600594">
+      <Q id="6427445773" qualifier_id="56" value="Back"/>
+      <Q id="6427445775" qualifier_id="140" value="31.2"/>
+      <Q id="6427445777" qualifier_id="141" value="13.7"/>
+      <Q id="6427445779" qualifier_id="212" value="15.9"/>
+      <Q id="6427445781" qualifier_id="213" value="4.68"/>
+    </Event>
+    <Event id="2939624619" event_id="214" type_id="1" period_id="1" min="16" sec="1" player_id="240166" team_id="244" outcome="1" x="33.6" y="23.9" timestamp="2026-05-18T18:33:24.233" timestamp_utc="2026-05-18T17:33:24.233" last_modified="2026-05-18T18:33:25" version="1779125604610">
+      <Q id="6427445883" qualifier_id="56" value="Back"/>
+      <Q id="6427445885" qualifier_id="140" value="27.2"/>
+      <Q id="6427445887" qualifier_id="141" value="31.6"/>
+      <Q id="6427445889" qualifier_id="212" value="8.5"/>
+      <Q id="6427445891" qualifier_id="213" value="2.48"/>
+    </Event>
+    <Event id="2939624671" event_id="215" type_id="1" period_id="1" min="16" sec="3" player_id="627127" team_id="244" outcome="1" x="30.0" y="24.6" timestamp="2026-05-18T18:33:25.849" timestamp_utc="2026-05-18T17:33:25.849" last_modified="2026-05-18T18:33:30" version="1779125606673">
+      <Q id="6427446159" qualifier_id="56" value="Right"/>
+      <Q id="6427446161" qualifier_id="140" value="52.5"/>
+      <Q id="6427446163" qualifier_id="141" value="7.9"/>
+      <Q id="6427446165" qualifier_id="212" value="26.2"/>
+      <Q id="6427446167" qualifier_id="213" value="5.84"/>
+    </Event>
+    <Event id="2939624681" event_id="216" type_id="4" period_id="1" min="16" sec="7" player_id="625775" team_id="244" outcome="1" x="45.6" y="8.2" timestamp="2026-05-18T18:33:30.617" timestamp_utc="2026-05-18T17:33:30.617" last_modified="2026-05-18T18:33:40" version="1779125619617">
+      <Q id="6427446241" qualifier_id="13"/>
+      <Q id="6427446243" qualifier_id="56" value="Back"/>
+      <Q id="6427446245" qualifier_id="152"/>
+      <Q id="6427446803" qualifier_id="233" value="117"/>
+      <Q id="6427446247" qualifier_id="265"/>
+      <Q id="6427446249" qualifier_id="286"/>
+    </Event>
+    <Event id="2939624689" event_id="117" type_id="4" period_id="1" min="16" sec="7" player_id="624620" team_id="417" outcome="0" x="54.4" y="91.8" timestamp="2026-05-18T18:33:30.618" timestamp_utc="2026-05-18T17:33:30.618" last_modified="2026-05-18T18:33:39" version="1779125617482">
+      <Q id="6427446727" qualifier_id="13"/>
+      <Q id="6427446729" qualifier_id="56" value="Left"/>
+      <Q id="6427446731" qualifier_id="152"/>
+      <Q id="6427446809" qualifier_id="233" value="216"/>
+      <Q id="6427446733" qualifier_id="265"/>
+      <Q id="6427446735" qualifier_id="285"/>
+    </Event>
+    <Event id="2939624863" event_id="217" type_id="1" period_id="1" min="16" sec="21" player_id="207884" team_id="244" outcome="0" x="42.8" y="14.0" timestamp="2026-05-18T18:33:44.033" timestamp_utc="2026-05-18T17:33:44.033" last_modified="2026-05-18T18:35:01" version="1779125701317">
+      <Q id="6427447247" qualifier_id="1"/>
+      <Q id="6427447231" qualifier_id="5"/>
+      <Q id="6427447237" qualifier_id="56" value="Left"/>
+      <Q id="6427447239" qualifier_id="140" value="71.7"/>
+      <Q id="6427447241" qualifier_id="141" value="100.0"/>
+      <Q id="6427447235" qualifier_id="152"/>
+      <Q id="6427447233" qualifier_id="157"/>
+      <Q id="6427447365" qualifier_id="189"/>
+      <Q id="6427447243" qualifier_id="212" value="66.5"/>
+      <Q id="6427447245" qualifier_id="213" value="1.10"/>
+    </Event>
+    <Event id="2939624871" event_id="218" type_id="5" period_id="1" min="16" sec="22" player_id="232091" team_id="244" outcome="0" x="73.6" y="101.0" timestamp="2026-05-18T18:33:45.034" timestamp_utc="2026-05-18T17:33:45.034" last_modified="2026-05-18T18:34:06" version="1779125642516">
+      <Q id="6427447285" qualifier_id="56" value="Left"/>
+      <Q id="6427448457" qualifier_id="233" value="118"/>
+      <Q id="6427447287" qualifier_id="347"/>
+    </Event>
+    <Event id="2939625077" event_id="118" type_id="5" period_id="1" min="16" sec="22" player_id="624620" team_id="417" outcome="1" x="26.4" y="-1.0" timestamp="2026-05-18T18:33:45.034" timestamp_utc="2026-05-18T17:33:45.034" last_modified="2026-05-18T19:36:52" version="1779129407918">
+      <Q id="6427448401" qualifier_id="56" value="Back"/>
+      <Q id="6427448425" qualifier_id="233" value="218"/>
+      <Q id="6427448405" qualifier_id="347"/>
+    </Event>
+    <Event id="2939625289" event_id="145" type_id="1" period_id="1" min="16" sec="47" player_id="157851" team_id="417" outcome="0" x="20.0" y="0.0" timestamp="2026-05-18T18:34:10.002" timestamp_utc="2026-05-18T17:34:10.002" last_modified="2026-05-18T18:34:15" version="1779125655475">
+      <Q id="6427449377" qualifier_id="1"/>
+      <Q id="6427449367" qualifier_id="56" value="Right"/>
+      <Q id="6427449457" qualifier_id="107"/>
+      <Q id="6427449369" qualifier_id="140" value="63.3"/>
+      <Q id="6427449371" qualifier_id="141" value="17.6"/>
+      <Q id="6427449373" qualifier_id="212" value="47.4"/>
+      <Q id="6427449375" qualifier_id="213" value="0.29"/>
+    </Event>
+    <Event id="2939625267" event_id="219" type_id="49" period_id="1" min="16" sec="51" player_id="180662" team_id="244" outcome="1" x="36.5" y="81.7" timestamp="2026-05-18T18:34:13.665" timestamp_utc="2026-05-18T17:34:13.665" last_modified="2026-05-18T18:34:13" version="1779125653666"/>
+    <Event id="2939625297" event_id="220" type_id="1" period_id="1" min="16" sec="51" player_id="180662" team_id="244" outcome="1" x="33.6" y="78.2" timestamp="2026-05-18T18:34:14.014" timestamp_utc="2026-05-18T17:34:14.014" last_modified="2026-05-18T18:34:15" version="1779125654352">
+      <Q id="6427449415" qualifier_id="56" value="Back"/>
+      <Q id="6427449417" qualifier_id="140" value="32.2"/>
+      <Q id="6427449419" qualifier_id="141" value="52.1"/>
+      <Q id="6427449421" qualifier_id="212" value="17.8"/>
+      <Q id="6427449423" qualifier_id="213" value="4.63"/>
+    </Event>
+    <Event id="2939625371" event_id="221" type_id="1" period_id="1" min="16" sec="52" player_id="627127" team_id="244" outcome="1" x="30.4" y="47.6" timestamp="2026-05-18T18:34:15.216" timestamp_utc="2026-05-18T17:34:15.216" last_modified="2026-05-18T18:34:20" version="1779125655516">
+      <Q id="6427449821" qualifier_id="56" value="Back"/>
+      <Q id="6427449823" qualifier_id="140" value="28.7"/>
+      <Q id="6427449825" qualifier_id="141" value="70.9"/>
+      <Q id="6427449827" qualifier_id="212" value="15.9"/>
+      <Q id="6427449829" qualifier_id="213" value="1.68"/>
+    </Event>
+    <Event id="2939625393" event_id="222" type_id="1" period_id="1" min="16" sec="56" player_id="180662" team_id="244" outcome="1" x="43.1" y="75.1" timestamp="2026-05-18T18:34:19.168" timestamp_utc="2026-05-18T17:34:19.168" last_modified="2026-05-18T18:34:22" version="1779125659657">
+      <Q id="6427449959" qualifier_id="56" value="Back"/>
+      <Q id="6427449961" qualifier_id="140" value="40.9"/>
+      <Q id="6427449963" qualifier_id="141" value="87.1"/>
+      <Q id="6427449965" qualifier_id="212" value="8.5"/>
+      <Q id="6427449967" qualifier_id="213" value="1.85"/>
+    </Event>
+    <Event id="2939625421" event_id="223" type_id="1" period_id="1" min="16" sec="59" player_id="575855" team_id="244" outcome="1" x="44.9" y="92.9" timestamp="2026-05-18T18:34:22.040" timestamp_utc="2026-05-18T17:34:22.040" last_modified="2026-05-18T18:34:24" version="1779125662752">
+      <Q id="6427450143" qualifier_id="56" value="Back"/>
+      <Q id="6427450145" qualifier_id="140" value="37.2"/>
+      <Q id="6427450147" qualifier_id="141" value="75.7"/>
+      <Q id="6427450149" qualifier_id="212" value="14.2"/>
+      <Q id="6427450151" qualifier_id="213" value="4.11"/>
+    </Event>
+    <Event id="2939625477" event_id="224" type_id="1" period_id="1" min="17" sec="1" player_id="180662" team_id="244" outcome="1" x="33.9" y="71.1" timestamp="2026-05-18T18:34:24.336" timestamp_utc="2026-05-18T17:34:24.336" last_modified="2026-05-18T18:34:27" version="1779125664762">
+      <Q id="6427450443" qualifier_id="56" value="Back"/>
+      <Q id="6427450445" qualifier_id="140" value="29.1"/>
+      <Q id="6427450447" qualifier_id="141" value="42.2"/>
+      <Q id="6427450449" qualifier_id="212" value="20.3"/>
+      <Q id="6427450451" qualifier_id="213" value="4.46"/>
+    </Event>
+    <Event id="2939625523" event_id="225" type_id="1" period_id="1" min="17" sec="5" player_id="627127" team_id="244" outcome="0" x="27.7" y="31.3" timestamp="2026-05-18T18:34:27.762" timestamp_utc="2026-05-18T17:34:27.762" last_modified="2026-05-18T18:34:30" version="1779125669945">
+      <Q id="6427450705" qualifier_id="1"/>
+      <Q id="6427450695" qualifier_id="56" value="Right"/>
+      <Q id="6427450697" qualifier_id="140" value="64.8"/>
+      <Q id="6427450699" qualifier_id="141" value="12.9"/>
+      <Q id="6427450701" qualifier_id="212" value="40.9"/>
+      <Q id="6427450703" qualifier_id="213" value="5.97"/>
+    </Event>
+    <Event id="2939625509" event_id="146" type_id="8" period_id="1" min="17" sec="6" player_id="624620" team_id="417" outcome="1" x="35.2" y="87.1" timestamp="2026-05-18T18:34:29.362" timestamp_utc="2026-05-18T17:34:29.362" last_modified="2026-05-18T19:37:41" version="1779129461557">
+      <Q id="6427450655" qualifier_id="56" value="Back"/>
+    </Event>
+    <Event id="2939625525" event_id="147" type_id="49" period_id="1" min="17" sec="7" player_id="624620" team_id="417" outcome="1" x="50.3" y="91.8" timestamp="2026-05-18T18:34:30.012" timestamp_utc="2026-05-18T17:34:30.012" last_modified="2026-05-18T18:34:30" version="1779125670013"/>
+    <Event id="2939625601" event_id="148" type_id="4" period_id="1" min="17" sec="11" player_id="624620" team_id="417" outcome="1" x="66.8" y="84.2" timestamp="2026-05-18T18:34:34.263" timestamp_utc="2026-05-18T17:34:34.263" last_modified="2026-05-18T18:34:41" version="1779125675506">
+      <Q id="6427451123" qualifier_id="13"/>
+      <Q id="6427451125" qualifier_id="56" value="Left"/>
+      <Q id="6427451127" qualifier_id="152"/>
+      <Q id="6427451161" qualifier_id="233" value="226"/>
+      <Q id="6427451129" qualifier_id="265"/>
+      <Q id="6427451131" qualifier_id="286"/>
+    </Event>
+    <Event id="2939625593" event_id="226" type_id="4" period_id="1" min="17" sec="11" player_id="207884" team_id="244" outcome="0" x="33.2" y="15.8" timestamp="2026-05-18T18:34:34.264" timestamp_utc="2026-05-18T17:34:34.264" last_modified="2026-05-19T14:17:43" version="1779196663738">
+      <Q id="6427451139" qualifier_id="13"/>
+      <Q id="6427452097" qualifier_id="55" value="227"/>
+      <Q id="6427451141" qualifier_id="56" value="Back"/>
+      <Q id="6427451143" qualifier_id="152"/>
+      <Q id="6427451181" qualifier_id="233" value="148"/>
+      <Q id="6427451145" qualifier_id="265"/>
+      <Q id="6427451147" qualifier_id="285"/>
+    </Event>
+    <Event id="2939625661" event_id="227" type_id="17" period_id="1" min="17" sec="15" player_id="207884" team_id="244" outcome="1" x="0.0" y="0.0" timestamp="2026-05-18T18:34:38.136" timestamp_utc="2026-05-18T17:34:38.136" last_modified="2026-05-18T18:34:45" version="1779125685172">
+      <Q id="6427452073" qualifier_id="13" value="243"/>
+      <Q id="6427452067" qualifier_id="31"/>
+      <Q id="6427452075" qualifier_id="55" value="226"/>
+      <Q id="6427452069" qualifier_id="393"/>
+    </Event>
+    <Event id="2939614777" event_id="91" type_id="43" period_id="1" min="17" sec="50" team_id="417" outcome="1" x="0.0" y="0.0" timestamp="2026-05-18T18:23:40.056" timestamp_utc="2026-05-18T17:23:40.056" last_modified="2026-05-18T18:26:44" version="1779125005153">
+      <Q id="6427390807" qualifier_id="55" value="90"/>
+      <Q id="6427421279" qualifier_id="144" value="28"/>
+      <Q id="6427390901" qualifier_id="233" value="133"/>
+    </Event>
+    <Event id="2939614791" event_id="133" type_id="43" period_id="1" min="17" sec="50" team_id="244" outcome="1" x="0.0" y="0.0" timestamp="2026-05-18T18:23:40.056" timestamp_utc="2026-05-18T17:23:40.056" last_modified="2026-05-18T18:26:46" version="1779125203934">
+      <Q id="6427390873" qualifier_id="55" value="132"/>
+      <Q id="6427421447" qualifier_id="144" value="28"/>
+    </Event>
+    <Event id="2939626451" event_id="149" type_id="1" period_id="1" min="18" sec="14" player_id="685390" team_id="417" outcome="0" x="75.5" y="92.6" timestamp="2026-05-18T18:35:37.321" timestamp_utc="2026-05-18T17:35:37.321" last_modified="2026-05-18T18:35:39" version="1779125739337">
+      <Q id="6427455871" qualifier_id="2"/>
+      <Q id="6427455875" qualifier_id="5"/>
+      <Q id="6427455885" qualifier_id="56" value="Center"/>
+      <Q id="6427455887" qualifier_id="140" value="91.3"/>
+      <Q id="6427455889" qualifier_id="141" value="55.2"/>
+      <Q id="6427455883" qualifier_id="152"/>
+      <Q id="6427455879" qualifier_id="155"/>
+      <Q id="6427455891" qualifier_id="212" value="30.4"/>
+      <Q id="6427455893" qualifier_id="213" value="5.29"/>
+    </Event>
+    <Event id="2939626491" event_id="228" type_id="12" period_id="1" min="18" sec="18" player_id="479433" team_id="244" outcome="1" x="12.0" y="49.3" timestamp="2026-05-18T18:35:41.423" timestamp_utc="2026-05-18T17:35:41.423" last_modified="2026-05-18T18:36:01" version="1779125760900">
+      <Q id="6427456137" qualifier_id="15"/>
+      <Q id="6427456127" qualifier_id="56" value="Back"/>
+      <Q id="6427456129" qualifier_id="140" value="24.8"/>
+      <Q id="6427456131" qualifier_id="141" value="76.1"/>
+      <Q id="6427456133" qualifier_id="212" value="22.6"/>
+      <Q id="6427456135" qualifier_id="213" value="0.94"/>
+    </Event>
+    <Event id="2939630193" event_id="248" type_id="61" period_id="1" min="18" sec="19" player_id="627127" team_id="244" outcome="1" x="5.3" y="52.7" timestamp="2026-05-18T18:35:42.411" timestamp_utc="2026-05-18T17:35:42.411" last_modified="2026-05-18T18:48:03" version="1779126483430">
+      <Q id="6427477209" qualifier_id="56" value="Back"/>
+    </Event>
+    <Event id="2939626537" event_id="229" type_id="12" period_id="1" min="18" sec="22" player_id="648131" team_id="244" outcome="1" x="11.8" y="72.1" timestamp="2026-05-18T18:35:44.872" timestamp_utc="2026-05-18T17:35:44.872" last_modified="2026-05-18T18:40:42" version="1779126042642">
+      <Q id="6427456381" qualifier_id="56" value="Back"/>
+      <Q id="6427456383" qualifier_id="140" value="33.9"/>
+      <Q id="6427456385" qualifier_id="141" value="100.0"/>
+      <Q id="6427456437" qualifier_id="167"/>
+      <Q id="6427456387" qualifier_id="212" value="30.3"/>
+      <Q id="6427456389" qualifier_id="213" value="0.70"/>
+    </Event>
+    <Event id="2939626543" event_id="230" type_id="5" period_id="1" min="18" sec="23" player_id="648131" team_id="244" outcome="0" x="33.7" y="101.1" timestamp="2026-05-18T18:35:45.698" timestamp_utc="2026-05-18T17:35:45.698" last_modified="2026-05-18T19:36:53" version="1779129407929">
+      <Q id="6427456423" qualifier_id="56" value="Back"/>
+      <Q id="6427457659" qualifier_id="233" value="150"/>
+      <Q id="6427456425" qualifier_id="347"/>
+    </Event>
+    <Event id="2939626787" event_id="150" type_id="5" period_id="1" min="18" sec="23" player_id="685390" team_id="417" outcome="1" x="66.3" y="-1.1" timestamp="2026-05-18T18:35:45.698" timestamp_utc="2026-05-18T17:35:45.698" last_modified="2026-05-18T19:36:53" version="1779129407924">
+      <Q id="6427457611" qualifier_id="56" value="Right"/>
+      <Q id="6427457651" qualifier_id="233" value="230"/>
+      <Q id="6427457613" qualifier_id="347"/>
+    </Event>
+    <Event id="2939626809" event_id="151" type_id="1" period_id="1" min="18" sec="42" player_id="531784" team_id="417" outcome="1" x="66.7" y="0.0" timestamp="2026-05-18T18:36:05.569" timestamp_utc="2026-05-18T17:36:05.569" last_modified="2026-05-18T18:36:07" version="1779125766683">
+      <Q id="6427457801" qualifier_id="56" value="Right"/>
+      <Q id="6427457799" qualifier_id="107"/>
+      <Q id="6427457803" qualifier_id="140" value="78.7"/>
+      <Q id="6427457805" qualifier_id="141" value="10.3"/>
+      <Q id="6427457807" qualifier_id="212" value="15.0"/>
+      <Q id="6427457809" qualifier_id="213" value="0.57"/>
+    </Event>
+    <Event id="2939626813" event_id="152" type_id="1" period_id="1" min="18" sec="44" player_id="157851" team_id="417" outcome="0" x="78.7" y="10.3" timestamp="2026-05-18T18:36:07.601" timestamp_utc="2026-05-18T17:36:07.601" last_modified="2026-05-18T18:36:08" version="1779125768169">
+      <Q id="6427457817" qualifier_id="56" value="Center"/>
+      <Q id="6427457819" qualifier_id="140" value="66.8"/>
+      <Q id="6427457821" qualifier_id="141" value="25.2"/>
+      <Q id="6427457833" qualifier_id="156"/>
+      <Q id="6427457823" qualifier_id="212" value="16.1"/>
+      <Q id="6427457825" qualifier_id="213" value="2.46"/>
+    </Event>
+    <Event id="2939626839" event_id="231" type_id="1" period_id="1" min="18" sec="45" player_id="515742" team_id="244" outcome="1" x="33.9" y="66.9" timestamp="2026-05-18T18:36:08.543" timestamp_utc="2026-05-18T17:36:08.543" last_modified="2026-05-18T18:36:10" version="1779125768746">
+      <Q id="6427457933" qualifier_id="56" value="Back"/>
+      <Q id="6427457935" qualifier_id="140" value="38.5"/>
+      <Q id="6427457937" qualifier_id="141" value="62.1"/>
+      <Q id="6427457939" qualifier_id="212" value="5.8"/>
+      <Q id="6427457941" qualifier_id="213" value="5.69"/>
+    </Event>
+    <Event id="2939626841" event_id="232" type_id="49" period_id="1" min="18" sec="47" player_id="625775" team_id="244" outcome="1" x="39.1" y="61.8" timestamp="2026-05-18T18:36:10.215" timestamp_utc="2026-05-18T17:36:10.215" last_modified="2026-05-18T18:36:10" version="1779125770216"/>
+    <Event id="2939626949" event_id="233" type_id="1" period_id="1" min="18" sec="47" player_id="625775" team_id="244" outcome="1" x="39.1" y="61.8" timestamp="2026-05-18T18:36:10.543" timestamp_utc="2026-05-18T17:36:10.543" last_modified="2026-05-18T18:36:18" version="1779125771995">
+      <Q id="6427458593" qualifier_id="56" value="Left"/>
+      <Q id="6427458595" qualifier_id="140" value="60.0"/>
+      <Q id="6427458597" qualifier_id="141" value="80.2"/>
+      <Q id="6427458599" qualifier_id="212" value="25.3"/>
+      <Q id="6427458601" qualifier_id="213" value="0.52"/>
+    </Event>
+    <Event id="2939626995" event_id="234" type_id="1" period_id="1" min="18" sec="55" player_id="207884" team_id="244" outcome="1" x="81.7" y="84.8" keypass="1" timestamp="2026-05-18T18:36:18.351" timestamp_utc="2026-05-18T17:36:18.351" last_modified="2026-05-18T19:37:40" version="1779129459987">
+      <Q id="6427458837" qualifier_id="2"/>
+      <Q id="6427458841" qualifier_id="56" value="Center"/>
+      <Q id="6427458843" qualifier_id="140" value="93.0"/>
+      <Q id="6427458845" qualifier_id="141" value="43.2"/>
+      <Q id="6427459645" qualifier_id="154"/>
+      <Q id="6427458839" qualifier_id="155"/>
+      <Q id="6427459643" qualifier_id="210" value="13"/>
+      <Q id="6427458847" qualifier_id="212" value="30.7"/>
+      <Q id="6427458849" qualifier_id="213" value="5.11"/>
+    </Event>
+    <Event id="2939626999" event_id="235" type_id="13" period_id="1" min="18" sec="56" player_id="479433" team_id="244" outcome="1" x="93.0" y="43.2" timestamp="2026-05-18T18:36:19.551" timestamp_utc="2026-05-18T17:36:19.551" last_modified="2026-05-18T18:39:42" version="1779125981867">
+      <Q id="6427459659" qualifier_id="15"/>
+      <Q id="6427458855" qualifier_id="17"/>
+      <Q id="6427474081" qualifier_id="23"/>
+      <Q id="6427459663" qualifier_id="29"/>
+      <Q id="6427459667" qualifier_id="55" value="234"/>
+      <Q id="6427458857" qualifier_id="56" value="Center"/>
+      <Q id="6427459661" qualifier_id="74"/>
+      <Q id="6427459671" qualifier_id="102" value="53.3"/>
+      <Q id="6427459673" qualifier_id="103" value="65.3"/>
+      <Q id="6427459665" qualifier_id="154"/>
+      <Q id="6427459677" qualifier_id="230" value="99.3"/>
+      <Q id="6427459679" qualifier_id="231" value="47.5"/>
+      <Q id="6427459675" qualifier_id="328"/>
+    </Event>
+    <Event id="2939627043" event_id="236" type_id="5" period_id="1" min="18" sec="58" player_id="479433" team_id="244" outcome="0" x="100.7" y="56.4" timestamp="2026-05-18T18:36:21.105" timestamp_utc="2026-05-18T17:36:21.105" last_modified="2026-05-18T19:36:53" version="1779129407940">
+      <Q id="6427459207" qualifier_id="56" value="Center"/>
+      <Q id="6427461241" qualifier_id="233" value="153"/>
+      <Q id="6427459209" qualifier_id="346"/>
+    </Event>
+    <Event id="2939627397" event_id="153" type_id="5" period_id="1" min="18" sec="58" player_id="720682" team_id="417" outcome="1" x="-0.7" y="43.6" timestamp="2026-05-18T18:36:21.105" timestamp_utc="2026-05-18T17:36:21.105" last_modified="2026-05-18T19:36:53" version="1779129407934">
+      <Q id="6427461145" qualifier_id="56" value="Back"/>
+      <Q id="6427461197" qualifier_id="233" value="236"/>
+      <Q id="6427461147" qualifier_id="346"/>
+    </Event>
+    <Event id="2939627489" event_id="154" type_id="1" period_id="1" min="19" sec="30" player_id="565487" team_id="417" outcome="1" x="2.8" y="47.3" timestamp="2026-05-18T18:36:52.920" timestamp_utc="2026-05-18T17:36:52.920" last_modified="2026-05-18T18:36:58" version="1779125817259">
+      <Q id="6427461641" qualifier_id="1"/>
+      <Q id="6427461631" qualifier_id="56" value="Right"/>
+      <Q id="6427461645" qualifier_id="74"/>
+      <Q id="6427461629" qualifier_id="124"/>
+      <Q id="6427461633" qualifier_id="140" value="58.8"/>
+      <Q id="6427461635" qualifier_id="141" value="10.0"/>
+      <Q id="6427461637" qualifier_id="212" value="64.0"/>
+      <Q id="6427461639" qualifier_id="213" value="5.88"/>
+    </Event>
+    <Event id="2939627493" event_id="155" type_id="44" period_id="1" min="19" sec="35" player_id="157851" team_id="417" outcome="1" x="58.8" y="10.0" timestamp="2026-05-18T18:36:58.520" timestamp_utc="2026-05-18T17:36:58.520" last_modified="2026-05-18T19:37:36" version="1779129456314">
+      <Q id="6427461665" qualifier_id="56" value="Right"/>
+      <Q id="6427461741" qualifier_id="233" value="237"/>
+      <Q id="6427461667" qualifier_id="286"/>
+    </Event>
+    <Event id="2939627501" event_id="237" type_id="44" period_id="1" min="19" sec="35" player_id="648131" team_id="244" outcome="0" x="41.2" y="90.0" timestamp="2026-05-18T18:36:58.521" timestamp_utc="2026-05-18T17:36:58.521" last_modified="2026-05-18T19:37:36" version="1779129456574">
+      <Q id="6427461709" qualifier_id="56" value="Back"/>
+      <Q id="6427461757" qualifier_id="233" value="155"/>
+      <Q id="6427461711" qualifier_id="285"/>
+    </Event>
+    <Event id="2939627543" event_id="156" type_id="1" period_id="1" min="19" sec="36" player_id="157851" team_id="417" outcome="1" x="58.8" y="10.0" timestamp="2026-05-18T18:36:58.848" timestamp_utc="2026-05-18T17:36:58.848" last_modified="2026-05-18T19:37:36" version="1779129456834">
+      <Q id="6427461953" qualifier_id="3"/>
+      <Q id="6427461955" qualifier_id="56" value="Right"/>
+      <Q id="6427461957" qualifier_id="140" value="61.9"/>
+      <Q id="6427461959" qualifier_id="141" value="14.7"/>
+      <Q id="6427461961" qualifier_id="212" value="4.6"/>
+      <Q id="6427461963" qualifier_id="213" value="0.78"/>
+    </Event>
+    <Event id="2939627549" event_id="157" type_id="1" period_id="1" min="19" sec="37" player_id="685390" team_id="417" outcome="0" x="63.4" y="17.7" timestamp="2026-05-18T18:37:00.216" timestamp_utc="2026-05-18T17:37:00.216" last_modified="2026-05-18T18:37:02" version="1779125820848">
+      <Q id="6427462027" qualifier_id="1"/>
+      <Q id="6427462009" qualifier_id="56" value="Center"/>
+      <Q id="6427462013" qualifier_id="140" value="90.7"/>
+      <Q id="6427462017" qualifier_id="141" value="43.0"/>
+      <Q id="6427462005" qualifier_id="155"/>
+      <Q id="6427462021" qualifier_id="212" value="33.4"/>
+      <Q id="6427462025" qualifier_id="213" value="0.54"/>
+    </Event>
+    <Event id="2939627583" event_id="238" type_id="1" period_id="1" min="19" sec="39" player_id="627127" team_id="244" outcome="1" x="20.6" y="72.0" timestamp="2026-05-18T18:37:01.751" timestamp_utc="2026-05-18T17:37:01.751" last_modified="2026-05-18T18:37:04" version="1779125822007">
+      <Q id="6427462167" qualifier_id="3"/>
+      <Q id="6427462169" qualifier_id="56" value="Back"/>
+      <Q id="6427462171" qualifier_id="140" value="9.1"/>
+      <Q id="6427462173" qualifier_id="141" value="55.5"/>
+      <Q id="6427462175" qualifier_id="212" value="16.5"/>
+      <Q id="6427462177" qualifier_id="213" value="3.89"/>
+    </Event>
+    <Event id="2939627587" event_id="239" type_id="52" period_id="1" min="19" sec="41" player_id="578592" team_id="244" outcome="1" x="9.8" y="56.1" timestamp="2026-05-18T18:37:04.030" timestamp_utc="2026-05-18T17:37:04.030" last_modified="2026-05-18T18:37:04" version="1779125824031"/>
+    <Event id="2939627631" event_id="240" type_id="80" period_id="1" min="19" sec="44" player_id="578592" team_id="244" outcome="0" x="10.8" y="46.1" timestamp="2026-05-18T18:37:07.278" timestamp_utc="2026-05-18T17:37:07.278" last_modified="2026-05-18T18:37:07" version="1779125827280"/>
+    <Event id="2939627687" event_id="241" type_id="1" period_id="1" min="19" sec="46" player_id="578592" team_id="244" outcome="1" x="13.6" y="50.1" timestamp="2026-05-18T18:37:08.655" timestamp_utc="2026-05-18T17:37:08.655" last_modified="2026-05-18T18:37:11" version="1779125829696">
+      <Q id="6427462729" qualifier_id="56" value="Back"/>
+      <Q id="6427462731" qualifier_id="140" value="12.3"/>
+      <Q id="6427462733" qualifier_id="141" value="85.4"/>
+      <Q id="6427462735" qualifier_id="212" value="24.0"/>
+      <Q id="6427462739" qualifier_id="213" value="1.63"/>
+    </Event>
+    <Event id="2939627695" event_id="242" type_id="61" period_id="1" min="19" sec="49" player_id="627127" team_id="244" outcome="0" x="12.9" y="86.5" timestamp="2026-05-18T18:37:11.767" timestamp_utc="2026-05-18T17:37:11.767" last_modified="2026-05-18T18:37:12" version="1779125831768">
+      <Q id="6427462771" qualifier_id="56" value="Back"/>
+    </Event>
+    <Event id="2939627709" event_id="158" type_id="50" period_id="1" min="19" sec="50" player_id="685390" team_id="417" outcome="1" x="79.4" y="14.4" timestamp="2026-05-18T18:37:13.365" timestamp_utc="2026-05-18T17:37:13.365" last_modified="2026-05-18T19:22:27" version="1779128546342">
+      <Q id="6427462835" qualifier_id="56" value="Right"/>
+      <Q id="6427463023" qualifier_id="233" value="243"/>
+      <Q id="6427462837" qualifier_id="286"/>
+    </Event>
+    <Event id="2939627737" event_id="243" type_id="7" period_id="1" min="19" sec="50" player_id="627127" team_id="244" outcome="1" x="20.6" y="85.6" timestamp="2026-05-18T18:37:13.366" timestamp_utc="2026-05-18T17:37:13.366" last_modified="2026-05-18T19:22:27" version="1779128546337">
+      <Q id="6427462959" qualifier_id="56" value="Back"/>
+      <Q id="6427462963" qualifier_id="178"/>
+      <Q id="6427462999" qualifier_id="233" value="158"/>
+      <Q id="6427462961" qualifier_id="285"/>
+    </Event>
+    <Event id="2939627807" event_id="244" type_id="1" period_id="1" min="19" sec="52" player_id="627127" team_id="244" outcome="1" x="16.9" y="86.0" timestamp="2026-05-18T18:37:14.974" timestamp_utc="2026-05-18T17:37:14.974" last_modified="2026-05-18T18:37:20" version="1779125835287">
+      <Q id="6427463343" qualifier_id="56" value="Back"/>
+      <Q id="6427463345" qualifier_id="140" value="22.1"/>
+      <Q id="6427463347" qualifier_id="141" value="94.1"/>
+      <Q id="6427463349" qualifier_id="212" value="7.8"/>
+      <Q id="6427463351" qualifier_id="213" value="0.79"/>
+    </Event>
+    <Event id="2939627907" event_id="245" type_id="1" period_id="1" min="19" sec="57" player_id="575855" team_id="244" outcome="1" x="43.2" y="66.6" timestamp="2026-05-18T18:37:20.406" timestamp_utc="2026-05-18T17:37:20.406" last_modified="2026-05-18T18:37:25" version="1779125841496">
+      <Q id="6427463937" qualifier_id="1"/>
+      <Q id="6427463927" qualifier_id="56" value="Center"/>
+      <Q id="6427463929" qualifier_id="140" value="74.1"/>
+      <Q id="6427463931" qualifier_id="141" value="23.6"/>
+      <Q id="6427463933" qualifier_id="212" value="43.7"/>
+      <Q id="6427463935" qualifier_id="213" value="5.55"/>
+    </Event>
+    <Event id="2939628319" event_id="246" type_id="1" period_id="1" min="20" sec="2" player_id="625775" team_id="244" outcome="1" x="86.4" y="36.7" assist="1" timestamp="2026-05-18T18:37:25.350" timestamp_utc="2026-05-18T17:37:25.350" last_modified="2026-05-18T18:38:24" version="1779125904038">
+      <Q id="6427468101" qualifier_id="22"/>
+      <Q id="6427466377" qualifier_id="56" value="Center"/>
+      <Q id="6427466379" qualifier_id="140" value="88.6"/>
+      <Q id="6427466381" qualifier_id="141" value="49.9"/>
+      <Q id="6427468099" qualifier_id="154"/>
+      <Q id="6427468097" qualifier_id="210" value="16"/>
+      <Q id="6427466383" qualifier_id="212" value="9.3"/>
+      <Q id="6427466385" qualifier_id="213" value="1.32"/>
+    </Event>
+    <Event id="2939628327" event_id="247" type_id="16" period_id="1" min="20" sec="11" player_id="232091" team_id="244" outcome="1" x="87.8" y="54.8" timestamp="2026-05-18T18:37:33.982" timestamp_utc="2026-05-18T17:37:33.982" last_modified="2026-05-18T18:38:24" version="1779125904045">
+      <Q id="6427466401" qualifier_id="17"/>
+      <Q id="6427468135" qualifier_id="20"/>
+      <Q id="6427466399" qualifier_id="22"/>
+      <Q id="6427468141" qualifier_id="29"/>
+      <Q id="6427468147" qualifier_id="55" value="246"/>
+      <Q id="6427466403" qualifier_id="56" value="Center"/>
+      <Q id="6427468137" qualifier_id="76"/>
+      <Q id="6427468155" qualifier_id="102" value="52.3"/>
+      <Q id="6427468157" qualifier_id="103" value="5.7"/>
+      <Q id="6427468143" qualifier_id="154"/>
+      <Q id="6427468165" qualifier_id="230" value="99.8"/>
+      <Q id="6427468167" qualifier_id="231" value="45.8"/>
+      <Q id="6427468171" qualifier_id="374" value="2026-05-18 18:37:33.188"/>
+      <Q id="6427468175" qualifier_id="375" value="20:10.541"/>
+    </Event>
+    <Event id="2939620767" event_id="95" type_id="43" period_id="1" min="21" sec="37" team_id="417" outcome="1" x="0.0" y="0.0" timestamp="2026-05-18T18:27:27.745" timestamp_utc="2026-05-18T17:27:27.745" last_modified="2026-05-18T18:29:03" version="1779125278412">
+      <Q id="6427424075" qualifier_id="55" value="90"/>
+      <Q id="6427429935" qualifier_id="144" value="28"/>
+    </Event>
+    <Event id="2939620785" event_id="136" type_id="43" period_id="1" min="21" sec="37" team_id="244" outcome="1" x="0.0" y="0.0" timestamp="2026-05-18T18:27:27.745" timestamp_utc="2026-05-18T17:27:27.745" last_modified="2026-05-18T18:27:58" version="1779125250019">
+      <Q id="6427424239" qualifier_id="55" value="132"/>
+      <Q id="6427425727" qualifier_id="144" value="28"/>
+      <Q id="6427424289" qualifier_id="233" value="95"/>
+    </Event>
+    <Event id="2939620863" event_id="96" type_id="43" period_id="1" min="21" sec="45" player_id="624620" team_id="417" outcome="1" x="0.0" y="0.0" timestamp="2026-05-18T18:27:35.480" timestamp_utc="2026-05-18T17:27:35.480" last_modified="2026-05-18T18:27:59" version="1779125258395">
+      <Q id="6427424759" qualifier_id="1" value="0"/>
+      <Q id="6427424749" qualifier_id="56" value="Left"/>
+      <Q id="6427424747" qualifier_id="107" value="0"/>
+      <Q id="6427424751" qualifier_id="140" value="72.9"/>
+      <Q id="6427424753" qualifier_id="141" value="83.5"/>
+      <Q id="6427425791" qualifier_id="144" value="1"/>
+      <Q id="6427424755" qualifier_id="212" value="38.0"/>
+      <Q id="6427424757" qualifier_id="213" value="5.95"/>
+    </Event>
+    <Event id="2939620875" event_id="137" type_id="43" period_id="1" min="21" sec="49" player_id="627127" team_id="244" outcome="1" x="0.0" y="0.0" timestamp="2026-05-18T18:27:38.949" timestamp_utc="2026-05-18T17:27:38.949" last_modified="2026-05-18T18:29:11" version="1779125259096">
+      <Q id="6427424817" qualifier_id="56" value="Back"/>
+      <Q id="6427424819" qualifier_id="140" value="29.5"/>
+      <Q id="6427424821" qualifier_id="141" value="29.1"/>
+      <Q id="6427430409" qualifier_id="144" value="1"/>
+      <Q id="6427424823" qualifier_id="212" value="4.5"/>
+      <Q id="6427424825" qualifier_id="213" value="0.47"/>
+    </Event>
+    <Event id="2939620901" event_id="138" type_id="43" period_id="1" min="21" sec="50" player_id="232091" team_id="244" outcome="1" x="0.0" y="0.0" timestamp="2026-05-18T18:27:40.118" timestamp_utc="2026-05-18T17:27:40.118" last_modified="2026-05-18T18:29:10" version="1779125264039">
+      <Q id="6427424997" qualifier_id="1" value="0"/>
+      <Q id="6427424987" qualifier_id="56" value="Right"/>
+      <Q id="6427424989" qualifier_id="140" value="67.3"/>
+      <Q id="6427424991" qualifier_id="141" value="0.0"/>
+      <Q id="6427430355" qualifier_id="144" value="1"/>
+      <Q id="6427424985" qualifier_id="157" value="0"/>
+      <Q id="6427424993" qualifier_id="212" value="40.6"/>
+      <Q id="6427424995" qualifier_id="213" value="5.84"/>
+    </Event>
+    <Event id="2939620903" event_id="139" type_id="43" period_id="1" min="21" sec="54" player_id="232091" team_id="244" outcome="1" x="0.0" y="0.0" timestamp="2026-05-18T18:27:44.055" timestamp_utc="2026-05-18T17:27:44.055" last_modified="2026-05-18T18:29:10" version="1779125277841">
+      <Q id="6427424999" qualifier_id="56" value="Right"/>
+      <Q id="6427430383" qualifier_id="144" value="5"/>
+      <Q id="6427425001" qualifier_id="347" value="0"/>
+    </Event>
+    <Event id="2939620923" event_id="97" type_id="43" period_id="1" min="21" sec="54" player_id="624620" team_id="417" outcome="1" x="0.0" y="0.0" timestamp="2026-05-18T18:27:44.576" timestamp_utc="2026-05-18T17:27:44.576" last_modified="2026-05-18T18:27:57" version="1779125266171">
+      <Q id="6427425123" qualifier_id="56" value="Back"/>
+      <Q id="6427425661" qualifier_id="144" value="5"/>
+      <Q id="6427425151" qualifier_id="233" value="139"/>
+      <Q id="6427425125" qualifier_id="347" value="0"/>
+    </Event>
+    <Event id="2939621063" event_id="140" type_id="43" period_id="1" min="22" sec="13" player_id="515742" team_id="244" outcome="1" x="0.0" y="0.0" timestamp="2026-05-18T18:28:03.309" timestamp_utc="2026-05-18T17:28:03.309" last_modified="2026-05-18T18:29:08" version="1779125283312">
+      <Q id="6427425971" qualifier_id="56" value="Back"/>
+      <Q id="6427430221" qualifier_id="144" value="8"/>
+    </Event>
+    <Event id="2939621069" event_id="141" type_id="43" period_id="1" min="22" sec="14" player_id="515742" team_id="244" outcome="1" x="0.0" y="0.0" timestamp="2026-05-18T18:28:03.933" timestamp_utc="2026-05-18T17:28:03.933" last_modified="2026-05-18T18:29:07" version="1779125284149">
+      <Q id="6427425995" qualifier_id="56" value="Back"/>
+      <Q id="6427430189" qualifier_id="144" value="5"/>
+      <Q id="6427425997" qualifier_id="347" value="0"/>
+    </Event>
+    <Event id="2939621247" event_id="142" type_id="43" period_id="1" min="22" sec="28" player_id="648131" team_id="244" outcome="1" x="0.0" y="0.0" timestamp="2026-05-18T18:28:18.423" timestamp_utc="2026-05-18T17:28:18.423" last_modified="2026-05-18T18:29:05" version="1779125298933">
+      <Q id="6427426943" qualifier_id="56" value="Back"/>
+      <Q id="6427430119" qualifier_id="144" value="61"/>
+    </Event>
+    <Event id="2939621265" event_id="143" type_id="43" period_id="1" min="22" sec="30" player_id="180662" team_id="244" outcome="1" x="0.0" y="0.0" timestamp="2026-05-18T18:28:20.412" timestamp_utc="2026-05-18T17:28:20.412" last_modified="2026-05-18T18:29:05" version="1779125300413">
+      <Q id="6427430075" qualifier_id="144" value="49"/>
+    </Event>
+    <Event id="2939621301" event_id="144" type_id="43" period_id="1" min="22" sec="30" player_id="180662" team_id="244" outcome="1" x="0.0" y="0.0" timestamp="2026-05-18T18:28:20.686" timestamp_utc="2026-05-18T17:28:20.686" last_modified="2026-05-18T18:29:09" version="1779125300758">
+      <Q id="6427427229" qualifier_id="56" value="Back"/>
+      <Q id="6427427231" qualifier_id="140" value="40.9"/>
+      <Q id="6427427233" qualifier_id="141" value="61.2"/>
+      <Q id="6427430301" qualifier_id="144" value="1"/>
+      <Q id="6427427235" qualifier_id="212" value="9.9"/>
+      <Q id="6427427237" qualifier_id="213" value="5.52"/>
+    </Event>
+    <Event id="2939621309" event_id="145" type_id="43" period_id="1" min="22" sec="33" player_id="625775" team_id="244" outcome="1" x="0.0" y="0.0" timestamp="2026-05-18T18:28:23.357" timestamp_utc="2026-05-18T17:28:23.357" last_modified="2026-05-18T18:29:04" version="1779125306537">
+      <Q id="6427427443" qualifier_id="13" value="0"/>
+      <Q id="6427427447" qualifier_id="56" value="Back"/>
+      <Q id="6427430011" qualifier_id="144" value="4"/>
+      <Q id="6427427449" qualifier_id="152" value="0"/>
+      <Q id="6427427451" qualifier_id="286" value="0"/>
+      <Q id="6427427445" qualifier_id="295" value="0"/>
+    </Event>
+    <Event id="2939630569" event_id="159" type_id="1" period_id="1" min="23" sec="26" player_id="445539" team_id="417" outcome="1" x="49.9" y="49.7" timestamp="2026-05-18T18:40:48.869" timestamp_utc="2026-05-18T17:40:48.869" last_modified="2026-05-18T18:40:50" version="1779126049337">
+      <Q id="6427479515" qualifier_id="56" value="Back"/>
+      <Q id="6427479517" qualifier_id="140" value="46.1"/>
+      <Q id="6427479519" qualifier_id="141" value="49.9"/>
+      <Q id="6427479521" qualifier_id="212" value="4.0"/>
+      <Q id="6427479523" qualifier_id="213" value="3.11"/>
+      <Q id="6427479527" qualifier_id="278"/>
+      <Q id="6427479525" qualifier_id="279" value="G"/>
+    </Event>
+    <Event id="2939630625" event_id="160" type_id="1" period_id="1" min="23" sec="27" player_id="218339" team_id="417" outcome="1" x="46.0" y="49.9" timestamp="2026-05-18T18:40:50.333" timestamp_utc="2026-05-18T17:40:50.333" last_modified="2026-05-18T18:40:53" version="1779126050576">
+      <Q id="6427479817" qualifier_id="56" value="Back"/>
+      <Q id="6427479819" qualifier_id="140" value="38.3"/>
+      <Q id="6427479821" qualifier_id="141" value="72.6"/>
+      <Q id="6427479823" qualifier_id="212" value="17.4"/>
+      <Q id="6427479825" qualifier_id="213" value="2.05"/>
+    </Event>
+    <Event id="2939630689" event_id="161" type_id="1" period_id="1" min="23" sec="30" player_id="720682" team_id="417" outcome="1" x="36.9" y="71.1" timestamp="2026-05-18T18:40:53.533" timestamp_utc="2026-05-18T17:40:53.533" last_modified="2026-05-18T18:40:56" version="1779126055559">
+      <Q id="6427480223" qualifier_id="56" value="Back"/>
+      <Q id="6427480225" qualifier_id="140" value="27.4"/>
+      <Q id="6427480227" qualifier_id="141" value="31.5"/>
+      <Q id="6427480229" qualifier_id="212" value="28.7"/>
+      <Q id="6427480231" qualifier_id="213" value="4.36"/>
+    </Event>
+    <Event id="2939630719" event_id="162" type_id="1" period_id="1" min="23" sec="34" player_id="531784" team_id="417" outcome="1" x="28.5" y="26.4" timestamp="2026-05-18T18:40:56.829" timestamp_utc="2026-05-18T17:40:56.829" last_modified="2026-05-18T18:40:58" version="1779126058008">
+      <Q id="6427480375" qualifier_id="56" value="Back"/>
+      <Q id="6427480377" qualifier_id="140" value="38.6"/>
+      <Q id="6427480379" qualifier_id="141" value="8.0"/>
+      <Q id="6427480381" qualifier_id="212" value="16.4"/>
+      <Q id="6427480383" qualifier_id="213" value="5.42"/>
+    </Event>
+    <Event id="2939630769" event_id="163" type_id="1" period_id="1" min="23" sec="35" player_id="157851" team_id="417" outcome="1" x="38.6" y="8.0" timestamp="2026-05-18T18:40:58.605" timestamp_utc="2026-05-18T17:40:58.605" last_modified="2026-05-18T18:41:01" version="1779126059624">
+      <Q id="6427480727" qualifier_id="56" value="Back"/>
+      <Q id="6427480729" qualifier_id="140" value="25.4"/>
+      <Q id="6427480731" qualifier_id="141" value="28.3"/>
+      <Q id="6427480733" qualifier_id="212" value="19.6"/>
+      <Q id="6427480735" qualifier_id="213" value="2.36"/>
+    </Event>
+    <Event id="2939630847" event_id="164" type_id="1" period_id="1" min="23" sec="38" player_id="531784" team_id="417" outcome="1" x="23.1" y="24.7" timestamp="2026-05-18T18:41:01.309" timestamp_utc="2026-05-18T17:41:01.309" last_modified="2026-05-18T18:41:04" version="1779126063174">
+      <Q id="6427481165" qualifier_id="56" value="Back"/>
+      <Q id="6427481167" qualifier_id="140" value="2.0"/>
+      <Q id="6427481169" qualifier_id="141" value="45.8"/>
+      <Q id="6427481171" qualifier_id="212" value="26.4"/>
+      <Q id="6427481173" qualifier_id="213" value="2.57"/>
+    </Event>
+    <Event id="2939630877" event_id="165" type_id="1" period_id="1" min="23" sec="41" player_id="565487" team_id="417" outcome="0" x="2.2" y="44.8" timestamp="2026-05-18T18:41:04.437" timestamp_utc="2026-05-18T17:41:04.437" last_modified="2026-05-18T18:41:06" version="1779126066117">
+      <Q id="6427481349" qualifier_id="1"/>
+      <Q id="6427481339" qualifier_id="56" value="Back"/>
+      <Q id="6427481341" qualifier_id="140" value="45.0"/>
+      <Q id="6427481343" qualifier_id="141" value="37.1"/>
+      <Q id="6427481337" qualifier_id="157"/>
+      <Q id="6427481345" qualifier_id="212" value="45.2"/>
+      <Q id="6427481347" qualifier_id="213" value="6.17"/>
+    </Event>
+    <Event id="2939630913" event_id="249" type_id="1" period_id="1" min="23" sec="43" player_id="232091" team_id="244" outcome="1" x="64.9" y="62.6" timestamp="2026-05-18T18:41:06.524" timestamp_utc="2026-05-18T17:41:06.524" last_modified="2026-05-18T18:41:07" version="1779126066805">
+      <Q id="6427481545" qualifier_id="56" value="Center"/>
+      <Q id="6427481547" qualifier_id="140" value="70.9"/>
+      <Q id="6427481549" qualifier_id="141" value="75.6"/>
+      <Q id="6427481551" qualifier_id="212" value="10.9"/>
+      <Q id="6427481553" qualifier_id="213" value="0.95"/>
+    </Event>
+    <Event id="2939630921" event_id="250" type_id="49" period_id="1" min="23" sec="45" player_id="207884" team_id="244" outcome="1" x="72.2" y="76.7" timestamp="2026-05-18T18:41:07.829" timestamp_utc="2026-05-18T17:41:07.829" last_modified="2026-05-18T18:41:08" version="1779126067830"/>
+    <Event id="2939630973" event_id="251" type_id="1" period_id="1" min="23" sec="45" player_id="207884" team_id="244" outcome="1" x="72.2" y="76.7" timestamp="2026-05-18T18:41:08.348" timestamp_utc="2026-05-18T17:41:08.348" last_modified="2026-05-18T18:41:11" version="1779126069158">
+      <Q id="6427481851" qualifier_id="56" value="Left"/>
+      <Q id="6427481853" qualifier_id="140" value="82.0"/>
+      <Q id="6427481855" qualifier_id="141" value="86.6"/>
+      <Q id="6427481857" qualifier_id="212" value="12.3"/>
+      <Q id="6427481859" qualifier_id="213" value="0.58"/>
+    </Event>
+    <Event id="2939630983" event_id="252" type_id="1" period_id="1" min="23" sec="48" player_id="479433" team_id="244" outcome="0" x="82.1" y="86.6" timestamp="2026-05-18T18:41:11.108" timestamp_utc="2026-05-18T17:41:11.108" last_modified="2026-05-18T18:41:12" version="1779126072228">
+      <Q id="6427481913" qualifier_id="56" value="Left"/>
+      <Q id="6427481915" qualifier_id="140" value="77.1"/>
+      <Q id="6427481917" qualifier_id="141" value="89.0"/>
+      <Q id="6427481919" qualifier_id="212" value="5.5"/>
+      <Q id="6427481921" qualifier_id="213" value="2.84"/>
+      <Q id="6427481957" qualifier_id="233" value="166"/>
+      <Q id="6427481951" qualifier_id="236"/>
+      <Q id="6427481955" qualifier_id="286"/>
+    </Event>
+    <Event id="2939630991" event_id="166" type_id="74" period_id="1" min="23" sec="48" player_id="157851" team_id="417" outcome="1" x="22.9" y="11.0" timestamp="2026-05-18T18:41:11.109" timestamp_utc="2026-05-18T17:41:11.109" last_modified="2026-05-18T19:37:39" version="1779129459725">
+      <Q id="6427481931" qualifier_id="56" value="Back"/>
+      <Q id="6427481985" qualifier_id="233" value="252"/>
+      <Q id="6427481933" qualifier_id="285"/>
+    </Event>
+    <Event id="2939631001" event_id="167" type_id="5" period_id="1" min="23" sec="50" player_id="157851" team_id="417" outcome="0" x="21.0" y="-1.4" timestamp="2026-05-18T18:41:12.773" timestamp_utc="2026-05-18T17:41:12.773" last_modified="2026-05-18T19:36:54" version="1779129407948">
+      <Q id="6427482025" qualifier_id="56" value="Back"/>
+      <Q id="6427482379" qualifier_id="233" value="253"/>
+      <Q id="6427482027" qualifier_id="347"/>
+    </Event>
+    <Event id="2939631063" event_id="253" type_id="5" period_id="1" min="23" sec="50" player_id="479433" team_id="244" outcome="1" x="79.0" y="101.4" timestamp="2026-05-18T18:41:12.773" timestamp_utc="2026-05-18T17:41:12.773" last_modified="2026-05-18T19:36:54" version="1779129407944">
+      <Q id="6427482331" qualifier_id="56" value="Left"/>
+      <Q id="6427482359" qualifier_id="233" value="167"/>
+      <Q id="6427482333" qualifier_id="347"/>
+    </Event>
+    <Event id="2939631097" event_id="254" type_id="1" period_id="1" min="23" sec="54" player_id="575855" team_id="244" outcome="1" x="76.3" y="100.0" timestamp="2026-05-18T18:41:17.140" timestamp_utc="2026-05-18T17:41:17.140" last_modified="2026-05-18T18:41:20" version="1779126078229">
+      <Q id="6427482521" qualifier_id="1"/>
+      <Q id="6427482511" qualifier_id="56" value="Left"/>
+      <Q id="6427482509" qualifier_id="107"/>
+      <Q id="6427482513" qualifier_id="140" value="57.7"/>
+      <Q id="6427482515" qualifier_id="141" value="87.5"/>
+      <Q id="6427482517" qualifier_id="212" value="21.8"/>
+      <Q id="6427482519" qualifier_id="213" value="3.60"/>
+    </Event>
+    <Event id="2939631115" event_id="255" type_id="1" period_id="1" min="23" sec="57" player_id="180662" team_id="244" outcome="1" x="44.2" y="87.1" timestamp="2026-05-18T18:41:20.156" timestamp_utc="2026-05-18T17:41:20.156" last_modified="2026-05-18T18:41:22" version="1779126080575">
+      <Q id="6427482619" qualifier_id="56" value="Back"/>
+      <Q id="6427482621" qualifier_id="140" value="41.2"/>
+      <Q id="6427482623" qualifier_id="141" value="71.1"/>
+      <Q id="6427482625" qualifier_id="212" value="11.3"/>
+      <Q id="6427482627" qualifier_id="213" value="4.43"/>
+    </Event>
+    <Event id="2939631233" event_id="256" type_id="1" period_id="1" min="24" sec="0" player_id="627127" team_id="244" outcome="1" x="33.5" y="56.3" timestamp="2026-05-18T18:41:22.756" timestamp_utc="2026-05-18T17:41:22.756" last_modified="2026-05-18T18:41:30" version="1779126086095">
+      <Q id="6427483261" qualifier_id="56" value="Back"/>
+      <Q id="6427483263" qualifier_id="140" value="15.7"/>
+      <Q id="6427483265" qualifier_id="141" value="62.7"/>
+      <Q id="6427483267" qualifier_id="212" value="19.2"/>
+      <Q id="6427483269" qualifier_id="213" value="2.91"/>
+    </Event>
+    <Event id="2939631267" event_id="257" type_id="1" period_id="1" min="24" sec="7" player_id="578592" team_id="244" outcome="0" x="21.6" y="67.9" timestamp="2026-05-18T18:41:30.269" timestamp_utc="2026-05-18T17:41:30.269" last_modified="2026-05-18T18:41:32" version="1779126092156">
+      <Q id="6427483467" qualifier_id="1"/>
+      <Q id="6427483457" qualifier_id="56" value="Center"/>
+      <Q id="6427483459" qualifier_id="140" value="71.4"/>
+      <Q id="6427483461" qualifier_id="141" value="67.9"/>
+      <Q id="6427483455" qualifier_id="155"/>
+      <Q id="6427483463" qualifier_id="212" value="52.3"/>
+      <Q id="6427483465" qualifier_id="213" value="0.00"/>
+    </Event>
+    <Event id="2939631291" event_id="168" type_id="1" period_id="1" min="24" sec="10" player_id="61812" team_id="417" outcome="0" x="23.3" y="28.5" timestamp="2026-05-18T18:41:32.964" timestamp_utc="2026-05-18T17:41:32.964" last_modified="2026-05-18T18:41:34" version="1779126093973">
+      <Q id="6427483579" qualifier_id="3"/>
+      <Q id="6427483581" qualifier_id="56" value="Back"/>
+      <Q id="6427483583" qualifier_id="140" value="41.9"/>
+      <Q id="6427483585" qualifier_id="141" value="50.6"/>
+      <Q id="6427483587" qualifier_id="212" value="24.6"/>
+      <Q id="6427483589" qualifier_id="213" value="0.66"/>
+    </Event>
+    <Event id="2939631343" event_id="169" type_id="83" period_id="1" min="24" sec="14" player_id="61778" team_id="417" outcome="0" x="40.0" y="49.3" timestamp="2026-05-18T18:41:37.220" timestamp_utc="2026-05-18T17:41:37.220" last_modified="2026-05-18T18:41:41" version="1779126101072">
+      <Q id="6427484103" qualifier_id="399" value="515742"/>
+    </Event>
+    <Event id="2939631387" event_id="258" type_id="1" period_id="1" min="24" sec="14" player_id="515742" team_id="244" outcome="1" x="52.5" y="55.5" timestamp="2026-05-18T18:41:37.292" timestamp_utc="2026-05-18T17:41:37.292" last_modified="2026-05-18T18:41:41" version="1779126097815">
+      <Q id="6427484091" qualifier_id="56" value="Center"/>
+      <Q id="6427484093" qualifier_id="140" value="52.7"/>
+      <Q id="6427484095" qualifier_id="141" value="78.5"/>
+      <Q id="6427484097" qualifier_id="212" value="15.6"/>
+      <Q id="6427484099" qualifier_id="213" value="1.56"/>
+    </Event>
+    <Event id="2939631415" event_id="259" type_id="1" period_id="1" min="24" sec="19" player_id="575855" team_id="244" outcome="1" x="47.1" y="69.4" timestamp="2026-05-18T18:41:42.556" timestamp_utc="2026-05-18T17:41:42.556" last_modified="2026-05-18T18:41:43" version="1779126103039">
+      <Q id="6427484247" qualifier_id="56" value="Back"/>
+      <Q id="6427484249" qualifier_id="140" value="41.2"/>
+      <Q id="6427484251" qualifier_id="141" value="76.4"/>
+      <Q id="6427484253" qualifier_id="212" value="7.8"/>
+      <Q id="6427484255" qualifier_id="213" value="2.49"/>
+    </Event>
+    <Event id="2939631443" event_id="260" type_id="1" period_id="1" min="24" sec="21" player_id="180662" team_id="244" outcome="1" x="41.2" y="76.4" timestamp="2026-05-18T18:41:43.748" timestamp_utc="2026-05-18T17:41:43.748" last_modified="2026-05-18T18:41:46" version="1779126104149">
+      <Q id="6427484421" qualifier_id="56" value="Left"/>
+      <Q id="6427484423" qualifier_id="140" value="57.5"/>
+      <Q id="6427484425" qualifier_id="141" value="91.5"/>
+      <Q id="6427484427" qualifier_id="212" value="20.0"/>
+      <Q id="6427484429" qualifier_id="213" value="0.54"/>
+    </Event>
+    <Event id="2939631475" event_id="261" type_id="1" period_id="1" min="24" sec="23" player_id="207884" team_id="244" outcome="0" x="58.1" y="86.2" timestamp="2026-05-18T18:41:46.223" timestamp_utc="2026-05-18T17:41:46.223" last_modified="2026-05-18T18:41:48" version="1779126108812">
+      <Q id="6427484593" qualifier_id="1"/>
+      <Q id="6427484583" qualifier_id="56" value="Center"/>
+      <Q id="6427484585" qualifier_id="140" value="89.6"/>
+      <Q id="6427484587" qualifier_id="141" value="56.1"/>
+      <Q id="6427484581" qualifier_id="155"/>
+      <Q id="6427484589" qualifier_id="212" value="38.9"/>
+      <Q id="6427484591" qualifier_id="213" value="5.73"/>
+    </Event>
+    <Event id="2939631481" event_id="170" type_id="52" period_id="1" min="24" sec="26" player_id="565487" team_id="417" outcome="1" x="8.7" y="47.5" timestamp="2026-05-18T18:41:49.597" timestamp_utc="2026-05-18T17:41:49.597" last_modified="2026-05-18T18:41:49" version="1779126109600"/>
+    <Event id="2939631533" event_id="171" type_id="1" period_id="1" min="24" sec="28" player_id="565487" team_id="417" outcome="1" x="11.2" y="46.4" timestamp="2026-05-18T18:41:50.876" timestamp_utc="2026-05-18T17:41:50.876" last_modified="2026-05-18T18:41:54" version="1779126112413">
+      <Q id="6427484907" qualifier_id="56" value="Back"/>
+      <Q id="6427484905" qualifier_id="123"/>
+      <Q id="6427484909" qualifier_id="140" value="24.9"/>
+      <Q id="6427484911" qualifier_id="141" value="30.4"/>
+      <Q id="6427484913" qualifier_id="212" value="18.0"/>
+      <Q id="6427484915" qualifier_id="213" value="5.64"/>
+    </Event>
+    <Event id="2939631573" event_id="172" type_id="1" period_id="1" min="24" sec="31" player_id="218339" team_id="417" outcome="1" x="26.0" y="31.8" timestamp="2026-05-18T18:41:54.196" timestamp_utc="2026-05-18T17:41:54.196" last_modified="2026-05-18T18:41:56" version="1779126115542">
+      <Q id="6427485177" qualifier_id="56" value="Back"/>
+      <Q id="6427485179" qualifier_id="140" value="32.2"/>
+      <Q id="6427485181" qualifier_id="141" value="6.2"/>
+      <Q id="6427485183" qualifier_id="212" value="18.6"/>
+      <Q id="6427485185" qualifier_id="213" value="5.07"/>
+    </Event>
+    <Event id="2939631689" event_id="173" type_id="1" period_id="1" min="24" sec="33" player_id="157851" team_id="417" outcome="1" x="32.2" y="6.2" timestamp="2026-05-18T18:41:56.365" timestamp_utc="2026-05-18T17:41:56.365" last_modified="2026-05-18T18:42:04" version="1779126118663">
+      <Q id="6427485803" qualifier_id="56" value="Right"/>
+      <Q id="6427485805" qualifier_id="140" value="59.6"/>
+      <Q id="6427485807" qualifier_id="141" value="13.4"/>
+      <Q id="6427485809" qualifier_id="212" value="29.2"/>
+      <Q id="6427485811" qualifier_id="213" value="0.17"/>
+    </Event>
+    <Event id="2939631691" event_id="174" type_id="61" period_id="1" min="24" sec="41" player_id="685390" team_id="417" outcome="0" x="46.7" y="20.0" timestamp="2026-05-18T18:42:04.148" timestamp_utc="2026-05-18T17:42:04.148" last_modified="2026-05-18T18:42:04" version="1779126124149">
+      <Q id="6427485817" qualifier_id="56" value="Back"/>
+    </Event>
+    <Event id="2939631709" event_id="262" type_id="61" period_id="1" min="24" sec="42" player_id="515742" team_id="244" outcome="1" x="47.9" y="78.1" timestamp="2026-05-18T18:42:05.188" timestamp_utc="2026-05-18T17:42:05.188" last_modified="2026-05-18T18:42:05" version="1779126125189">
+      <Q id="6427485929" qualifier_id="56" value="Back"/>
+    </Event>
+    <Event id="2939631725" event_id="263" type_id="49" period_id="1" min="24" sec="43" player_id="207884" team_id="244" outcome="1" x="57.4" y="77.5" timestamp="2026-05-18T18:42:06.404" timestamp_utc="2026-05-18T17:42:06.404" last_modified="2026-05-18T18:42:06" version="1779126126405"/>
+    <Event id="2939631843" event_id="264" type_id="1" period_id="1" min="24" sec="46" player_id="207884" team_id="244" outcome="1" x="74.1" y="72.1" keypass="1" timestamp="2026-05-18T18:42:09.356" timestamp_utc="2026-05-18T17:42:09.356" last_modified="2026-05-18T18:42:25" version="1779126145708">
+      <Q id="6427486661" qualifier_id="56" value="Center"/>
+      <Q id="6427486663" qualifier_id="140" value="90.7"/>
+      <Q id="6427486665" qualifier_id="141" value="75.6"/>
+      <Q id="6427487655" qualifier_id="154"/>
+      <Q id="6427487653" qualifier_id="210" value="13"/>
+      <Q id="6427486667" qualifier_id="212" value="17.6"/>
+      <Q id="6427486669" qualifier_id="213" value="0.14"/>
+    </Event>
+    <Event id="2939631849" event_id="265" type_id="13" period_id="1" min="24" sec="51" player_id="648131" team_id="244" outcome="1" x="85.6" y="66.3" timestamp="2026-05-18T18:42:14.156" timestamp_utc="2026-05-18T17:42:14.156" last_modified="2026-05-18T18:42:26" version="1779126145718">
+      <Q id="6427487021" qualifier_id="20"/>
+      <Q id="6427486707" qualifier_id="22"/>
+      <Q id="6427487691" qualifier_id="29"/>
+      <Q id="6427487695" qualifier_id="55" value="264"/>
+      <Q id="6427486713" qualifier_id="56" value="Center"/>
+      <Q id="6427486709" qualifier_id="64"/>
+      <Q id="6427487689" qualifier_id="83"/>
+      <Q id="6427487699" qualifier_id="102" value="58.0"/>
+      <Q id="6427487701" qualifier_id="103" value="8.3"/>
+      <Q id="6427487693" qualifier_id="154"/>
+      <Q id="6427487703" qualifier_id="230" value="99.7"/>
+      <Q id="6427487705" qualifier_id="231" value="51.4"/>
+    </Event>
+    <Event id="2939631895" event_id="266" type_id="5" period_id="1" min="24" sec="52" player_id="648131" team_id="244" outcome="0" x="100.7" y="63.8" timestamp="2026-05-18T18:42:14.900" timestamp_utc="2026-05-18T17:42:14.900" last_modified="2026-05-18T19:36:55" version="1779129407955">
+      <Q id="6427487013" qualifier_id="56" value="Center"/>
+      <Q id="6427489039" qualifier_id="233" value="175"/>
+      <Q id="6427487015" qualifier_id="346"/>
+    </Event>
+    <Event id="2939632265" event_id="175" type_id="5" period_id="1" min="24" sec="52" player_id="531784" team_id="417" outcome="1" x="-0.7" y="36.2" timestamp="2026-05-18T18:42:14.900" timestamp_utc="2026-05-18T17:42:14.900" last_modified="2026-05-18T19:36:54" version="1779129407952">
+      <Q id="6427488963" qualifier_id="56" value="Back"/>
+      <Q id="6427489011" qualifier_id="233" value="266"/>
+      <Q id="6427488965" qualifier_id="346"/>
+    </Event>
+    <Event id="2939632371" event_id="176" type_id="1" period_id="1" min="25" sec="19" player_id="565487" team_id="417" outcome="0" x="3.0" y="44.9" timestamp="2026-05-18T18:42:42.108" timestamp_utc="2026-05-18T17:42:42.108" last_modified="2026-05-18T18:42:48" version="1779126168620">
+      <Q id="6427489541" qualifier_id="1"/>
+      <Q id="6427489531" qualifier_id="56" value="Center"/>
+      <Q id="6427489545" qualifier_id="74"/>
+      <Q id="6427489529" qualifier_id="124"/>
+      <Q id="6427489533" qualifier_id="140" value="56.1"/>
+      <Q id="6427489535" qualifier_id="141" value="46.1"/>
+      <Q id="6427489537" qualifier_id="212" value="55.8"/>
+      <Q id="6427489539" qualifier_id="213" value="0.01"/>
+    </Event>
+    <Event id="2939632415" event_id="267" type_id="44" period_id="1" min="25" sec="25" player_id="515742" team_id="244" outcome="1" x="43.9" y="53.9" timestamp="2026-05-18T18:42:48.347" timestamp_utc="2026-05-18T17:42:48.347" last_modified="2026-05-18T19:37:37" version="1779129457099">
+      <Q id="6427489777" qualifier_id="56" value="Back"/>
+      <Q id="6427489839" qualifier_id="233" value="177"/>
+      <Q id="6427489781" qualifier_id="285"/>
+    </Event>
+    <Event id="2939632377" event_id="177" type_id="44" period_id="1" min="25" sec="25" player_id="61778" team_id="417" outcome="0" x="56.1" y="46.1" timestamp="2026-05-18T18:42:48.348" timestamp_utc="2026-05-18T17:42:48.348" last_modified="2026-05-18T19:37:37" version="1779129457363">
+      <Q id="6427489561" qualifier_id="56" value="Center"/>
+      <Q id="6427489843" qualifier_id="233" value="267"/>
+      <Q id="6427489563" qualifier_id="286"/>
+    </Event>
+    <Event id="2939632435" event_id="268" type_id="1" period_id="1" min="25" sec="26" player_id="515742" team_id="244" outcome="1" x="43.9" y="53.9" timestamp="2026-05-18T18:42:49.283" timestamp_utc="2026-05-18T17:42:49.283" last_modified="2026-05-18T19:37:58" version="1779129477958">
+      <Q id="6427489891" qualifier_id="3"/>
+      <Q id="6427489893" qualifier_id="56" value="Back"/>
+      <Q id="6427489895" qualifier_id="140" value="49.5"/>
+      <Q id="6427489897" qualifier_id="141" value="60.3"/>
+      <Q id="6427489899" qualifier_id="212" value="7.3"/>
+      <Q id="6427489901" qualifier_id="213" value="0.64"/>
+    </Event>
+    <Event id="2939632451" event_id="269" type_id="61" period_id="1" min="25" sec="30" player_id="207884" team_id="244" outcome="1" x="43.3" y="74.5" timestamp="2026-05-18T18:42:53.539" timestamp_utc="2026-05-18T17:42:53.539" last_modified="2026-05-18T18:43:31" version="1779126211120">
+      <Q id="6427489985" qualifier_id="56" value="Back"/>
+    </Event>
+    <Event id="2939632479" event_id="270" type_id="49" period_id="1" min="25" sec="32" player_id="180662" team_id="244" outcome="1" x="40.2" y="67.5" timestamp="2026-05-18T18:42:55.172" timestamp_utc="2026-05-18T17:42:55.172" last_modified="2026-05-18T18:42:55" version="1779126175173"/>
+    <Event id="2939632493" event_id="271" type_id="1" period_id="1" min="25" sec="32" player_id="180662" team_id="244" outcome="1" x="40.2" y="67.5" timestamp="2026-05-18T18:42:55.420" timestamp_utc="2026-05-18T17:42:55.420" last_modified="2026-05-18T18:42:56" version="1779126175529">
+      <Q id="6427490181" qualifier_id="56" value="Back"/>
+      <Q id="6427490183" qualifier_id="140" value="40.2"/>
+      <Q id="6427490185" qualifier_id="141" value="80.9"/>
+      <Q id="6427490187" qualifier_id="212" value="9.1"/>
+      <Q id="6427490189" qualifier_id="213" value="1.57"/>
+    </Event>
+    <Event id="2939632513" event_id="272" type_id="1" period_id="1" min="25" sec="33" player_id="207884" team_id="244" outcome="1" x="40.2" y="80.9" timestamp="2026-05-18T18:42:56.131" timestamp_utc="2026-05-18T17:42:56.131" last_modified="2026-05-18T18:42:57" version="1779126176239">
+      <Q id="6427490297" qualifier_id="56" value="Back"/>
+      <Q id="6427490299" qualifier_id="140" value="43.9"/>
+      <Q id="6427490301" qualifier_id="141" value="86.3"/>
+      <Q id="6427490303" qualifier_id="212" value="5.3"/>
+      <Q id="6427490305" qualifier_id="213" value="0.76"/>
+    </Event>
+    <Event id="2939632541" event_id="273" type_id="1" period_id="1" min="25" sec="34" player_id="575855" team_id="244" outcome="1" x="38.9" y="80.5" timestamp="2026-05-18T18:42:57.364" timestamp_utc="2026-05-18T17:42:57.364" last_modified="2026-05-18T18:42:59" version="1779126177630">
+      <Q id="6427490437" qualifier_id="56" value="Back"/>
+      <Q id="6427490439" qualifier_id="140" value="43.1"/>
+      <Q id="6427490441" qualifier_id="141" value="65.5"/>
+      <Q id="6427490443" qualifier_id="212" value="11.1"/>
+      <Q id="6427490445" qualifier_id="213" value="5.12"/>
+    </Event>
+    <Event id="2939632569" event_id="274" type_id="1" period_id="1" min="25" sec="36" player_id="515742" team_id="244" outcome="1" x="43.5" y="65.4" timestamp="2026-05-18T18:42:59.043" timestamp_utc="2026-05-18T17:42:59.043" last_modified="2026-05-18T18:47:13" version="1779126433239">
+      <Q id="6427490579" qualifier_id="56" value="Left"/>
+      <Q id="6427490581" qualifier_id="140" value="69.9"/>
+      <Q id="6427490583" qualifier_id="141" value="86.8"/>
+      <Q id="6427490585" qualifier_id="212" value="31.3"/>
+      <Q id="6427490587" qualifier_id="213" value="0.48"/>
+    </Event>
+    <Event id="2939632619" event_id="275" type_id="4" period_id="1" min="25" sec="42" player_id="207884" team_id="244" outcome="1" x="76.8" y="89.0" timestamp="2026-05-18T18:43:04.764" timestamp_utc="2026-05-18T17:43:04.764" last_modified="2026-05-18T18:43:08" version="1779126186743">
+      <Q id="6427491003" qualifier_id="13"/>
+      <Q id="6427491007" qualifier_id="56" value="Left"/>
+      <Q id="6427491009" qualifier_id="152"/>
+      <Q id="6427491075" qualifier_id="233" value="178"/>
+      <Q id="6427491011" qualifier_id="286"/>
+      <Q id="6427491005" qualifier_id="295"/>
+    </Event>
+    <Event id="2939632621" event_id="178" type_id="4" period_id="1" min="25" sec="42" player_id="531784" team_id="417" outcome="0" x="23.1" y="11.0" timestamp="2026-05-18T18:43:04.765" timestamp_utc="2026-05-18T17:43:04.765" last_modified="2026-05-18T18:43:09" version="1779126186747">
+      <Q id="6427491061" qualifier_id="13"/>
+      <Q id="6427491065" qualifier_id="56" value="Back"/>
+      <Q id="6427491067" qualifier_id="152"/>
+      <Q id="6427491089" qualifier_id="233" value="275"/>
+      <Q id="6427491069" qualifier_id="285"/>
+      <Q id="6427491063" qualifier_id="295"/>
+    </Event>
+    <Event id="2939633027" event_id="276" type_id="1" period_id="1" min="26" sec="14" player_id="207884" team_id="244" outcome="0" x="79.7" y="88.0" timestamp="2026-05-18T18:43:37.267" timestamp_utc="2026-05-18T17:43:37.267" last_modified="2026-05-18T18:43:40" version="1779126220635">
+      <Q id="6427493037" qualifier_id="2"/>
+      <Q id="6427493039" qualifier_id="5"/>
+      <Q id="6427493045" qualifier_id="56" value="Center"/>
+      <Q id="6427493047" qualifier_id="140" value="92.4"/>
+      <Q id="6427493049" qualifier_id="141" value="50.3"/>
+      <Q id="6427493043" qualifier_id="152"/>
+      <Q id="6427493041" qualifier_id="155"/>
+      <Q id="6427493051" qualifier_id="212" value="28.9"/>
+      <Q id="6427493053" qualifier_id="213" value="5.19"/>
+    </Event>
+    <Event id="2939633041" event_id="179" type_id="12" period_id="1" min="26" sec="18" player_id="164593" team_id="417" outcome="1" x="9.5" y="54.6" timestamp="2026-05-18T18:43:41.275" timestamp_utc="2026-05-18T17:43:41.275" last_modified="2026-05-18T18:44:34" version="1779126274551">
+      <Q id="6427493169" qualifier_id="15"/>
+      <Q id="6427493147" qualifier_id="56" value="Back"/>
+      <Q id="6427493149" qualifier_id="140" value="0.0"/>
+      <Q id="6427493151" qualifier_id="141" value="23.9"/>
+      <Q id="6427493805" qualifier_id="167"/>
+      <Q id="6427493153" qualifier_id="212" value="23.6"/>
+      <Q id="6427493155" qualifier_id="213" value="4.23"/>
+    </Event>
+    <Event id="2939633109" event_id="180" type_id="6" period_id="1" min="26" sec="23" player_id="164593" team_id="417" outcome="0" x="7.6" y="22.2" timestamp="2026-05-18T18:43:46.267" timestamp_utc="2026-05-18T17:43:46.267" last_modified="2026-05-18T18:43:51" version="1779126229479">
+      <Q id="6427493541" qualifier_id="56" value="Back"/>
+      <Q id="6427493543" qualifier_id="73"/>
+      <Q id="6427493793" qualifier_id="233" value="277"/>
+    </Event>
+    <Event id="2939633141" event_id="277" type_id="6" period_id="1" min="26" sec="23" player_id="207884" team_id="244" outcome="1" x="92.4" y="77.8" timestamp="2026-05-18T18:43:46.267" timestamp_utc="2026-05-18T17:43:46.267" last_modified="2026-05-18T19:36:25" version="1779129384315">
+      <Q id="6427493743" qualifier_id="56" value="Center"/>
+      <Q id="6427493745" qualifier_id="73"/>
+      <Q id="6427493779" qualifier_id="233" value="180"/>
+    </Event>
+    <Event id="2939633431" event_id="278" type_id="1" period_id="1" min="26" sec="44" player_id="207884" team_id="244" outcome="0" x="99.5" y="99.5" timestamp="2026-05-18T18:44:06.659" timestamp_utc="2026-05-18T17:44:06.659" last_modified="2026-05-18T18:44:12" version="1779126252223">
+      <Q id="6427495327" qualifier_id="1"/>
+      <Q id="6427495309" qualifier_id="2"/>
+      <Q id="6427495311" qualifier_id="6"/>
+      <Q id="6427495317" qualifier_id="56" value="Center"/>
+      <Q id="6427495319" qualifier_id="140" value="95.7"/>
+      <Q id="6427495321" qualifier_id="141" value="51.0"/>
+      <Q id="6427495313" qualifier_id="155"/>
+      <Q id="6427495323" qualifier_id="212" value="33.2"/>
+      <Q id="6427495325" qualifier_id="213" value="4.59"/>
+      <Q id="6427495315" qualifier_id="223"/>
+      <Q id="6427495587" qualifier_id="233" value="181"/>
+    </Event>
+    <Event id="2939633481" event_id="181" type_id="41" period_id="1" min="26" sec="48" player_id="565487" team_id="417" outcome="0" x="4.3" y="49.0" timestamp="2026-05-18T18:44:11.234" timestamp_utc="2026-05-18T17:44:11.234" last_modified="2026-05-18T19:37:42" version="1779129462083">
+      <Q id="6427495577" qualifier_id="140" value="18.2"/>
+      <Q id="6427495579" qualifier_id="141" value="95.0"/>
+      <Q id="6427495581" qualifier_id="212" value="34.5"/>
+      <Q id="6427495583" qualifier_id="213" value="1.13"/>
+      <Q id="6427495605" qualifier_id="233" value="278"/>
+    </Event>
+    <Event id="2939633513" event_id="279" type_id="1" period_id="1" min="26" sec="50" player_id="240166" team_id="244" outcome="0" x="81.0" y="15.3" timestamp="2026-05-18T18:44:12.723" timestamp_utc="2026-05-18T17:44:12.723" last_modified="2026-05-18T18:44:15" version="1779126255339">
+      <Q id="6427495789" qualifier_id="2"/>
+      <Q id="6427495793" qualifier_id="56" value="Center"/>
+      <Q id="6427495795" qualifier_id="140" value="87.6"/>
+      <Q id="6427495797" qualifier_id="141" value="49.7"/>
+      <Q id="6427495791" qualifier_id="155"/>
+      <Q id="6427495799" qualifier_id="212" value="24.4"/>
+      <Q id="6427495801" qualifier_id="213" value="1.28"/>
+    </Event>
+    <Event id="2939633533" event_id="182" type_id="12" period_id="1" min="26" sec="54" player_id="445539" team_id="417" outcome="1" x="13.6" y="54.0" timestamp="2026-05-18T18:44:16.674" timestamp_utc="2026-05-18T17:44:16.674" last_modified="2026-05-18T18:44:18" version="1779126257333">
+      <Q id="6427495939" qualifier_id="15"/>
+      <Q id="6427495893" qualifier_id="56" value="Back"/>
+      <Q id="6427495895" qualifier_id="140" value="21.1"/>
+      <Q id="6427495897" qualifier_id="141" value="44.8"/>
+      <Q id="6427495899" qualifier_id="212" value="10.1"/>
+      <Q id="6427495901" qualifier_id="213" value="5.61"/>
+    </Event>
+    <Event id="2939633607" event_id="183" type_id="1" period_id="1" min="26" sec="55" player_id="685390" team_id="417" outcome="0" x="21.1" y="44.8" timestamp="2026-05-18T18:44:18.403" timestamp_utc="2026-05-18T17:44:18.403" last_modified="2026-05-18T18:44:23" version="1779126263476">
+      <Q id="6427496309" qualifier_id="1"/>
+      <Q id="6427496299" qualifier_id="56" value="Right"/>
+      <Q id="6427496301" qualifier_id="140" value="63.4"/>
+      <Q id="6427496303" qualifier_id="141" value="0.0"/>
+      <Q id="6427496297" qualifier_id="157"/>
+      <Q id="6427496305" qualifier_id="212" value="54.2"/>
+      <Q id="6427496307" qualifier_id="213" value="5.67"/>
+    </Event>
+    <Event id="2939633613" event_id="184" type_id="5" period_id="1" min="27" sec="0" player_id="685390" team_id="417" outcome="0" x="62.5" y="-1.4" timestamp="2026-05-18T18:44:23.427" timestamp_utc="2026-05-18T17:44:23.427" last_modified="2026-05-18T19:36:55" version="1779129407963">
+      <Q id="6427496335" qualifier_id="56" value="Right"/>
+      <Q id="6427497635" qualifier_id="233" value="280"/>
+      <Q id="6427496337" qualifier_id="347"/>
+    </Event>
+    <Event id="2939633815" event_id="280" type_id="5" period_id="1" min="27" sec="0" player_id="240166" team_id="244" outcome="1" x="37.5" y="101.4" timestamp="2026-05-18T18:44:23.427" timestamp_utc="2026-05-18T17:44:23.427" last_modified="2026-05-18T19:36:55" version="1779129407960">
+      <Q id="6427497601" qualifier_id="56" value="Back"/>
+      <Q id="6427497607" qualifier_id="233" value="184"/>
+      <Q id="6427497603" qualifier_id="347"/>
+    </Event>
+    <Event id="2939633843" event_id="281" type_id="1" period_id="1" min="27" sec="19" player_id="575855" team_id="244" outcome="1" x="41.3" y="100.0" timestamp="2026-05-18T18:44:41.738" timestamp_utc="2026-05-18T17:44:41.738" last_modified="2026-05-18T18:44:44" version="1779126282717">
+      <Q id="6427497817" qualifier_id="56" value="Back"/>
+      <Q id="6427497815" qualifier_id="107"/>
+      <Q id="6427497819" qualifier_id="140" value="45.1"/>
+      <Q id="6427497821" qualifier_id="141" value="84.1"/>
+      <Q id="6427497823" qualifier_id="212" value="12.2"/>
+      <Q id="6427497825" qualifier_id="213" value="5.05"/>
+    </Event>
+    <Event id="2939633891" event_id="282" type_id="1" period_id="1" min="27" sec="21" player_id="515742" team_id="244" outcome="1" x="45.1" y="84.5" timestamp="2026-05-18T18:44:44.250" timestamp_utc="2026-05-18T17:44:44.250" last_modified="2026-05-18T18:44:47" version="1779126284418">
+      <Q id="6427498143" qualifier_id="56" value="Back"/>
+      <Q id="6427498145" qualifier_id="140" value="47.2"/>
+      <Q id="6427498147" qualifier_id="141" value="89.7"/>
+      <Q id="6427498149" qualifier_id="212" value="4.2"/>
+      <Q id="6427498151" qualifier_id="213" value="1.01"/>
+    </Event>
+    <Event id="2939633899" event_id="283" type_id="4" period_id="1" min="27" sec="24" player_id="575855" team_id="244" outcome="1" x="45.4" y="92.5" timestamp="2026-05-18T18:44:47.192" timestamp_utc="2026-05-18T17:44:47.192" last_modified="2026-05-18T18:44:50" version="1779126289619">
+      <Q id="6427498257" qualifier_id="13"/>
+      <Q id="6427498259" qualifier_id="56" value="Back"/>
+      <Q id="6427498261" qualifier_id="152"/>
+      <Q id="6427498293" qualifier_id="233" value="185"/>
+      <Q id="6427498263" qualifier_id="265"/>
+      <Q id="6427498265" qualifier_id="286"/>
+    </Event>
+    <Event id="2939633887" event_id="185" type_id="4" period_id="1" min="27" sec="24" player_id="720682" team_id="417" outcome="0" x="54.6" y="7.6" timestamp="2026-05-18T18:44:47.193" timestamp_utc="2026-05-18T17:44:47.193" last_modified="2026-05-18T18:44:49" version="1779126288095">
+      <Q id="6427498231" qualifier_id="13"/>
+      <Q id="6427498233" qualifier_id="56" value="Right"/>
+      <Q id="6427498235" qualifier_id="152"/>
+      <Q id="6427498303" qualifier_id="233" value="283"/>
+      <Q id="6427498237" qualifier_id="265"/>
+      <Q id="6427498239" qualifier_id="285"/>
+    </Event>
+    <Event id="2939634049" event_id="284" type_id="1" period_id="1" min="27" sec="31" player_id="207884" team_id="244" outcome="1" x="46.1" y="94.2" timestamp="2026-05-18T18:44:53.842" timestamp_utc="2026-05-18T17:44:53.842" last_modified="2026-05-18T18:44:56" version="1779126294372">
+      <Q id="6427498989" qualifier_id="1"/>
+      <Q id="6427498975" qualifier_id="5"/>
+      <Q id="6427498979" qualifier_id="56" value="Center"/>
+      <Q id="6427498981" qualifier_id="140" value="55.3"/>
+      <Q id="6427498983" qualifier_id="141" value="43.4"/>
+      <Q id="6427498977" qualifier_id="152"/>
+      <Q id="6427498985" qualifier_id="212" value="35.9"/>
+      <Q id="6427498987" qualifier_id="213" value="4.99"/>
+    </Event>
+    <Event id="2939634059" event_id="285" type_id="43" period_id="1" min="27" sec="33" player_id="240166" team_id="244" outcome="1" x="0.0" y="0.0" timestamp="2026-05-18T18:44:56.551" timestamp_utc="2026-05-18T17:44:56.551" last_modified="2026-05-18T18:46:40" version="1779126297082">
+      <Q id="6427499025" qualifier_id="56" value="Center"/>
+      <Q id="6427506349" qualifier_id="144" value="61"/>
+    </Event>
+    <Event id="2939634425" event_id="286" type_id="1" period_id="1" min="27" sec="38" player_id="625775" team_id="244" outcome="1" x="66.6" y="28.2" assist="1" timestamp="2026-05-18T18:45:01.594" timestamp_utc="2026-05-18T17:45:01.594" last_modified="2026-05-18T19:37:40" version="1779129460252">
+      <Q id="6427672495" qualifier_id="1"/>
+      <Q id="6427504133" qualifier_id="22"/>
+      <Q id="6427501047" qualifier_id="56" value="Center"/>
+      <Q id="6427501049" qualifier_id="140" value="93.2"/>
+      <Q id="6427501051" qualifier_id="141" value="53.3"/>
+      <Q id="6427504131" qualifier_id="154"/>
+      <Q id="6427501045" qualifier_id="155"/>
+      <Q id="6427504129" qualifier_id="210" value="16"/>
+      <Q id="6427501053" qualifier_id="212" value="32.7"/>
+      <Q id="6427501055" qualifier_id="213" value="0.55"/>
+    </Event>
+    <Event id="2939634429" event_id="287" type_id="16" period_id="1" min="27" sec="47" player_id="648131" team_id="244" outcome="1" x="93.2" y="53.3" timestamp="2026-05-18T18:45:10.331" timestamp_utc="2026-05-18T17:45:10.331" last_modified="2026-05-18T19:37:40" version="1779129460675">
+      <Q id="6427501077" qualifier_id="17"/>
+      <Q id="6427504145" qualifier_id="20"/>
+      <Q id="6427501075" qualifier_id="22"/>
+      <Q id="6427504149" qualifier_id="29"/>
+      <Q id="6427504153" qualifier_id="55" value="286"/>
+      <Q id="6427501079" qualifier_id="56" value="Center"/>
+      <Q id="6427504147" qualifier_id="80"/>
+      <Q id="6427504157" qualifier_id="102" value="47.6"/>
+      <Q id="6427504159" qualifier_id="103" value="10.8"/>
+      <Q id="6427504151" qualifier_id="154"/>
+      <Q id="6427504161" qualifier_id="214"/>
+      <Q id="6427504167" qualifier_id="230" value="100.0"/>
+      <Q id="6427504169" qualifier_id="231" value="50.4"/>
+      <Q id="6427504165" qualifier_id="328"/>
+      <Q id="6427504173" qualifier_id="374" value="2026-05-18 18:45:09.881"/>
+      <Q id="6427504177" qualifier_id="375" value="27:47.234"/>
+    </Event>
+    <Event id="2939635029" event_id="288" type_id="43" period_id="1" min="28" sec="51" player_id="648131" team_id="244" outcome="1" x="0.0" y="0.0" timestamp="2026-05-18T18:46:13.875" timestamp_utc="2026-05-18T17:46:13.875" last_modified="2026-05-18T18:46:16" version="1779126373876">
+      <Q id="6427504769" qualifier_id="144" value="49"/>
+    </Event>
+    <Event id="2939635043" event_id="289" type_id="43" period_id="1" min="28" sec="51" player_id="648131" team_id="244" outcome="1" x="0.0" y="0.0" timestamp="2026-05-18T18:46:14.049" timestamp_utc="2026-05-18T17:46:14.049" last_modified="2026-05-18T18:46:16" version="1779126374051">
+      <Q id="6427504677" qualifier_id="144" value="49"/>
+    </Event>
+    <Event id="2939636075" event_id="186" type_id="1" period_id="1" min="30" sec="16" player_id="445539" team_id="417" outcome="1" x="49.8" y="49.7" timestamp="2026-05-18T18:47:39.559" timestamp_utc="2026-05-18T17:47:39.559" last_modified="2026-05-18T18:47:41" version="1779126460544">
+      <Q id="6427510221" qualifier_id="56" value="Back"/>
+      <Q id="6427510223" qualifier_id="140" value="45.7"/>
+      <Q id="6427510225" qualifier_id="141" value="46.4"/>
+      <Q id="6427510227" qualifier_id="212" value="4.9"/>
+      <Q id="6427510229" qualifier_id="213" value="3.62"/>
+      <Q id="6427510233" qualifier_id="278"/>
+      <Q id="6427510231" qualifier_id="279" value="G"/>
+    </Event>
+    <Event id="2939636107" event_id="187" type_id="1" period_id="1" min="30" sec="18" player_id="218339" team_id="417" outcome="1" x="45.7" y="46.4" timestamp="2026-05-18T18:47:41.151" timestamp_utc="2026-05-18T17:47:41.151" last_modified="2026-05-18T18:47:42" version="1779126462034">
+      <Q id="6427510405" qualifier_id="56" value="Back"/>
+      <Q id="6427510407" qualifier_id="140" value="37.4"/>
+      <Q id="6427510409" qualifier_id="141" value="69.4"/>
+      <Q id="6427510411" qualifier_id="212" value="17.9"/>
+      <Q id="6427510413" qualifier_id="213" value="2.08"/>
+    </Event>
+    <Event id="2939636125" event_id="188" type_id="1" period_id="1" min="30" sec="20" player_id="720682" team_id="417" outcome="1" x="37.4" y="69.4" timestamp="2026-05-18T18:47:42.863" timestamp_utc="2026-05-18T17:47:42.863" last_modified="2026-05-18T18:47:45" version="1779126463792">
+      <Q id="6427510497" qualifier_id="56" value="Back"/>
+      <Q id="6427510499" qualifier_id="140" value="34.4"/>
+      <Q id="6427510501" qualifier_id="141" value="83.9"/>
+      <Q id="6427510503" qualifier_id="212" value="10.4"/>
+      <Q id="6427510505" qualifier_id="213" value="1.88"/>
+    </Event>
+    <Event id="2939636163" event_id="189" type_id="1" period_id="1" min="30" sec="22" player_id="624620" team_id="417" outcome="1" x="33.5" y="77.8" timestamp="2026-05-18T18:47:45.016" timestamp_utc="2026-05-18T17:47:45.016" last_modified="2026-05-18T18:47:48" version="1779126467019">
+      <Q id="6427510757" qualifier_id="56" value="Back"/>
+      <Q id="6427510759" qualifier_id="140" value="22.4"/>
+      <Q id="6427510761" qualifier_id="141" value="60.5"/>
+      <Q id="6427510763" qualifier_id="212" value="16.6"/>
+      <Q id="6427510765" qualifier_id="213" value="3.93"/>
+    </Event>
+    <Event id="2939636183" event_id="190" type_id="1" period_id="1" min="30" sec="25" player_id="61812" team_id="417" outcome="0" x="22.3" y="60.0" timestamp="2026-05-18T18:47:48.240" timestamp_utc="2026-05-18T17:47:48.240" last_modified="2026-05-18T18:47:50" version="1779126470176">
+      <Q id="6427510887" qualifier_id="1"/>
+      <Q id="6427510877" qualifier_id="56" value="Center"/>
+      <Q id="6427510879" qualifier_id="140" value="66.0"/>
+      <Q id="6427510881" qualifier_id="141" value="23.9"/>
+      <Q id="6427510875" qualifier_id="155"/>
+      <Q id="6427510883" qualifier_id="212" value="52.0"/>
+      <Q id="6427510885" qualifier_id="213" value="5.79"/>
+    </Event>
+    <Event id="2939636217" event_id="290" type_id="1" period_id="1" min="30" sec="29" player_id="180662" team_id="244" outcome="0" x="36.6" y="70.6" timestamp="2026-05-18T18:47:51.673" timestamp_utc="2026-05-18T17:47:51.673" last_modified="2026-05-18T18:47:53" version="1779126473555">
+      <Q id="6427511143" qualifier_id="1"/>
+      <Q id="6427511131" qualifier_id="3"/>
+      <Q id="6427511133" qualifier_id="56" value="Left"/>
+      <Q id="6427511135" qualifier_id="140" value="69.0"/>
+      <Q id="6427511137" qualifier_id="141" value="100.0"/>
+      <Q id="6427511139" qualifier_id="212" value="39.9"/>
+      <Q id="6427511141" qualifier_id="213" value="0.55"/>
+    </Event>
+    <Event id="2939636221" event_id="291" type_id="5" period_id="1" min="30" sec="30" player_id="180662" team_id="244" outcome="0" x="67.6" y="101.4" timestamp="2026-05-18T18:47:52.927" timestamp_utc="2026-05-18T17:47:52.927" last_modified="2026-05-18T19:36:56" version="1779129407977">
+      <Q id="6427511161" qualifier_id="56" value="Left"/>
+      <Q id="6427511849" qualifier_id="233" value="191"/>
+      <Q id="6427511163" qualifier_id="347"/>
+    </Event>
+    <Event id="2939636339" event_id="191" type_id="5" period_id="1" min="30" sec="30" player_id="61812" team_id="417" outcome="1" x="32.4" y="-1.4" timestamp="2026-05-18T18:47:52.927" timestamp_utc="2026-05-18T17:47:52.927" last_modified="2026-05-18T19:36:55" version="1779129407973">
+      <Q id="6427511799" qualifier_id="56" value="Back"/>
+      <Q id="6427511821" qualifier_id="233" value="291"/>
+      <Q id="6427511801" qualifier_id="347"/>
+    </Event>
+    <Event id="2939636379" event_id="192" type_id="1" period_id="1" min="30" sec="42" player_id="531784" team_id="417" outcome="0" x="32.2" y="0.0" timestamp="2026-05-18T18:48:04.887" timestamp_utc="2026-05-18T17:48:04.887" last_modified="2026-05-18T18:48:13" version="1779126491651">
+      <Q id="6427511973" qualifier_id="1"/>
+      <Q id="6427511963" qualifier_id="56" value="Right"/>
+      <Q id="6427511961" qualifier_id="107"/>
+      <Q id="6427511965" qualifier_id="140" value="56.3"/>
+      <Q id="6427511967" qualifier_id="141" value="17.0"/>
+      <Q id="6427511969" qualifier_id="212" value="28.4"/>
+      <Q id="6427511971" qualifier_id="213" value="0.47"/>
+    </Event>
+    <Event id="2939636383" event_id="193" type_id="4" period_id="1" min="30" sec="45" player_id="61778" team_id="417" outcome="1" x="61.4" y="25.0" timestamp="2026-05-18T18:48:07.903" timestamp_utc="2026-05-18T17:48:07.903" last_modified="2026-05-18T18:48:14" version="1779126492107">
+      <Q id="6427512123" qualifier_id="13"/>
+      <Q id="6427512127" qualifier_id="56" value="Center"/>
+      <Q id="6427512129" qualifier_id="152"/>
+      <Q id="6427512143" qualifier_id="233" value="292"/>
+      <Q id="6427512131" qualifier_id="286"/>
+      <Q id="6427512125" qualifier_id="294"/>
+    </Event>
+    <Event id="2939636371" event_id="292" type_id="4" period_id="1" min="30" sec="45" player_id="232091" team_id="244" outcome="0" x="38.6" y="75.0" timestamp="2026-05-18T18:48:07.904" timestamp_utc="2026-05-18T17:48:07.904" last_modified="2026-05-18T18:48:15" version="1779126495028">
+      <Q id="6427511997" qualifier_id="13"/>
+      <Q id="6427511999" qualifier_id="56" value="Back"/>
+      <Q id="6427512001" qualifier_id="152"/>
+      <Q id="6427512275" qualifier_id="233" value="193"/>
+      <Q id="6427512005" qualifier_id="285"/>
+      <Q id="6427512299" qualifier_id="294"/>
+    </Event>
+    <Event id="2939636531" event_id="194" type_id="1" period_id="1" min="31" sec="1" player_id="218339" team_id="417" outcome="1" x="60.4" y="13.8" timestamp="2026-05-18T18:48:24.119" timestamp_utc="2026-05-18T17:48:24.119" last_modified="2026-05-18T18:48:26" version="1779126504689">
+      <Q id="6427512949" qualifier_id="5"/>
+      <Q id="6427512953" qualifier_id="56" value="Back"/>
+      <Q id="6427512955" qualifier_id="140" value="48.0"/>
+      <Q id="6427512957" qualifier_id="141" value="17.9"/>
+      <Q id="6427512951" qualifier_id="152"/>
+      <Q id="6427512959" qualifier_id="212" value="13.3"/>
+      <Q id="6427512961" qualifier_id="213" value="2.93"/>
+    </Event>
+    <Event id="2939636565" event_id="195" type_id="1" period_id="1" min="31" sec="3" player_id="531784" team_id="417" outcome="1" x="53.1" y="21.9" timestamp="2026-05-18T18:48:26.399" timestamp_utc="2026-05-18T17:48:26.399" last_modified="2026-05-18T18:48:31" version="1779126510321">
+      <Q id="6427513285" qualifier_id="1"/>
+      <Q id="6427513275" qualifier_id="56" value="Left"/>
+      <Q id="6427513277" qualifier_id="140" value="75.8"/>
+      <Q id="6427513279" qualifier_id="141" value="93.3"/>
+      <Q id="6427513271" qualifier_id="155"/>
+      <Q id="6427513273" qualifier_id="196"/>
+      <Q id="6427513281" qualifier_id="212" value="54.1"/>
+      <Q id="6427513283" qualifier_id="213" value="1.11"/>
+    </Event>
+    <Event id="2939636573" event_id="196" type_id="44" period_id="1" min="31" sec="8" player_id="164593" team_id="417" outcome="1" x="75.8" y="93.3" timestamp="2026-05-18T18:48:31.167" timestamp_utc="2026-05-18T17:48:31.167" last_modified="2026-05-18T19:37:40" version="1779129460515">
+      <Q id="6427513321" qualifier_id="56" value="Left"/>
+      <Q id="6427513449" qualifier_id="233" value="293"/>
+      <Q id="6427513323" qualifier_id="286"/>
+    </Event>
+    <Event id="2939636589" event_id="293" type_id="44" period_id="1" min="31" sec="8" player_id="240166" team_id="244" outcome="0" x="24.2" y="6.7" timestamp="2026-05-18T18:48:31.168" timestamp_utc="2026-05-18T17:48:31.168" last_modified="2026-05-18T19:37:41" version="1779129460776">
+      <Q id="6427513413" qualifier_id="56" value="Back"/>
+      <Q id="6427513463" qualifier_id="233" value="196"/>
+      <Q id="6427513415" qualifier_id="285"/>
+    </Event>
+    <Event id="2939636575" event_id="197" type_id="61" period_id="1" min="31" sec="8" player_id="164593" team_id="417" outcome="0" x="75.8" y="93.3" timestamp="2026-05-18T18:48:31.423" timestamp_utc="2026-05-18T17:48:31.423" last_modified="2026-05-18T18:48:31" version="1779126511424">
+      <Q id="6427513325" qualifier_id="56" value="Left"/>
+    </Event>
+    <Event id="2939636633" event_id="294" type_id="56" period_id="1" min="31" sec="10" player_id="240166" team_id="244" outcome="1" x="19.8" y="4.9" timestamp="2026-05-18T18:48:33.520" timestamp_utc="2026-05-18T17:48:33.520" last_modified="2026-05-18T18:48:42" version="1779126522329">
+      <Q id="6427513613" qualifier_id="56" value="Back"/>
+    </Event>
+    <Event id="2939636649" event_id="198" type_id="5" period_id="1" min="31" sec="13" player_id="164593" team_id="417" outcome="0" x="81.9" y="101.4" timestamp="2026-05-18T18:48:36.367" timestamp_utc="2026-05-18T17:48:36.367" last_modified="2026-05-18T19:36:56" version="1779129407985">
+      <Q id="6427513707" qualifier_id="56" value="Left"/>
+      <Q id="6427514083" qualifier_id="233" value="295"/>
+      <Q id="6427513709" qualifier_id="347"/>
+    </Event>
+    <Event id="2939636705" event_id="295" type_id="5" period_id="1" min="31" sec="13" player_id="240166" team_id="244" outcome="1" x="18.1" y="-1.4" timestamp="2026-05-18T18:48:36.367" timestamp_utc="2026-05-18T17:48:36.367" last_modified="2026-05-18T19:36:56" version="1779129407981">
+      <Q id="6427514035" qualifier_id="56" value="Back"/>
+      <Q id="6427514065" qualifier_id="233" value="198"/>
+      <Q id="6427514037" qualifier_id="347"/>
+    </Event>
+    <Event id="2939636807" event_id="296" type_id="1" period_id="1" min="31" sec="28" player_id="240166" team_id="244" outcome="1" x="18.3" y="0.0" timestamp="2026-05-18T18:48:51.129" timestamp_utc="2026-05-18T17:48:51.129" last_modified="2026-05-18T18:48:52" version="1779126531529">
+      <Q id="6427514615" qualifier_id="56" value="Back"/>
+      <Q id="6427514613" qualifier_id="107"/>
+      <Q id="6427514617" qualifier_id="140" value="22.5"/>
+      <Q id="6427514619" qualifier_id="141" value="18.0"/>
+      <Q id="6427514621" qualifier_id="212" value="14.1"/>
+      <Q id="6427514623" qualifier_id="213" value="1.25"/>
+    </Event>
+    <Event id="2939636833" event_id="297" type_id="1" period_id="1" min="31" sec="29" player_id="207884" team_id="244" outcome="0" x="22.5" y="18.0" timestamp="2026-05-18T18:48:52.538" timestamp_utc="2026-05-18T17:48:52.538" last_modified="2026-05-18T18:48:55" version="1779126535176">
+      <Q id="6427514755" qualifier_id="1"/>
+      <Q id="6427514745" qualifier_id="56" value="Back"/>
+      <Q id="6427514747" qualifier_id="140" value="40.7"/>
+      <Q id="6427514749" qualifier_id="141" value="23.6"/>
+      <Q id="6427514743" qualifier_id="157"/>
+      <Q id="6427514751" qualifier_id="212" value="19.5"/>
+      <Q id="6427514753" qualifier_id="213" value="0.20"/>
+    </Event>
+    <Event id="2939636863" event_id="199" type_id="1" period_id="1" min="31" sec="32" player_id="531784" team_id="417" outcome="1" x="57.2" y="78.2" timestamp="2026-05-18T18:48:55.366" timestamp_utc="2026-05-18T17:48:55.366" last_modified="2026-05-18T18:48:57" version="1779126536384">
+      <Q id="6427514889" qualifier_id="3"/>
+      <Q id="6427514891" qualifier_id="56" value="Left"/>
+      <Q id="6427514893" qualifier_id="140" value="62.5"/>
+      <Q id="6427514895" qualifier_id="141" value="90.5"/>
+      <Q id="6427514897" qualifier_id="212" value="10.0"/>
+      <Q id="6427514899" qualifier_id="213" value="0.98"/>
+    </Event>
+    <Event id="2939636873" event_id="200" type_id="44" period_id="1" min="31" sec="34" player_id="720682" team_id="417" outcome="1" x="62.5" y="90.5" timestamp="2026-05-18T18:48:56.946" timestamp_utc="2026-05-18T17:48:56.946" last_modified="2026-05-18T19:37:38" version="1779129457889">
+      <Q id="6427514959" qualifier_id="56" value="Left"/>
+      <Q id="6427561307" qualifier_id="233" value="384"/>
+      <Q id="6427514961" qualifier_id="286"/>
+    </Event>
+    <Event id="2939644891" event_id="384" type_id="44" period_id="1" min="31" sec="34" player_id="232091" team_id="244" outcome="0" x="37.5" y="9.5" timestamp="2026-05-18T18:48:56.947" timestamp_utc="2026-05-18T17:48:56.947" last_modified="2026-05-18T19:37:38" version="1779129458153">
+      <Q id="6427561299" qualifier_id="56" value="Back"/>
+      <Q id="6427561317" qualifier_id="233" value="200"/>
+      <Q id="6427561301" qualifier_id="285"/>
+    </Event>
+    <Event id="2939636877" event_id="201" type_id="1" period_id="1" min="31" sec="35" player_id="720682" team_id="417" outcome="1" x="62.5" y="90.5" timestamp="2026-05-18T18:48:57.759" timestamp_utc="2026-05-18T17:48:57.759" last_modified="2026-05-18T19:37:38" version="1779129458412">
+      <Q id="6427514973" qualifier_id="3"/>
+      <Q id="6427514975" qualifier_id="56" value="Left"/>
+      <Q id="6427514979" qualifier_id="140" value="56.9"/>
+      <Q id="6427514983" qualifier_id="141" value="93.8"/>
+      <Q id="6427515019" qualifier_id="156"/>
+      <Q id="6427514987" qualifier_id="212" value="6.3"/>
+      <Q id="6427514989" qualifier_id="213" value="2.78"/>
+    </Event>
+    <Event id="2939636887" event_id="298" type_id="83" period_id="1" min="31" sec="35" player_id="232091" team_id="244" outcome="0" x="39.2" y="21.9" timestamp="2026-05-18T18:48:58.136" timestamp_utc="2026-05-18T17:48:58.136" last_modified="2026-05-18T19:06:09" version="1779127569473">
+      <Q id="6427515225" qualifier_id="399" value="624620"/>
+    </Event>
+    <Event id="2939645585" event_id="385" type_id="83" period_id="1" min="31" sec="36" player_id="207884" team_id="244" outcome="0" x="38.5" y="14.8" timestamp="2026-05-18T18:48:58.947" timestamp_utc="2026-05-18T17:48:58.947" last_modified="2026-05-18T19:06:15" version="1779127575093">
+      <Q id="6427566433" qualifier_id="399" value="624620"/>
+    </Event>
+    <Event id="2939636913" event_id="299" type_id="83" period_id="1" min="31" sec="37" player_id="232091" team_id="244" outcome="1" x="42.6" y="8.9" timestamp="2026-05-18T18:48:59.889" timestamp_utc="2026-05-18T17:48:59.889" last_modified="2026-05-18T19:06:20" version="1779127580139">
+      <Q id="6427567995" qualifier_id="399" value="624620"/>
+    </Event>
+    <Event id="2939646163" event_id="246" type_id="49" period_id="1" min="31" sec="37" player_id="624620" team_id="417" outcome="1" x="64.5" y="73.8" timestamp="2026-05-18T18:48:59.947" timestamp_utc="2026-05-18T17:48:59.947" last_modified="2026-05-18T19:06:16" version="1779127576781"/>
+    <Event id="2939636897" event_id="202" type_id="61" period_id="1" min="31" sec="38" player_id="624620" team_id="417" outcome="0" x="58.0" y="89.8" timestamp="2026-05-18T18:49:00.888" timestamp_utc="2026-05-18T17:49:00.888" last_modified="2026-05-18T19:04:54" version="1779127494483">
+      <Q id="6427515113" qualifier_id="56" value="Left"/>
+    </Event>
+    <Event id="2939636953" event_id="204" type_id="43" period_id="1" min="31" sec="38" player_id="624620" team_id="417" outcome="1" x="0.0" y="0.0" timestamp="2026-05-18T18:49:00.888" timestamp_utc="2026-05-18T17:49:00.888" last_modified="2026-05-18T19:07:49" version="1779127494945">
+      <Q id="6427515431" qualifier_id="56" value="Left"/>
+      <Q id="6427573099" qualifier_id="144" value="50"/>
+      <Q id="6427515607" qualifier_id="233" value="301"/>
+      <Q id="6427515433" qualifier_id="286" value="0"/>
+    </Event>
+    <Event id="2939646517" event_id="386" type_id="49" period_id="1" min="31" sec="38" player_id="207884" team_id="244" outcome="1" x="44.7" y="14.8" timestamp="2026-05-18T18:49:00.947" timestamp_utc="2026-05-18T17:49:00.947" last_modified="2026-05-18T19:06:49" version="1779127609136"/>
+    <Event id="2939636931" event_id="300" type_id="1" period_id="1" min="31" sec="40" player_id="207884" team_id="244" outcome="0" x="42.2" y="15.0" timestamp="2026-05-18T18:49:02.865" timestamp_utc="2026-05-18T17:49:02.865" last_modified="2026-05-18T18:49:03" version="1779126543128">
+      <Q id="6427515325" qualifier_id="56" value="Back"/>
+      <Q id="6427515327" qualifier_id="140" value="39.4"/>
+      <Q id="6427515329" qualifier_id="141" value="16.7"/>
+      <Q id="6427515331" qualifier_id="212" value="3.2"/>
+      <Q id="6427515333" qualifier_id="213" value="2.77"/>
+    </Event>
+    <Event id="2939636929" event_id="203" type_id="50" period_id="1" min="31" sec="40" player_id="624620" team_id="417" outcome="1" x="56.1" y="96.1" timestamp="2026-05-18T18:49:03.352" timestamp_utc="2026-05-18T17:49:03.352" last_modified="2026-05-18T19:22:28" version="1779128546350">
+      <Q id="6427515323" qualifier_id="56" value="Left"/>
+      <Q id="6427575869" qualifier_id="233" value="301"/>
+      <Q id="6427575829" qualifier_id="286"/>
+    </Event>
+    <Event id="2939636977" event_id="301" type_id="7" period_id="1" min="31" sec="40" player_id="232091" team_id="244" outcome="1" x="43.9" y="3.9" timestamp="2026-05-18T18:49:03.353" timestamp_utc="2026-05-18T17:49:03.353" last_modified="2026-05-18T19:22:27" version="1779128546346">
+      <Q id="6427515551" qualifier_id="56" value="Back"/>
+      <Q id="6427515555" qualifier_id="178"/>
+      <Q id="6427575845" qualifier_id="233" value="203"/>
+      <Q id="6427515553" qualifier_id="285"/>
+    </Event>
+    <Event id="2939636981" event_id="302" type_id="61" period_id="1" min="31" sec="45" player_id="625775" team_id="244" outcome="1" x="52.3" y="24.1" timestamp="2026-05-18T18:49:08.011" timestamp_utc="2026-05-18T17:49:08.011" last_modified="2026-05-18T18:49:08" version="1779126548012">
+      <Q id="6427515569" qualifier_id="56" value="Center"/>
+    </Event>
+    <Event id="2939637001" event_id="303" type_id="43" period_id="1" min="31" sec="47" player_id="479433" team_id="244" outcome="1" x="0.0" y="0.0" timestamp="2026-05-18T18:49:09.888" timestamp_utc="2026-05-18T17:49:09.888" last_modified="2026-05-18T19:07:12" version="1779126549889">
+      <Q id="6427571333" qualifier_id="144" value="49"/>
+    </Event>
+    <Event id="2939637007" event_id="304" type_id="1" period_id="1" min="31" sec="47" player_id="479433" team_id="244" outcome="1" x="55.7" y="35.1" timestamp="2026-05-18T18:49:10.120" timestamp_utc="2026-05-18T17:49:10.120" last_modified="2026-05-18T19:07:27" version="1779127646948">
+      <Q id="6427515695" qualifier_id="56" value="Center"/>
+      <Q id="6427515697" qualifier_id="140" value="50.2"/>
+      <Q id="6427515699" qualifier_id="141" value="41.5"/>
+      <Q id="6427515701" qualifier_id="212" value="7.2"/>
+      <Q id="6427515703" qualifier_id="213" value="2.50"/>
+    </Event>
+    <Event id="2939637017" event_id="305" type_id="1" period_id="1" min="31" sec="48" player_id="515742" team_id="244" outcome="1" x="57.0" y="22.1" timestamp="2026-05-18T18:49:11.576" timestamp_utc="2026-05-18T17:49:11.576" last_modified="2026-05-18T19:07:25" version="1779127645556">
+      <Q id="6427571945" qualifier_id="56" value="Center"/>
+      <Q id="6427571947" qualifier_id="140" value="63.8"/>
+      <Q id="6427571949" qualifier_id="141" value="39.3"/>
+      <Q id="6427571951" qualifier_id="212" value="13.7"/>
+      <Q id="6427571953" qualifier_id="213" value="1.02"/>
+    </Event>
+    <Event id="2939637049" event_id="205" type_id="83" period_id="1" min="31" sec="51" player_id="685390" team_id="417" outcome="0" x="29.3" y="21.0" timestamp="2026-05-18T18:49:14.374" timestamp_utc="2026-05-18T17:49:14.374" last_modified="2026-05-18T18:49:17" version="1779126557654">
+      <Q id="6427516089" qualifier_id="399" value="575855"/>
+    </Event>
+    <Event id="2939637075" event_id="306" type_id="1" period_id="1" min="31" sec="53" player_id="575855" team_id="244" outcome="1" x="72.2" y="82.0" timestamp="2026-05-18T18:49:15.776" timestamp_utc="2026-05-18T17:49:15.776" last_modified="2026-05-18T18:49:17" version="1779126556010">
+      <Q id="6427516065" qualifier_id="56" value="Left"/>
+      <Q id="6427516067" qualifier_id="140" value="66.6"/>
+      <Q id="6427516069" qualifier_id="141" value="80.0"/>
+      <Q id="6427516071" qualifier_id="212" value="6.0"/>
+      <Q id="6427516073" qualifier_id="213" value="3.37"/>
+    </Event>
+    <Event id="2939637093" event_id="307" type_id="1" period_id="1" min="31" sec="55" player_id="648131" team_id="244" outcome="1" x="66.5" y="82.4" timestamp="2026-05-18T18:49:18.528" timestamp_utc="2026-05-18T17:49:18.528" last_modified="2026-05-18T18:49:19" version="1779126558834">
+      <Q id="6427516161" qualifier_id="56" value="Left"/>
+      <Q id="6427516163" qualifier_id="140" value="57.5"/>
+      <Q id="6427516165" qualifier_id="141" value="81.4"/>
+      <Q id="6427516167" qualifier_id="212" value="9.5"/>
+      <Q id="6427516169" qualifier_id="213" value="3.21"/>
+    </Event>
+    <Event id="2939637123" event_id="308" type_id="1" period_id="1" min="31" sec="56" player_id="180662" team_id="244" outcome="1" x="55.5" y="80.0" timestamp="2026-05-18T18:49:19.328" timestamp_utc="2026-05-18T17:49:19.328" last_modified="2026-05-18T18:49:21" version="1779126559800">
+      <Q id="6427516323" qualifier_id="56" value="Back"/>
+      <Q id="6427516325" qualifier_id="140" value="49.3"/>
+      <Q id="6427516327" qualifier_id="141" value="56.9"/>
+      <Q id="6427516329" qualifier_id="212" value="17.0"/>
+      <Q id="6427516331" qualifier_id="213" value="4.32"/>
+    </Event>
+    <Event id="2939637181" event_id="309" type_id="1" period_id="1" min="31" sec="58" player_id="627127" team_id="244" outcome="1" x="50.8" y="53.9" timestamp="2026-05-18T18:49:21.512" timestamp_utc="2026-05-18T17:49:21.512" last_modified="2026-05-18T18:49:25" version="1779126561830">
+      <Q id="6427516621" qualifier_id="56" value="Center"/>
+      <Q id="6427516623" qualifier_id="140" value="56.5"/>
+      <Q id="6427516625" qualifier_id="141" value="28.2"/>
+      <Q id="6427516627" qualifier_id="212" value="18.5"/>
+      <Q id="6427516631" qualifier_id="213" value="5.04"/>
+    </Event>
+    <Event id="2939637259" event_id="310" type_id="1" period_id="1" min="32" sec="3" player_id="240166" team_id="244" outcome="1" x="57.4" y="32.2" timestamp="2026-05-18T18:49:25.664" timestamp_utc="2026-05-18T17:49:25.664" last_modified="2026-05-18T18:49:32" version="1779126566867">
+      <Q id="6427517021" qualifier_id="1"/>
+      <Q id="6427517011" qualifier_id="56" value="Left"/>
+      <Q id="6427517013" qualifier_id="140" value="68.4"/>
+      <Q id="6427517015" qualifier_id="141" value="81.2"/>
+      <Q id="6427517009" qualifier_id="155"/>
+      <Q id="6427517017" qualifier_id="212" value="35.3"/>
+      <Q id="6427517019" qualifier_id="213" value="1.24"/>
+    </Event>
+    <Event id="2939637299" event_id="311" type_id="1" period_id="1" min="32" sec="9" player_id="648131" team_id="244" outcome="1" x="66.8" y="78.8" timestamp="2026-05-18T18:49:31.992" timestamp_utc="2026-05-18T17:49:31.992" last_modified="2026-05-18T18:49:34" version="1779126572996">
+      <Q id="6427517239" qualifier_id="56" value="Left"/>
+      <Q id="6427517241" qualifier_id="140" value="84.9"/>
+      <Q id="6427517243" qualifier_id="141" value="90.3"/>
+      <Q id="6427517245" qualifier_id="212" value="20.6"/>
+      <Q id="6427517247" qualifier_id="213" value="0.39"/>
+    </Event>
+    <Event id="2939637321" event_id="312" type_id="1" period_id="1" min="32" sec="11" player_id="575855" team_id="244" outcome="1" x="82.5" y="91.2" timestamp="2026-05-18T18:49:34.536" timestamp_utc="2026-05-18T17:49:34.536" last_modified="2026-05-18T18:49:37" version="1779126574737">
+      <Q id="6427517377" qualifier_id="56" value="Left"/>
+      <Q id="6427517379" qualifier_id="140" value="75.7"/>
+      <Q id="6427517381" qualifier_id="141" value="89.1"/>
+      <Q id="6427517383" qualifier_id="212" value="7.3"/>
+      <Q id="6427517385" qualifier_id="213" value="3.34"/>
+    </Event>
+    <Event id="2939637359" event_id="313" type_id="1" period_id="1" min="32" sec="14" player_id="648131" team_id="244" outcome="1" x="66.2" y="86.8" timestamp="2026-05-18T18:49:37.136" timestamp_utc="2026-05-18T17:49:37.136" last_modified="2026-05-18T18:49:40" version="1779126577853">
+      <Q id="6427517615" qualifier_id="56" value="Center"/>
+      <Q id="6427517617" qualifier_id="140" value="55.1"/>
+      <Q id="6427517619" qualifier_id="141" value="75.4"/>
+      <Q id="6427517621" qualifier_id="212" value="14.0"/>
+      <Q id="6427517623" qualifier_id="213" value="3.73"/>
+    </Event>
+    <Event id="2939637423" event_id="314" type_id="1" period_id="1" min="32" sec="17" player_id="180662" team_id="244" outcome="1" x="49.9" y="58.4" timestamp="2026-05-18T18:49:40.104" timestamp_utc="2026-05-18T17:49:40.104" last_modified="2026-05-18T18:49:45" version="1779126580601">
+      <Q id="6427517939" qualifier_id="56" value="Back"/>
+      <Q id="6427517941" qualifier_id="140" value="48.7"/>
+      <Q id="6427517943" qualifier_id="141" value="45.7"/>
+      <Q id="6427517945" qualifier_id="212" value="8.7"/>
+      <Q id="6427517947" qualifier_id="213" value="4.57"/>
+    </Event>
+    <Event id="2939637437" event_id="315" type_id="1" period_id="1" min="32" sec="22" player_id="627127" team_id="244" outcome="1" x="41.8" y="15.3" timestamp="2026-05-18T18:49:45.232" timestamp_utc="2026-05-18T17:49:45.232" last_modified="2026-05-18T18:49:46" version="1779126585488">
+      <Q id="6427518009" qualifier_id="56" value="Right"/>
+      <Q id="6427518011" qualifier_id="140" value="56.0"/>
+      <Q id="6427518013" qualifier_id="141" value="9.1"/>
+      <Q id="6427518015" qualifier_id="212" value="15.5"/>
+      <Q id="6427518017" qualifier_id="213" value="6.01"/>
+    </Event>
+    <Event id="2939637459" event_id="316" type_id="1" period_id="1" min="32" sec="24" player_id="207884" team_id="244" outcome="1" x="58.1" y="8.5" timestamp="2026-05-18T18:49:46.744" timestamp_utc="2026-05-18T17:49:46.744" last_modified="2026-05-18T18:49:49" version="1779126587090">
+      <Q id="6427518127" qualifier_id="56" value="Center"/>
+      <Q id="6427518129" qualifier_id="140" value="56.5"/>
+      <Q id="6427518131" qualifier_id="141" value="23.6"/>
+      <Q id="6427518133" qualifier_id="212" value="10.4"/>
+      <Q id="6427518135" qualifier_id="213" value="1.73"/>
+    </Event>
+    <Event id="2939637519" event_id="317" type_id="1" period_id="1" min="32" sec="26" player_id="515742" team_id="244" outcome="1" x="54.5" y="31.9" timestamp="2026-05-18T18:49:48.919" timestamp_utc="2026-05-18T17:49:48.919" last_modified="2026-05-18T18:49:54" version="1779126590722">
+      <Q id="6427518487" qualifier_id="56" value="Center"/>
+      <Q id="6427518489" qualifier_id="140" value="65.5"/>
+      <Q id="6427518491" qualifier_id="141" value="67.2"/>
+      <Q id="6427518493" qualifier_id="212" value="26.6"/>
+      <Q id="6427518495" qualifier_id="213" value="1.12"/>
+    </Event>
+    <Event id="2939637543" event_id="318" type_id="1" period_id="1" min="32" sec="31" player_id="575855" team_id="244" outcome="0" x="64.4" y="85.9" timestamp="2026-05-18T18:49:53.936" timestamp_utc="2026-05-18T17:49:53.936" last_modified="2026-05-18T18:49:56" version="1779126596089">
+      <Q id="6427518605" qualifier_id="56" value="Left"/>
+      <Q id="6427518609" qualifier_id="140" value="79.1"/>
+      <Q id="6427518611" qualifier_id="141" value="100.0"/>
+      <Q id="6427518613" qualifier_id="212" value="18.6"/>
+      <Q id="6427518615" qualifier_id="213" value="0.59"/>
+    </Event>
+    <Event id="2939637547" event_id="319" type_id="5" period_id="1" min="32" sec="32" player_id="575855" team_id="244" outcome="0" x="75.4" y="101.2" timestamp="2026-05-18T18:49:55.470" timestamp_utc="2026-05-18T17:49:55.470" last_modified="2026-05-18T19:36:57" version="1779129407995">
+      <Q id="6427518649" qualifier_id="56" value="Left"/>
+      <Q id="6427519541" qualifier_id="233" value="206"/>
+      <Q id="6427518653" qualifier_id="347"/>
+    </Event>
+    <Event id="2939637703" event_id="206" type_id="5" period_id="1" min="32" sec="32" player_id="157851" team_id="417" outcome="1" x="24.6" y="-1.2" timestamp="2026-05-18T18:49:55.470" timestamp_utc="2026-05-18T17:49:55.470" last_modified="2026-05-18T19:36:56" version="1779129407989">
+      <Q id="6427519501" qualifier_id="56" value="Back"/>
+      <Q id="6427519525" qualifier_id="233" value="319"/>
+      <Q id="6427519503" qualifier_id="347"/>
+    </Event>
+    <Event id="2939637743" event_id="207" type_id="1" period_id="1" min="32" sec="46" player_id="157851" team_id="417" outcome="1" x="28.9" y="0.0" timestamp="2026-05-18T18:50:09.006" timestamp_utc="2026-05-18T17:50:09.006" last_modified="2026-05-18T18:50:12" version="1779126611262">
+      <Q id="6427519699" qualifier_id="1"/>
+      <Q id="6427519689" qualifier_id="56" value="Right"/>
+      <Q id="6427519687" qualifier_id="107"/>
+      <Q id="6427519691" qualifier_id="140" value="56.1"/>
+      <Q id="6427519693" qualifier_id="141" value="12.9"/>
+      <Q id="6427519695" qualifier_id="212" value="30.2"/>
+      <Q id="6427519697" qualifier_id="213" value="0.33"/>
+    </Event>
+    <Event id="2939637749" event_id="208" type_id="61" period_id="1" min="32" sec="50" player_id="445539" team_id="417" outcome="0" x="58.3" y="14.7" timestamp="2026-05-18T18:50:12.690" timestamp_utc="2026-05-18T17:50:12.690" last_modified="2026-05-18T18:50:13" version="1779126612692">
+      <Q id="6427519737" qualifier_id="56" value="Right"/>
+    </Event>
+    <Event id="2939637779" event_id="320" type_id="49" period_id="1" min="32" sec="53" player_id="180662" team_id="244" outcome="1" x="44.9" y="79.0" timestamp="2026-05-18T18:50:15.935" timestamp_utc="2026-05-18T17:50:15.935" last_modified="2026-05-18T19:02:40" version="1779127360142"/>
+    <Event id="2939637803" event_id="321" type_id="1" period_id="1" min="32" sec="54" player_id="180662" team_id="244" outcome="1" x="44.9" y="79.0" timestamp="2026-05-18T18:50:16.783" timestamp_utc="2026-05-18T17:50:16.783" last_modified="2026-05-18T18:59:34" version="1779127174257">
+      <Q id="6427520081" qualifier_id="56" value="Back"/>
+      <Q id="6427520083" qualifier_id="140" value="33.0"/>
+      <Q id="6427520085" qualifier_id="141" value="64.0"/>
+      <Q id="6427520087" qualifier_id="212" value="16.1"/>
+      <Q id="6427520089" qualifier_id="213" value="3.83"/>
+    </Event>
+    <Event id="2939637833" event_id="322" type_id="1" period_id="1" min="32" sec="54" player_id="627127" team_id="244" outcome="1" x="32.8" y="64.3" timestamp="2026-05-18T18:50:17.599" timestamp_utc="2026-05-18T17:50:17.599" last_modified="2026-05-18T18:50:19" version="1779126617801">
+      <Q id="6427520229" qualifier_id="56" value="Back"/>
+      <Q id="6427520231" qualifier_id="140" value="29.2"/>
+      <Q id="6427520233" qualifier_id="141" value="35.1"/>
+      <Q id="6427520235" qualifier_id="212" value="20.2"/>
+      <Q id="6427520237" qualifier_id="213" value="4.52"/>
+    </Event>
+    <Event id="2939637843" event_id="323" type_id="1" period_id="1" min="32" sec="56" player_id="240166" team_id="244" outcome="1" x="30.1" y="35.2" timestamp="2026-05-18T18:50:19.488" timestamp_utc="2026-05-18T17:50:19.488" last_modified="2026-05-18T18:50:20" version="1779126619696">
+      <Q id="6427520301" qualifier_id="56" value="Back"/>
+      <Q id="6427520303" qualifier_id="140" value="28.9"/>
+      <Q id="6427520305" qualifier_id="141" value="46.1"/>
+      <Q id="6427520307" qualifier_id="212" value="7.5"/>
+      <Q id="6427520309" qualifier_id="213" value="1.74"/>
+    </Event>
+    <Event id="2939637899" event_id="324" type_id="1" period_id="1" min="32" sec="57" player_id="627127" team_id="244" outcome="1" x="28.9" y="46.1" timestamp="2026-05-18T18:50:20.007" timestamp_utc="2026-05-18T17:50:20.007" last_modified="2026-05-18T18:50:24" version="1779126620984">
+      <Q id="6427520627" qualifier_id="56" value="Back"/>
+      <Q id="6427520629" qualifier_id="140" value="10.6"/>
+      <Q id="6427520631" qualifier_id="141" value="48.1"/>
+      <Q id="6427520633" qualifier_id="212" value="19.3"/>
+      <Q id="6427520635" qualifier_id="213" value="3.07"/>
+    </Event>
+    <Event id="2939637985" event_id="325" type_id="1" period_id="1" min="33" sec="2" player_id="578592" team_id="244" outcome="1" x="12.2" y="54.5" keypass="1" timestamp="2026-05-18T18:50:24.704" timestamp_utc="2026-05-18T17:50:24.704" last_modified="2026-05-18T18:50:55" version="1779126655127">
+      <Q id="6427521147" qualifier_id="1"/>
+      <Q id="6427521137" qualifier_id="56" value="Center"/>
+      <Q id="6427521139" qualifier_id="140" value="80.3"/>
+      <Q id="6427521141" qualifier_id="141" value="63.3"/>
+      <Q id="6427522763" qualifier_id="154"/>
+      <Q id="6427521135" qualifier_id="157"/>
+      <Q id="6427522761" qualifier_id="210" value="15"/>
+      <Q id="6427521143" qualifier_id="212" value="71.8"/>
+      <Q id="6427521145" qualifier_id="213" value="0.08"/>
+    </Event>
+    <Event id="2939637987" event_id="326" type_id="15" period_id="1" min="33" sec="8" player_id="479433" team_id="244" outcome="1" x="84.7" y="54.5" timestamp="2026-05-18T18:50:30.943" timestamp_utc="2026-05-18T17:50:30.943" last_modified="2026-05-18T18:59:02" version="1779127142201">
+      <Q id="6427521153" qualifier_id="17"/>
+      <Q id="6427522095" qualifier_id="20"/>
+      <Q id="6427521151" qualifier_id="22"/>
+      <Q id="6427522777" qualifier_id="29"/>
+      <Q id="6427522781" qualifier_id="55" value="325"/>
+      <Q id="6427521155" qualifier_id="56" value="Center"/>
+      <Q id="6427545991" qualifier_id="76"/>
+      <Q id="6427522789" qualifier_id="82"/>
+      <Q id="6427522785" qualifier_id="102" value="53.4"/>
+      <Q id="6427522787" qualifier_id="103" value="19.0"/>
+      <Q id="6427522791" qualifier_id="146" value="87.1"/>
+      <Q id="6427522793" qualifier_id="147" value="54.3"/>
+      <Q id="6427522779" qualifier_id="154"/>
+      <Q id="6427522795" qualifier_id="230" value="91.6"/>
+      <Q id="6427522797" qualifier_id="231" value="52.2"/>
+      <Q id="6427526173" qualifier_id="233" value="209"/>
+    </Event>
+    <Event id="2939637995" event_id="209" type_id="10" period_id="1" min="33" sec="8" player_id="531784" team_id="417" outcome="1" x="10.2" y="47.8" timestamp="2026-05-18T18:50:31.043" timestamp_utc="2026-05-18T17:50:31.043" last_modified="2026-05-18T19:06:46" version="1779127606701">
+      <Q id="6427521203" qualifier_id="56" value="Back"/>
+      <Q id="6427526141" qualifier_id="94"/>
+      <Q id="6427526233" qualifier_id="233" value="326"/>
+    </Event>
+    <Event id="2939638099" event_id="327" type_id="1" period_id="1" min="33" sec="14" player_id="625775" team_id="244" outcome="0" x="89.2" y="14.8" timestamp="2026-05-18T18:50:37.471" timestamp_utc="2026-05-18T17:50:37.471" last_modified="2026-05-18T18:52:00" version="1779126720091">
+      <Q id="6427526807" qualifier_id="1"/>
+      <Q id="6427521823" qualifier_id="2"/>
+      <Q id="6427521827" qualifier_id="56" value="Left"/>
+      <Q id="6427521829" qualifier_id="140" value="100.0"/>
+      <Q id="6427521831" qualifier_id="141" value="87.3"/>
+      <Q id="6427521825" qualifier_id="155"/>
+      <Q id="6427521833" qualifier_id="212" value="50.8"/>
+      <Q id="6427521835" qualifier_id="213" value="1.33"/>
+    </Event>
+    <Event id="2939638103" event_id="328" type_id="5" period_id="1" min="33" sec="17" player_id="625775" team_id="244" outcome="0" x="100.7" y="45.4" timestamp="2026-05-18T18:50:40.221" timestamp_utc="2026-05-18T17:50:40.221" last_modified="2026-05-18T19:36:57" version="1779129407999">
+      <Q id="6427521851" qualifier_id="56" value="Center"/>
+      <Q id="6427522079" qualifier_id="233" value="210"/>
+      <Q id="6427523307" qualifier_id="346"/>
+    </Event>
+    <Event id="2939638127" event_id="210" type_id="5" period_id="1" min="33" sec="17" player_id="565487" team_id="417" outcome="1" x="-0.7" y="54.6" timestamp="2026-05-18T18:50:40.221" timestamp_utc="2026-05-18T17:50:40.221" last_modified="2026-05-18T18:51:07" version="1779126667430">
+      <Q id="6427521999" qualifier_id="56" value="Back"/>
+      <Q id="6427522037" qualifier_id="233" value="328"/>
+      <Q id="6427523303" qualifier_id="346"/>
+    </Event>
+    <Event id="2939638389" event_id="211" type_id="43" period_id="1" min="33" sec="42" player_id="565487" team_id="417" outcome="1" x="0.0" y="0.0" timestamp="2026-05-18T18:51:05.077" timestamp_utc="2026-05-18T17:51:05.077" last_modified="2026-05-18T18:51:12" version="1779126665647">
+      <Q id="6427523513" qualifier_id="56" value="Back"/>
+      <Q id="6427523511" qualifier_id="124" value="0"/>
+      <Q id="6427523515" qualifier_id="140" value="7.1"/>
+      <Q id="6427523517" qualifier_id="141" value="29.4"/>
+      <Q id="6427523933" qualifier_id="144" value="1"/>
+      <Q id="6427523519" qualifier_id="212" value="16.5"/>
+      <Q id="6427523521" qualifier_id="213" value="4.98"/>
+      <Q id="6427523525" qualifier_id="237" value="0"/>
+    </Event>
+    <Event id="2939638701" event_id="212" type_id="1" period_id="1" min="34" sec="7" player_id="565487" team_id="417" outcome="0" x="2.7" y="46.4" timestamp="2026-05-18T18:51:30.412" timestamp_utc="2026-05-18T17:51:30.412" last_modified="2026-05-18T18:51:35" version="1779126695816">
+      <Q id="6427525385" qualifier_id="1"/>
+      <Q id="6427525375" qualifier_id="56" value="Center"/>
+      <Q id="6427525387" qualifier_id="74"/>
+      <Q id="6427525373" qualifier_id="124"/>
+      <Q id="6427525377" qualifier_id="140" value="78.3"/>
+      <Q id="6427525379" qualifier_id="141" value="32.7"/>
+      <Q id="6427525381" qualifier_id="212" value="79.9"/>
+      <Q id="6427525383" qualifier_id="213" value="6.17"/>
+    </Event>
+    <Event id="2939638747" event_id="329" type_id="1" period_id="1" min="34" sec="13" player_id="180662" team_id="244" outcome="1" x="24.6" y="71.7" timestamp="2026-05-18T18:51:36.150" timestamp_utc="2026-05-18T17:51:36.150" last_modified="2026-05-18T18:51:39" version="1779126697032">
+      <Q id="6427525653" qualifier_id="3"/>
+      <Q id="6427525655" qualifier_id="56" value="Back"/>
+      <Q id="6427525657" qualifier_id="140" value="7.6"/>
+      <Q id="6427525659" qualifier_id="141" value="65.2"/>
+      <Q id="6427525661" qualifier_id="212" value="18.4"/>
+      <Q id="6427525663" qualifier_id="213" value="3.38"/>
+    </Event>
+    <Event id="2939638749" event_id="330" type_id="52" period_id="1" min="34" sec="17" player_id="578592" team_id="244" outcome="1" x="6.8" y="68.1" timestamp="2026-05-18T18:51:39.735" timestamp_utc="2026-05-18T17:51:39.735" last_modified="2026-05-18T18:51:40" version="1779126699736"/>
+    <Event id="2939638813" event_id="331" type_id="1" period_id="1" min="34" sec="21" player_id="578592" team_id="244" outcome="1" x="10.0" y="55.4" timestamp="2026-05-18T18:51:43.991" timestamp_utc="2026-05-18T17:51:43.991" last_modified="2026-05-18T18:51:46" version="1779126705089">
+      <Q id="6427526021" qualifier_id="56" value="Back"/>
+      <Q id="6427526019" qualifier_id="123"/>
+      <Q id="6427526023" qualifier_id="140" value="15.9"/>
+      <Q id="6427526025" qualifier_id="141" value="33.6"/>
+      <Q id="6427526027" qualifier_id="212" value="16.1"/>
+      <Q id="6427526029" qualifier_id="213" value="5.11"/>
+    </Event>
+    <Event id="2939638851" event_id="332" type_id="1" period_id="1" min="34" sec="23" player_id="627127" team_id="244" outcome="1" x="25.7" y="37.3" timestamp="2026-05-18T18:51:46.534" timestamp_utc="2026-05-18T17:51:46.534" last_modified="2026-05-18T18:51:49" version="1779126707040">
+      <Q id="6427526241" qualifier_id="56" value="Back"/>
+      <Q id="6427526243" qualifier_id="140" value="39.6"/>
+      <Q id="6427526245" qualifier_id="141" value="41.6"/>
+      <Q id="6427526247" qualifier_id="212" value="14.9"/>
+      <Q id="6427526251" qualifier_id="213" value="0.20"/>
+    </Event>
+    <Event id="2939638893" event_id="333" type_id="1" period_id="1" min="34" sec="25" player_id="207884" team_id="244" outcome="1" x="39.8" y="38.3" timestamp="2026-05-18T18:51:48.615" timestamp_utc="2026-05-18T17:51:48.615" last_modified="2026-05-18T18:51:52" version="1779126708775">
+      <Q id="6427526441" qualifier_id="56" value="Back"/>
+      <Q id="6427526443" qualifier_id="140" value="44.5"/>
+      <Q id="6427526445" qualifier_id="141" value="30.0"/>
+      <Q id="6427526447" qualifier_id="212" value="7.5"/>
+      <Q id="6427526449" qualifier_id="213" value="5.43"/>
+    </Event>
+    <Event id="2939638897" event_id="334" type_id="1" period_id="1" min="34" sec="30" player_id="625775" team_id="244" outcome="0" x="40.8" y="32.5" timestamp="2026-05-18T18:51:52.719" timestamp_utc="2026-05-18T17:51:52.719" last_modified="2026-05-18T18:51:53" version="1779126713023">
+      <Q id="6427526469" qualifier_id="1"/>
+      <Q id="6427526459" qualifier_id="56" value="Center"/>
+      <Q id="6427526461" qualifier_id="140" value="63.3"/>
+      <Q id="6427526463" qualifier_id="141" value="69.1"/>
+      <Q id="6427526457" qualifier_id="155"/>
+      <Q id="6427526465" qualifier_id="212" value="34.3"/>
+      <Q id="6427526467" qualifier_id="213" value="0.81"/>
+    </Event>
+    <Event id="2939638895" event_id="213" type_id="49" period_id="1" min="34" sec="30" player_id="157851" team_id="417" outcome="1" x="34.9" y="34.0" timestamp="2026-05-18T18:51:52.972" timestamp_utc="2026-05-18T17:51:52.972" last_modified="2026-05-18T18:51:53" version="1779126712973"/>
+    <Event id="2939638945" event_id="214" type_id="1" period_id="1" min="34" sec="30" player_id="157851" team_id="417" outcome="1" x="34.4" y="33.7" timestamp="2026-05-18T18:51:53.444" timestamp_utc="2026-05-18T17:51:53.444" last_modified="2026-05-18T18:51:57" version="1779126715334">
+      <Q id="6427526717" qualifier_id="56" value="Back"/>
+      <Q id="6427526719" qualifier_id="140" value="11.9"/>
+      <Q id="6427526721" qualifier_id="141" value="50.1"/>
+      <Q id="6427526723" qualifier_id="212" value="26.1"/>
+      <Q id="6427526725" qualifier_id="213" value="2.70"/>
+    </Event>
+    <Event id="2939638975" event_id="215" type_id="1" period_id="1" min="34" sec="34" player_id="565487" team_id="417" outcome="1" x="13.4" y="43.4" timestamp="2026-05-18T18:51:56.940" timestamp_utc="2026-05-18T17:51:56.940" last_modified="2026-05-18T18:52:00" version="1779126718046">
+      <Q id="6427526911" qualifier_id="56" value="Back"/>
+      <Q id="6427526913" qualifier_id="140" value="26.9"/>
+      <Q id="6427526915" qualifier_id="141" value="35.2"/>
+      <Q id="6427526917" qualifier_id="212" value="15.2"/>
+      <Q id="6427526919" qualifier_id="213" value="5.91"/>
+    </Event>
+    <Event id="2939639001" event_id="216" type_id="1" period_id="1" min="34" sec="37" player_id="218339" team_id="417" outcome="1" x="27.5" y="32.8" timestamp="2026-05-18T18:52:00.548" timestamp_utc="2026-05-18T17:52:00.548" last_modified="2026-05-18T18:52:03" version="1779126721621">
+      <Q id="6427527057" qualifier_id="56" value="Back"/>
+      <Q id="6427527059" qualifier_id="140" value="42.0"/>
+      <Q id="6427527061" qualifier_id="141" value="26.1"/>
+      <Q id="6427527063" qualifier_id="212" value="15.9"/>
+      <Q id="6427527065" qualifier_id="213" value="5.99"/>
+    </Event>
+    <Event id="2939639025" event_id="217" type_id="1" period_id="1" min="34" sec="40" player_id="685390" team_id="417" outcome="1" x="41.7" y="25.5" timestamp="2026-05-18T18:52:02.956" timestamp_utc="2026-05-18T17:52:02.956" last_modified="2026-05-18T18:52:05" version="1779126723919">
+      <Q id="6427527193" qualifier_id="56" value="Back"/>
+      <Q id="6427527195" qualifier_id="140" value="40.1"/>
+      <Q id="6427527197" qualifier_id="141" value="5.0"/>
+      <Q id="6427527199" qualifier_id="212" value="14.0"/>
+      <Q id="6427527201" qualifier_id="213" value="4.59"/>
+    </Event>
+    <Event id="2939639061" event_id="218" type_id="1" period_id="1" min="34" sec="43" player_id="157851" team_id="417" outcome="1" x="36.9" y="5.2" timestamp="2026-05-18T18:52:05.868" timestamp_utc="2026-05-18T17:52:05.868" last_modified="2026-05-18T18:52:10" version="1779126727199">
+      <Q id="6427527415" qualifier_id="56" value="Back"/>
+      <Q id="6427527417" qualifier_id="140" value="22.0"/>
+      <Q id="6427527419" qualifier_id="141" value="15.2"/>
+      <Q id="6427527421" qualifier_id="212" value="17.1"/>
+      <Q id="6427527423" qualifier_id="213" value="2.73"/>
+    </Event>
+    <Event id="2939639087" event_id="219" type_id="1" period_id="1" min="34" sec="47" player_id="531784" team_id="417" outcome="1" x="22.7" y="16.4" timestamp="2026-05-18T18:52:10.084" timestamp_utc="2026-05-18T17:52:10.084" last_modified="2026-05-18T18:52:12" version="1779126731417">
+      <Q id="6427527585" qualifier_id="56" value="Back"/>
+      <Q id="6427527587" qualifier_id="140" value="46.5"/>
+      <Q id="6427527589" qualifier_id="141" value="34.0"/>
+      <Q id="6427527591" qualifier_id="212" value="27.7"/>
+      <Q id="6427527593" qualifier_id="213" value="0.45"/>
+    </Event>
+    <Event id="2939639113" event_id="220" type_id="1" period_id="1" min="34" sec="49" player_id="445539" team_id="417" outcome="1" x="46.5" y="34.0" timestamp="2026-05-18T18:52:12.508" timestamp_utc="2026-05-18T17:52:12.508" last_modified="2026-05-18T18:52:15" version="1779126732781">
+      <Q id="6427527763" qualifier_id="56" value="Back"/>
+      <Q id="6427527765" qualifier_id="140" value="43.7"/>
+      <Q id="6427527767" qualifier_id="141" value="26.5"/>
+      <Q id="6427527769" qualifier_id="212" value="5.9"/>
+      <Q id="6427527771" qualifier_id="213" value="4.19"/>
+    </Event>
+    <Event id="2939639137" event_id="221" type_id="1" period_id="1" min="34" sec="52" player_id="218339" team_id="417" outcome="1" x="58.6" y="21.3" timestamp="2026-05-18T18:52:15.476" timestamp_utc="2026-05-18T17:52:15.476" last_modified="2026-05-18T18:52:18" version="1779126736767">
+      <Q id="6427527909" qualifier_id="56" value="Center"/>
+      <Q id="6427527911" qualifier_id="140" value="72.7"/>
+      <Q id="6427527913" qualifier_id="141" value="58.5"/>
+      <Q id="6427527915" qualifier_id="212" value="29.3"/>
+      <Q id="6427527917" qualifier_id="213" value="1.04"/>
+    </Event>
+    <Event id="2939639141" event_id="222" type_id="50" period_id="1" min="34" sec="55" player_id="445539" team_id="417" outcome="1" x="72.3" y="54.6" timestamp="2026-05-18T18:52:17.957" timestamp_utc="2026-05-18T17:52:17.957" last_modified="2026-05-18T19:22:28" version="1779128546362">
+      <Q id="6427527935" qualifier_id="56" value="Center"/>
+      <Q id="6427528077" qualifier_id="233" value="335"/>
+      <Q id="6427527937" qualifier_id="286"/>
+    </Event>
+    <Event id="2939639165" event_id="335" type_id="7" period_id="1" min="34" sec="55" player_id="627127" team_id="244" outcome="1" x="27.7" y="45.4" timestamp="2026-05-18T18:52:17.958" timestamp_utc="2026-05-18T17:52:17.958" last_modified="2026-05-18T19:22:28" version="1779128546354">
+      <Q id="6427528027" qualifier_id="56" value="Back"/>
+      <Q id="6427528031" qualifier_id="178"/>
+      <Q id="6427528061" qualifier_id="233" value="222"/>
+      <Q id="6427528029" qualifier_id="285"/>
+    </Event>
+    <Event id="2939639171" event_id="336" type_id="49" period_id="1" min="34" sec="57" player_id="240166" team_id="244" outcome="1" x="9.9" y="31.2" timestamp="2026-05-18T18:52:20.134" timestamp_utc="2026-05-18T17:52:20.134" last_modified="2026-05-18T18:52:20" version="1779126740136"/>
+    <Event id="2939639225" event_id="337" type_id="1" period_id="1" min="35" sec="1" player_id="240166" team_id="244" outcome="1" x="18.1" y="9.2" timestamp="2026-05-18T18:52:23.734" timestamp_utc="2026-05-18T17:52:23.734" last_modified="2026-05-18T18:52:25" version="1779126744367">
+      <Q id="6427528407" qualifier_id="56" value="Back"/>
+      <Q id="6427528409" qualifier_id="140" value="9.4"/>
+      <Q id="6427528411" qualifier_id="141" value="23.6"/>
+      <Q id="6427528413" qualifier_id="212" value="13.4"/>
+      <Q id="6427528415" qualifier_id="213" value="2.32"/>
+    </Event>
+    <Event id="2939639253" event_id="338" type_id="1" period_id="1" min="35" sec="3" player_id="627127" team_id="244" outcome="1" x="9.0" y="21.2" timestamp="2026-05-18T18:52:25.663" timestamp_utc="2026-05-18T17:52:25.663" last_modified="2026-05-18T18:52:28" version="1779126747097">
+      <Q id="6427528555" qualifier_id="56" value="Back"/>
+      <Q id="6427528557" qualifier_id="140" value="36.0"/>
+      <Q id="6427528559" qualifier_id="141" value="11.9"/>
+      <Q id="6427528561" qualifier_id="212" value="29.0"/>
+      <Q id="6427528563" qualifier_id="213" value="6.06"/>
+    </Event>
+    <Event id="2939639273" event_id="339" type_id="1" period_id="1" min="35" sec="5" player_id="625775" team_id="244" outcome="1" x="37.1" y="12.0" timestamp="2026-05-18T18:52:28.270" timestamp_utc="2026-05-18T17:52:28.270" last_modified="2026-05-18T18:52:29" version="1779126748809">
+      <Q id="6427528633" qualifier_id="56" value="Back"/>
+      <Q id="6427528635" qualifier_id="140" value="29.4"/>
+      <Q id="6427528637" qualifier_id="141" value="19.2"/>
+      <Q id="6427528639" qualifier_id="212" value="9.5"/>
+      <Q id="6427528641" qualifier_id="213" value="2.60"/>
+    </Event>
+    <Event id="2939639329" event_id="340" type_id="1" period_id="1" min="35" sec="6" player_id="515742" team_id="244" outcome="1" x="31.8" y="22.8" timestamp="2026-05-18T18:52:29.630" timestamp_utc="2026-05-18T17:52:29.630" last_modified="2026-05-18T18:52:33" version="1779126750609">
+      <Q id="6427528875" qualifier_id="56" value="Back"/>
+      <Q id="6427528877" qualifier_id="140" value="40.8"/>
+      <Q id="6427528879" qualifier_id="141" value="39.8"/>
+      <Q id="6427528881" qualifier_id="212" value="14.9"/>
+      <Q id="6427528883" qualifier_id="213" value="0.89"/>
+    </Event>
+    <Event id="2939639357" event_id="341" type_id="1" period_id="1" min="35" sec="10" player_id="232091" team_id="244" outcome="1" x="42.1" y="51.9" timestamp="2026-05-18T18:52:33.398" timestamp_utc="2026-05-18T17:52:33.398" last_modified="2026-05-18T18:52:38" version="1779126754025">
+      <Q id="6427529057" qualifier_id="56" value="Back"/>
+      <Q id="6427529059" qualifier_id="140" value="48.9"/>
+      <Q id="6427529061" qualifier_id="141" value="76.0"/>
+      <Q id="6427529063" qualifier_id="212" value="17.9"/>
+      <Q id="6427529065" qualifier_id="213" value="1.16"/>
+    </Event>
+    <Event id="2939639393" event_id="342" type_id="1" period_id="1" min="35" sec="15" player_id="575855" team_id="244" outcome="1" x="74.7" y="82.1" timestamp="2026-05-18T18:52:38.598" timestamp_utc="2026-05-18T17:52:38.598" last_modified="2026-05-18T18:52:43" version="1779126759063">
+      <Q id="6427529243" qualifier_id="56" value="Left"/>
+      <Q id="6427529245" qualifier_id="140" value="86.1"/>
+      <Q id="6427529247" qualifier_id="141" value="92.0"/>
+      <Q id="6427529249" qualifier_id="212" value="13.7"/>
+      <Q id="6427529251" qualifier_id="213" value="0.51"/>
+    </Event>
+    <Event id="2939639439" event_id="343" type_id="1" period_id="1" min="35" sec="20" player_id="479433" team_id="244" outcome="1" x="88.0" y="89.3" keypass="1" timestamp="2026-05-18T18:52:42.926" timestamp_utc="2026-05-18T17:52:42.926" last_modified="2026-05-18T18:52:59" version="1779126778935">
+      <Q id="6427529525" qualifier_id="56" value="Center"/>
+      <Q id="6427529527" qualifier_id="140" value="77.9"/>
+      <Q id="6427529529" qualifier_id="141" value="72.1"/>
+      <Q id="6427530135" qualifier_id="210" value="15"/>
+      <Q id="6427529531" qualifier_id="212" value="15.8"/>
+      <Q id="6427529533" qualifier_id="213" value="3.98"/>
+    </Event>
+    <Event id="2939639445" event_id="344" type_id="15" period_id="1" min="35" sec="23" player_id="515742" team_id="244" outcome="1" x="78.3" y="70.1" timestamp="2026-05-18T18:52:45.670" timestamp_utc="2026-05-18T17:52:45.670" last_modified="2026-05-18T18:52:59" version="1779126778950">
+      <Q id="6427529551" qualifier_id="18"/>
+      <Q id="6427529903" qualifier_id="20"/>
+      <Q id="6427529549" qualifier_id="22"/>
+      <Q id="6427530171" qualifier_id="29"/>
+      <Q id="6427530173" qualifier_id="55" value="343"/>
+      <Q id="6427529553" qualifier_id="56" value="Center"/>
+      <Q id="6427530169" qualifier_id="81"/>
+      <Q id="6427530177" qualifier_id="102" value="47.6"/>
+      <Q id="6427530179" qualifier_id="103" value="33.5"/>
+      <Q id="6427530183" qualifier_id="146" value="100.0"/>
+      <Q id="6427530185" qualifier_id="147" value="49.3"/>
+      <Q id="6427530181" qualifier_id="215"/>
+      <Q id="6427530213" qualifier_id="233" value="223"/>
+    </Event>
+    <Event id="2939639455" event_id="223" type_id="10" period_id="1" min="35" sec="23" player_id="565487" team_id="417" outcome="1" x="2.2" y="51.6" timestamp="2026-05-18T18:52:45.770" timestamp_utc="2026-05-18T17:52:45.770" last_modified="2026-05-18T18:52:59" version="1779126778955">
+      <Q id="6427529613" qualifier_id="56" value="Back"/>
+      <Q id="6427529607" qualifier_id="173"/>
+      <Q id="6427529891" qualifier_id="179"/>
+      <Q id="6427529611" qualifier_id="182"/>
+      <Q id="6427530247" qualifier_id="233" value="344"/>
+    </Event>
+    <Event id="2939639449" event_id="345" type_id="6" period_id="1" min="35" sec="25" player_id="515742" team_id="244" outcome="1" x="89.7" y="56.7" timestamp="2026-05-18T18:52:48.134" timestamp_utc="2026-05-18T17:52:48.134" last_modified="2026-05-18T18:52:52" version="1779126770097">
+      <Q id="6427529711" qualifier_id="56" value="Center"/>
+      <Q id="6427529713" qualifier_id="75"/>
+      <Q id="6427529725" qualifier_id="233" value="224"/>
+    </Event>
+    <Event id="2939639461" event_id="224" type_id="6" period_id="1" min="35" sec="25" player_id="565487" team_id="417" outcome="0" x="10.4" y="43.2" timestamp="2026-05-18T18:52:48.134" timestamp_utc="2026-05-18T17:52:48.134" last_modified="2026-05-18T19:36:25" version="1779129384320">
+      <Q id="6427529719" qualifier_id="56" value="Back"/>
+      <Q id="6427529721" qualifier_id="73"/>
+      <Q id="6427529731" qualifier_id="233" value="345"/>
+    </Event>
+    <Event id="2939639801" event_id="346" type_id="1" period_id="1" min="35" sec="58" player_id="207884" team_id="244" outcome="0" x="99.5" y="0.5" timestamp="2026-05-18T18:53:21.198" timestamp_utc="2026-05-18T17:53:21.198" last_modified="2026-05-18T18:55:02" version="1779126902050">
+      <Q id="6427531697" qualifier_id="1"/>
+      <Q id="6427531679" qualifier_id="2"/>
+      <Q id="6427531681" qualifier_id="6"/>
+      <Q id="6427531687" qualifier_id="56" value="Center"/>
+      <Q id="6427531689" qualifier_id="140" value="90.8"/>
+      <Q id="6427531691" qualifier_id="141" value="51.6"/>
+      <Q id="6427531683" qualifier_id="155"/>
+      <Q id="6427531693" qualifier_id="212" value="35.9"/>
+      <Q id="6427531695" qualifier_id="213" value="1.83"/>
+      <Q id="6427531685" qualifier_id="224"/>
+    </Event>
+    <Event id="2939639805" event_id="225" type_id="12" period_id="1" min="36" sec="1" player_id="61812" team_id="417" outcome="1" x="7.3" y="55.8" timestamp="2026-05-18T18:53:23.931" timestamp_utc="2026-05-18T17:53:23.931" last_modified="2026-05-18T19:05:33" version="1779127533054">
+      <Q id="6427531753" qualifier_id="15"/>
+      <Q id="6427531723" qualifier_id="56" value="Back"/>
+      <Q id="6427531725" qualifier_id="140" value="23.6"/>
+      <Q id="6427531727" qualifier_id="141" value="37.6"/>
+      <Q id="6427531729" qualifier_id="212" value="21.1"/>
+      <Q id="6427531731" qualifier_id="213" value="5.66"/>
+    </Event>
+    <Event id="2939639833" event_id="347" type_id="1" period_id="1" min="36" sec="3" player_id="625775" team_id="244" outcome="1" x="79.4" y="67.5" timestamp="2026-05-18T18:53:26.541" timestamp_utc="2026-05-18T17:53:26.541" last_modified="2026-05-18T18:53:29" version="1779126806833">
+      <Q id="6427531911" qualifier_id="56" value="Center"/>
+      <Q id="6427531913" qualifier_id="140" value="88.4"/>
+      <Q id="6427531915" qualifier_id="141" value="71.4"/>
+      <Q id="6427531917" qualifier_id="212" value="9.8"/>
+      <Q id="6427531919" qualifier_id="213" value="0.27"/>
+    </Event>
+    <Event id="2939639841" event_id="348" type_id="1" period_id="1" min="36" sec="6" player_id="515742" team_id="244" outcome="0" x="89.2" y="71.7" timestamp="2026-05-18T18:53:29.070" timestamp_utc="2026-05-18T17:53:29.070" last_modified="2026-05-18T18:53:30" version="1779126809902">
+      <Q id="6427531967" qualifier_id="56" value="Center"/>
+      <Q id="6427531969" qualifier_id="140" value="89.4"/>
+      <Q id="6427531971" qualifier_id="141" value="47.6"/>
+      <Q id="6427531965" qualifier_id="155"/>
+      <Q id="6427531973" qualifier_id="212" value="16.4"/>
+      <Q id="6427531975" qualifier_id="213" value="4.73"/>
+    </Event>
+    <Event id="2939639855" event_id="226" type_id="12" period_id="1" min="36" sec="8" player_id="445539" team_id="417" outcome="1" x="10.3" y="45.2" timestamp="2026-05-18T18:53:30.883" timestamp_utc="2026-05-18T17:53:30.883" last_modified="2026-05-18T18:53:42" version="1779126811308">
+      <Q id="6427532063" qualifier_id="15"/>
+      <Q id="6427532039" qualifier_id="56" value="Back"/>
+      <Q id="6427532041" qualifier_id="140" value="24.0"/>
+      <Q id="6427532043" qualifier_id="141" value="42.7"/>
+      <Q id="6427532045" qualifier_id="212" value="14.5"/>
+      <Q id="6427532047" qualifier_id="213" value="6.17"/>
+    </Event>
+    <Event id="2939639909" event_id="349" type_id="1" period_id="1" min="36" sec="10" player_id="627127" team_id="244" outcome="1" x="73.6" y="42.7" timestamp="2026-05-18T18:53:32.830" timestamp_utc="2026-05-18T17:53:32.830" last_modified="2026-05-18T18:53:35" version="1779126813279">
+      <Q id="6427532325" qualifier_id="56" value="Right"/>
+      <Q id="6427532327" qualifier_id="140" value="81.3"/>
+      <Q id="6427532329" qualifier_id="141" value="19.2"/>
+      <Q id="6427532331" qualifier_id="212" value="17.9"/>
+      <Q id="6427532333" qualifier_id="213" value="5.18"/>
+    </Event>
+    <Event id="2939639925" event_id="350" type_id="1" period_id="1" min="36" sec="13" player_id="207884" team_id="244" outcome="1" x="81.7" y="15.9" timestamp="2026-05-18T18:53:35.870" timestamp_utc="2026-05-18T17:53:35.870" last_modified="2026-05-18T18:53:37" version="1779126816178">
+      <Q id="6427532427" qualifier_id="56" value="Right"/>
+      <Q id="6427532429" qualifier_id="140" value="86.5"/>
+      <Q id="6427532431" qualifier_id="141" value="17.7"/>
+      <Q id="6427532433" qualifier_id="212" value="5.2"/>
+      <Q id="6427532435" qualifier_id="213" value="0.24"/>
+    </Event>
+    <Event id="2939639993" event_id="351" type_id="1" period_id="1" min="36" sec="14" player_id="180662" team_id="244" outcome="1" x="86.6" y="17.7" timestamp="2026-05-18T18:53:36.886" timestamp_utc="2026-05-18T17:53:36.886" last_modified="2026-05-18T18:53:41" version="1779126817056">
+      <Q id="6427532731" qualifier_id="56" value="Center"/>
+      <Q id="6427532733" qualifier_id="140" value="82.9"/>
+      <Q id="6427532735" qualifier_id="141" value="27.9"/>
+      <Q id="6427532737" qualifier_id="212" value="7.9"/>
+      <Q id="6427532739" qualifier_id="213" value="2.08"/>
+    </Event>
+    <Event id="2939640001" event_id="352" type_id="1" period_id="1" min="36" sec="19" player_id="207884" team_id="244" outcome="0" x="93.2" y="31.9" timestamp="2026-05-18T18:53:41.846" timestamp_utc="2026-05-18T17:53:41.846" last_modified="2026-05-18T19:41:17" version="1779129677731">
+      <Q id="6427532775" qualifier_id="56" value="Center"/>
+      <Q id="6427532777" qualifier_id="140" value="95.8"/>
+      <Q id="6427532779" qualifier_id="141" value="42.2"/>
+      <Q id="6427532781" qualifier_id="212" value="7.5"/>
+      <Q id="6427532783" qualifier_id="213" value="1.20"/>
+    </Event>
+    <Event id="2939640039" event_id="227" type_id="12" period_id="1" min="36" sec="19" player_id="565487" team_id="417" outcome="1" x="2.1" y="54.9" timestamp="2026-05-18T18:53:42.027" timestamp_utc="2026-05-18T17:53:42.027" last_modified="2026-05-19T16:27:45" version="1779204465806">
+      <Q id="6427533013" qualifier_id="56" value="Back"/>
+      <Q id="6427533015" qualifier_id="140" value="10.7"/>
+      <Q id="6427533017" qualifier_id="141" value="68.2"/>
+      <Q id="6427533019" qualifier_id="212" value="12.8"/>
+      <Q id="6427533021" qualifier_id="213" value="0.79"/>
+    </Event>
+    <Event id="2939640019" event_id="353" type_id="61" period_id="1" min="36" sec="21" player_id="180662" team_id="244" outcome="1" x="87.6" y="34.0" keypass="1" timestamp="2026-05-18T18:53:43.894" timestamp_utc="2026-05-18T17:53:43.894" last_modified="2026-05-18T18:54:58" version="1779126898717">
+      <Q id="6427535215" qualifier_id="56" value="Center"/>
+    </Event>
+    <Event id="2939640027" event_id="354" type_id="13" period_id="1" min="36" sec="21" player_id="515742" team_id="244" outcome="1" x="85.5" y="37.5" timestamp="2026-05-18T18:53:44.022" timestamp_utc="2026-05-18T17:53:44.022" last_modified="2026-05-18T18:54:59" version="1779126898726">
+      <Q id="6427536123" qualifier_id="17"/>
+      <Q id="6427536121" qualifier_id="20"/>
+      <Q id="6427536119" qualifier_id="25"/>
+      <Q id="6427536389" qualifier_id="29"/>
+      <Q id="6427536391" qualifier_id="55" value="353"/>
+      <Q id="6427535401" qualifier_id="56" value="Center"/>
+      <Q id="6427536387" qualifier_id="73"/>
+      <Q id="6427536395" qualifier_id="102" value="61.0"/>
+      <Q id="6427536397" qualifier_id="103" value="23.6"/>
+      <Q id="6427536399" qualifier_id="146" value="88.1"/>
+      <Q id="6427536401" qualifier_id="147" value="44.4"/>
+      <Q id="6427536127" qualifier_id="153"/>
+      <Q id="6427536403" qualifier_id="230" value="99.5"/>
+      <Q id="6427536405" qualifier_id="231" value="48.2"/>
+    </Event>
+    <Event id="2939640055" event_id="228" type_id="12" period_id="1" min="36" sec="22" player_id="531784" team_id="417" outcome="1" x="9.5" y="53.3" timestamp="2026-05-18T18:53:44.963" timestamp_utc="2026-05-18T17:53:44.963" last_modified="2026-05-18T18:53:46" version="1779126825452">
+      <Q id="6427533075" qualifier_id="56" value="Back"/>
+      <Q id="6427533077" qualifier_id="140" value="31.9"/>
+      <Q id="6427533079" qualifier_id="141" value="85.3"/>
+      <Q id="6427533081" qualifier_id="212" value="32.0"/>
+      <Q id="6427533083" qualifier_id="213" value="0.75"/>
+    </Event>
+    <Event id="2939640065" event_id="229" type_id="3" period_id="1" min="36" sec="24" player_id="445539" team_id="417" outcome="1" x="34.0" y="77.2" timestamp="2026-05-18T18:53:46.859" timestamp_utc="2026-05-18T17:53:46.859" last_modified="2026-05-18T18:53:51" version="1779126828058">
+      <Q id="6427533117" qualifier_id="56" value="Back"/>
+      <Q id="6427533169" qualifier_id="233" value="355"/>
+      <Q id="6427533167" qualifier_id="286"/>
+    </Event>
+    <Event id="2939640071" event_id="355" type_id="45" period_id="1" min="36" sec="24" player_id="627127" team_id="244" outcome="0" x="66.0" y="22.8" timestamp="2026-05-18T18:53:46.859" timestamp_utc="2026-05-18T17:53:46.859" last_modified="2026-05-18T18:53:51" version="1779126828062">
+      <Q id="6427533137" qualifier_id="56" value="Center"/>
+      <Q id="6427533209" qualifier_id="233" value="229"/>
+      <Q id="6427533141" qualifier_id="285"/>
+    </Event>
+    <Event id="2939640073" event_id="230" type_id="49" period_id="1" min="36" sec="24" player_id="445539" team_id="417" outcome="1" x="35.8" y="88.6" timestamp="2026-05-18T18:53:47.530" timestamp_utc="2026-05-18T17:53:47.530" last_modified="2026-05-18T18:53:47" version="1779126827531"/>
+    <Event id="2939640143" event_id="232" type_id="1" period_id="1" min="36" sec="31" player_id="445539" team_id="417" outcome="1" x="61.3" y="85.7" timestamp="2026-05-18T18:53:54.347" timestamp_utc="2026-05-18T17:53:54.347" last_modified="2026-05-18T18:53:55" version="1779126834669">
+      <Q id="6427533585" qualifier_id="56" value="Center"/>
+      <Q id="6427533587" qualifier_id="140" value="65.2"/>
+      <Q id="6427533589" qualifier_id="141" value="71.4"/>
+      <Q id="6427533591" qualifier_id="212" value="10.6"/>
+      <Q id="6427533593" qualifier_id="213" value="5.11"/>
+    </Event>
+    <Event id="2939640135" event_id="356" type_id="83" period_id="1" min="36" sec="31" player_id="180662" team_id="244" outcome="0" x="28.5" y="30.1" timestamp="2026-05-18T18:53:54.398" timestamp_utc="2026-05-18T17:53:54.398" last_modified="2026-05-18T18:57:57" version="1779127077537">
+      <Q id="6427533635" qualifier_id="399" value="61778"/>
+    </Event>
+    <Event id="2939640149" event_id="233" type_id="1" period_id="1" min="36" sec="32" player_id="61778" team_id="417" outcome="1" x="65.3" y="71.4" assist="1" timestamp="2026-05-18T18:53:55.427" timestamp_utc="2026-05-18T17:53:55.427" last_modified="2026-05-18T18:55:02" version="1779126902444">
+      <Q id="6427533631" qualifier_id="1"/>
+      <Q id="6427536557" qualifier_id="23"/>
+      <Q id="6427533621" qualifier_id="56" value="Center"/>
+      <Q id="6427533623" qualifier_id="140" value="87.9"/>
+      <Q id="6427533625" qualifier_id="141" value="36.1"/>
+      <Q id="6427536555" qualifier_id="210" value="16"/>
+      <Q id="6427533627" qualifier_id="212" value="33.8"/>
+      <Q id="6427533629" qualifier_id="213" value="5.49"/>
+    </Event>
+    <Event id="2939640345" event_id="235" type_id="16" period_id="1" min="36" sec="41" player_id="685390" team_id="417" outcome="1" x="87.7" y="34.3" timestamp="2026-05-18T18:54:04.411" timestamp_utc="2026-05-18T17:54:04.411" last_modified="2026-05-18T18:55:02" version="1779126902449">
+      <Q id="6427536577" qualifier_id="20"/>
+      <Q id="6427536575" qualifier_id="23"/>
+      <Q id="6427536581" qualifier_id="29"/>
+      <Q id="6427536583" qualifier_id="55" value="233"/>
+      <Q id="6427534599" qualifier_id="56" value="Center"/>
+      <Q id="6427534597" qualifier_id="63"/>
+      <Q id="6427536579" qualifier_id="81"/>
+      <Q id="6427536587" qualifier_id="102" value="46.6"/>
+      <Q id="6427536589" qualifier_id="103" value="29.7"/>
+      <Q id="6427536601" qualifier_id="138"/>
+      <Q id="6427536591" qualifier_id="214"/>
+      <Q id="6427536593" qualifier_id="215"/>
+      <Q id="6427536597" qualifier_id="230" value="98.2"/>
+      <Q id="6427536599" qualifier_id="231" value="47.8"/>
+      <Q id="6427536603" qualifier_id="275"/>
+      <Q id="6427536607" qualifier_id="374" value="2026-05-18 18:54:03.405"/>
+      <Q id="6427536611" qualifier_id="375" value="36:40.758"/>
+    </Event>
+    <Event id="2939640755" event_id="357" type_id="1" period_id="1" min="37" sec="44" player_id="207884" team_id="244" outcome="1" x="50.1" y="50.7" timestamp="2026-05-18T18:55:07.101" timestamp_utc="2026-05-18T17:55:07.101" last_modified="2026-05-18T18:55:09" version="1779126907874">
+      <Q id="6427536795" qualifier_id="56" value="Back"/>
+      <Q id="6427536797" qualifier_id="140" value="43.6"/>
+      <Q id="6427536799" qualifier_id="141" value="53.4"/>
+      <Q id="6427536801" qualifier_id="212" value="7.1"/>
+      <Q id="6427536803" qualifier_id="213" value="2.88"/>
+      <Q id="6427536807" qualifier_id="278"/>
+      <Q id="6427536805" qualifier_id="279" value="G"/>
+    </Event>
+    <Event id="2939640773" event_id="358" type_id="1" period_id="1" min="37" sec="46" player_id="515742" team_id="244" outcome="1" x="44.9" y="53.4" timestamp="2026-05-18T18:55:09.141" timestamp_utc="2026-05-18T17:55:09.141" last_modified="2026-05-18T18:55:11" version="1779126910399">
+      <Q id="6427536929" qualifier_id="56" value="Back"/>
+      <Q id="6427536931" qualifier_id="140" value="38.2"/>
+      <Q id="6427536933" qualifier_id="141" value="16.4"/>
+      <Q id="6427536935" qualifier_id="212" value="26.1"/>
+      <Q id="6427536937" qualifier_id="213" value="4.44"/>
+    </Event>
+    <Event id="2939640793" event_id="359" type_id="1" period_id="1" min="37" sec="48" player_id="240166" team_id="244" outcome="1" x="37.0" y="16.1" timestamp="2026-05-18T18:55:11.605" timestamp_utc="2026-05-18T17:55:11.605" last_modified="2026-05-18T18:55:14" version="1779126912078">
+      <Q id="6427537107" qualifier_id="56" value="Back"/>
+      <Q id="6427537109" qualifier_id="140" value="27.9"/>
+      <Q id="6427537111" qualifier_id="141" value="29.2"/>
+      <Q id="6427537113" qualifier_id="212" value="13.1"/>
+      <Q id="6427537115" qualifier_id="213" value="2.39"/>
+    </Event>
+    <Event id="2939640799" event_id="360" type_id="1" period_id="1" min="37" sec="51" player_id="627127" team_id="244" outcome="0" x="27.9" y="29.2" timestamp="2026-05-18T18:55:14.566" timestamp_utc="2026-05-18T17:55:14.566" last_modified="2026-05-18T18:55:15" version="1779126915093">
+      <Q id="6427537163" qualifier_id="1"/>
+      <Q id="6427537153" qualifier_id="56" value="Right"/>
+      <Q id="6427537155" qualifier_id="140" value="72.6"/>
+      <Q id="6427537157" qualifier_id="141" value="15.0"/>
+      <Q id="6427537151" qualifier_id="155"/>
+      <Q id="6427537159" qualifier_id="212" value="47.9"/>
+      <Q id="6427537161" qualifier_id="213" value="6.08"/>
+    </Event>
+    <Event id="2939640807" event_id="236" type_id="1" period_id="1" min="37" sec="52" player_id="624620" team_id="417" outcome="0" x="26.9" y="86.2" timestamp="2026-05-18T18:55:15.249" timestamp_utc="2026-05-18T17:55:15.249" last_modified="2026-05-18T18:55:16" version="1779126916282">
+      <Q id="6427537183" qualifier_id="3"/>
+      <Q id="6427537185" qualifier_id="56" value="Back"/>
+      <Q id="6427537187" qualifier_id="140" value="39.2"/>
+      <Q id="6427537189" qualifier_id="141" value="94.1"/>
+      <Q id="6427537191" qualifier_id="212" value="14.0"/>
+      <Q id="6427537193" qualifier_id="213" value="0.39"/>
+    </Event>
+    <Event id="2939640821" event_id="361" type_id="1" period_id="1" min="37" sec="54" player_id="232091" team_id="244" outcome="0" x="69.5" y="18.5" timestamp="2026-05-18T18:55:17.285" timestamp_utc="2026-05-18T17:55:17.285" last_modified="2026-05-18T18:55:18" version="1779126917949">
+      <Q id="6427537261" qualifier_id="3"/>
+      <Q id="6427537263" qualifier_id="56" value="Center"/>
+      <Q id="6427537265" qualifier_id="140" value="75.5"/>
+      <Q id="6427537267" qualifier_id="141" value="28.8"/>
+      <Q id="6427537269" qualifier_id="212" value="9.4"/>
+      <Q id="6427537271" qualifier_id="213" value="0.84"/>
+    </Event>
+    <Event id="2939640823" event_id="237" type_id="8" period_id="1" min="37" sec="55" player_id="61812" team_id="417" outcome="1" x="24.5" y="71.2" timestamp="2026-05-18T18:55:18.297" timestamp_utc="2026-05-18T17:55:18.297" last_modified="2026-05-18T19:37:41" version="1779129461822">
+      <Q id="6427537293" qualifier_id="15"/>
+      <Q id="6427537287" qualifier_id="56" value="Back"/>
+    </Event>
+    <Event id="2939640871" event_id="362" type_id="1" period_id="1" min="38" sec="0" player_id="515742" team_id="244" outcome="1" x="63.2" y="62.9" timestamp="2026-05-18T18:55:23.461" timestamp_utc="2026-05-18T17:55:23.461" last_modified="2026-05-18T18:55:26" version="1779126924278">
+      <Q id="6427537577" qualifier_id="56" value="Left"/>
+      <Q id="6427537579" qualifier_id="140" value="74.8"/>
+      <Q id="6427537581" qualifier_id="141" value="79.6"/>
+      <Q id="6427537583" qualifier_id="212" value="16.7"/>
+      <Q id="6427537585" qualifier_id="213" value="0.75"/>
+    </Event>
+    <Event id="2939640891" event_id="363" type_id="1" period_id="1" min="38" sec="3" player_id="575855" team_id="244" outcome="1" x="77.1" y="83.3" timestamp="2026-05-18T18:55:26.413" timestamp_utc="2026-05-18T17:55:26.413" last_modified="2026-05-18T18:55:28" version="1779126926799">
+      <Q id="6427537687" qualifier_id="56" value="Left"/>
+      <Q id="6427537691" qualifier_id="140" value="70.3"/>
+      <Q id="6427537693" qualifier_id="141" value="80.3"/>
+      <Q id="6427537695" qualifier_id="212" value="7.4"/>
+      <Q id="6427537697" qualifier_id="213" value="3.42"/>
+    </Event>
+    <Event id="2939640913" event_id="364" type_id="1" period_id="1" min="38" sec="5" player_id="515742" team_id="244" outcome="1" x="72.4" y="82.7" timestamp="2026-05-18T18:55:28.493" timestamp_utc="2026-05-18T17:55:28.493" last_modified="2026-05-18T18:55:32" version="1779126929157">
+      <Q id="6427537877" qualifier_id="56" value="Center"/>
+      <Q id="6427537879" qualifier_id="140" value="61.5"/>
+      <Q id="6427537881" qualifier_id="141" value="74.2"/>
+      <Q id="6427537883" qualifier_id="212" value="12.8"/>
+      <Q id="6427537885" qualifier_id="213" value="3.61"/>
+    </Event>
+    <Event id="2939640937" event_id="365" type_id="1" period_id="1" min="38" sec="10" player_id="180662" team_id="244" outcome="1" x="60.4" y="68.7" timestamp="2026-05-18T18:55:32.837" timestamp_utc="2026-05-18T17:55:32.837" last_modified="2026-05-18T18:55:36" version="1779126933711">
+      <Q id="6427538047" qualifier_id="56" value="Left"/>
+      <Q id="6427538049" qualifier_id="140" value="76.4"/>
+      <Q id="6427538051" qualifier_id="141" value="85.1"/>
+      <Q id="6427538053" qualifier_id="212" value="20.2"/>
+      <Q id="6427538055" qualifier_id="213" value="0.59"/>
+    </Event>
+    <Event id="2939640959" event_id="366" type_id="1" period_id="1" min="38" sec="13" player_id="648131" team_id="244" outcome="1" x="74.9" y="89.6" timestamp="2026-05-18T18:55:36.245" timestamp_utc="2026-05-18T17:55:36.245" last_modified="2026-05-18T18:55:39" version="1779126936614">
+      <Q id="6427538187" qualifier_id="56" value="Left"/>
+      <Q id="6427538189" qualifier_id="140" value="71.0"/>
+      <Q id="6427538191" qualifier_id="141" value="84.8"/>
+      <Q id="6427538193" qualifier_id="212" value="5.2"/>
+      <Q id="6427538195" qualifier_id="213" value="3.81"/>
+    </Event>
+    <Event id="2939640965" event_id="367" type_id="1" period_id="1" min="38" sec="16" player_id="515742" team_id="244" outcome="1" x="71.3" y="82.7" timestamp="2026-05-18T18:55:38.949" timestamp_utc="2026-05-18T17:55:38.949" last_modified="2026-05-18T18:55:40" version="1779126939269">
+      <Q id="6427538227" qualifier_id="56" value="Center"/>
+      <Q id="6427538229" qualifier_id="140" value="76.3"/>
+      <Q id="6427538231" qualifier_id="141" value="71.2"/>
+      <Q id="6427538233" qualifier_id="212" value="9.4"/>
+      <Q id="6427538235" qualifier_id="213" value="5.30"/>
+    </Event>
+    <Event id="2939640981" event_id="368" type_id="1" period_id="1" min="38" sec="17" player_id="207884" team_id="244" outcome="1" x="75.7" y="71.2" timestamp="2026-05-18T18:55:39.965" timestamp_utc="2026-05-18T17:55:39.965" last_modified="2026-05-18T18:55:42" version="1779126940670">
+      <Q id="6427538309" qualifier_id="56" value="Left"/>
+      <Q id="6427538311" qualifier_id="140" value="70.1"/>
+      <Q id="6427538313" qualifier_id="141" value="83.9"/>
+      <Q id="6427538315" qualifier_id="212" value="10.4"/>
+      <Q id="6427538317" qualifier_id="213" value="2.17"/>
+    </Event>
+    <Event id="2939641005" event_id="369" type_id="1" period_id="1" min="38" sec="19" player_id="515742" team_id="244" outcome="1" x="69.9" y="83.6" timestamp="2026-05-18T18:55:42.284" timestamp_utc="2026-05-18T17:55:42.284" last_modified="2026-05-18T18:55:46" version="1779126943359">
+      <Q id="6427538459" qualifier_id="56" value="Center"/>
+      <Q id="6427538461" qualifier_id="140" value="59.0"/>
+      <Q id="6427538463" qualifier_id="141" value="61.8"/>
+      <Q id="6427538465" qualifier_id="212" value="18.7"/>
+      <Q id="6427538467" qualifier_id="213" value="4.05"/>
+    </Event>
+    <Event id="2939641031" event_id="370" type_id="1" period_id="1" min="38" sec="23" player_id="180662" team_id="244" outcome="1" x="53.7" y="55.7" timestamp="2026-05-18T18:55:46.420" timestamp_utc="2026-05-18T17:55:46.420" last_modified="2026-05-18T18:55:49" version="1779126947629">
+      <Q id="6427538655" qualifier_id="56" value="Center"/>
+      <Q id="6427538657" qualifier_id="140" value="59.8"/>
+      <Q id="6427538659" qualifier_id="141" value="68.4"/>
+      <Q id="6427538661" qualifier_id="212" value="10.8"/>
+      <Q id="6427538663" qualifier_id="213" value="0.93"/>
+    </Event>
+    <Event id="2939641039" event_id="371" type_id="1" period_id="1" min="38" sec="26" player_id="515742" team_id="244" outcome="1" x="60.6" y="70.8" timestamp="2026-05-18T18:55:49.516" timestamp_utc="2026-05-18T17:55:49.516" last_modified="2026-05-18T18:55:51" version="1779126950351">
+      <Q id="6427538703" qualifier_id="56" value="Left"/>
+      <Q id="6427538705" qualifier_id="140" value="74.8"/>
+      <Q id="6427538707" qualifier_id="141" value="86.5"/>
+      <Q id="6427538709" qualifier_id="212" value="18.3"/>
+      <Q id="6427538711" qualifier_id="213" value="0.62"/>
+    </Event>
+    <Event id="2939641055" event_id="372" type_id="1" period_id="1" min="38" sec="28" player_id="575855" team_id="244" outcome="1" x="74.8" y="86.5" timestamp="2026-05-18T18:55:51.076" timestamp_utc="2026-05-18T17:55:51.076" last_modified="2026-05-18T18:55:53" version="1779126951294">
+      <Q id="6427538809" qualifier_id="56" value="Left"/>
+      <Q id="6427538811" qualifier_id="140" value="64.4"/>
+      <Q id="6427538813" qualifier_id="141" value="84.1"/>
+      <Q id="6427538815" qualifier_id="212" value="11.0"/>
+      <Q id="6427538817" qualifier_id="213" value="3.29"/>
+    </Event>
+    <Event id="2939641073" event_id="373" type_id="1" period_id="1" min="38" sec="30" player_id="515742" team_id="244" outcome="0" x="60.2" y="81.7" timestamp="2026-05-18T18:55:53.166" timestamp_utc="2026-05-18T17:55:53.166" last_modified="2026-05-18T18:55:55" version="1779126955813">
+      <Q id="6427538949" qualifier_id="1"/>
+      <Q id="6427538939" qualifier_id="56" value="Center"/>
+      <Q id="6427538941" qualifier_id="140" value="74.7"/>
+      <Q id="6427538943" qualifier_id="141" value="22.8"/>
+      <Q id="6427538937" qualifier_id="155"/>
+      <Q id="6427538945" qualifier_id="212" value="42.8"/>
+      <Q id="6427538947" qualifier_id="213" value="5.08"/>
+    </Event>
+    <Event id="2939641079" event_id="238" type_id="12" period_id="1" min="38" sec="33" player_id="164593" team_id="417" outcome="1" x="28.7" y="87.2" timestamp="2026-05-18T18:55:56.049" timestamp_utc="2026-05-18T17:55:56.049" last_modified="2026-05-18T18:55:59" version="1779126959259">
+      <Q id="6427538993" qualifier_id="15"/>
+      <Q id="6427538969" qualifier_id="56" value="Back"/>
+      <Q id="6427538971" qualifier_id="140" value="45.5"/>
+      <Q id="6427538973" qualifier_id="141" value="100.0"/>
+      <Q id="6427539127" qualifier_id="167"/>
+      <Q id="6427538975" qualifier_id="212" value="20.3"/>
+      <Q id="6427538977" qualifier_id="213" value="0.52"/>
+    </Event>
+    <Event id="2939641107" event_id="239" type_id="5" period_id="1" min="38" sec="36" player_id="164593" team_id="417" outcome="0" x="46.4" y="101.8" timestamp="2026-05-18T18:55:59.227" timestamp_utc="2026-05-18T17:55:59.227" last_modified="2026-05-18T19:36:57" version="1779129408010">
+      <Q id="6427539119" qualifier_id="56" value="Back"/>
+      <Q id="6427539305" qualifier_id="233" value="374"/>
+      <Q id="6427539121" qualifier_id="347"/>
+    </Event>
+    <Event id="2939641135" event_id="374" type_id="5" period_id="1" min="38" sec="36" player_id="240166" team_id="244" outcome="1" x="53.6" y="-1.8" timestamp="2026-05-18T18:55:59.227" timestamp_utc="2026-05-18T17:55:59.227" last_modified="2026-05-18T19:36:57" version="1779129408004">
+      <Q id="6427539263" qualifier_id="56" value="Right"/>
+      <Q id="6427539283" qualifier_id="233" value="239"/>
+      <Q id="6427539265" qualifier_id="347"/>
+    </Event>
+    <Event id="2939641155" event_id="375" type_id="1" period_id="1" min="38" sec="41" player_id="240166" team_id="244" outcome="1" x="46.6" y="0.0" timestamp="2026-05-18T18:56:04.484" timestamp_utc="2026-05-18T17:56:04.484" last_modified="2026-05-18T18:56:06" version="1779126965005">
+      <Q id="6427539391" qualifier_id="56" value="Back"/>
+      <Q id="6427539389" qualifier_id="107"/>
+      <Q id="6427539393" qualifier_id="140" value="34.8"/>
+      <Q id="6427539395" qualifier_id="141" value="15.9"/>
+      <Q id="6427539397" qualifier_id="212" value="17.4"/>
+      <Q id="6427539399" qualifier_id="213" value="2.37"/>
+    </Event>
+    <Event id="2939641197" event_id="376" type_id="1" period_id="1" min="38" sec="43" player_id="627127" team_id="244" outcome="1" x="34.6" y="17.9" timestamp="2026-05-18T18:56:06.324" timestamp_utc="2026-05-18T17:56:06.324" last_modified="2026-05-18T18:56:10" version="1779126966743">
+      <Q id="6427539649" qualifier_id="56" value="Back"/>
+      <Q id="6427539651" qualifier_id="140" value="31.2"/>
+      <Q id="6427539653" qualifier_id="141" value="41.0"/>
+      <Q id="6427539655" qualifier_id="212" value="16.1"/>
+      <Q id="6427539657" qualifier_id="213" value="1.79"/>
+    </Event>
+    <Event id="2939641221" event_id="377" type_id="1" period_id="1" min="38" sec="47" player_id="180662" team_id="244" outcome="1" x="33.5" y="44.8" timestamp="2026-05-18T18:56:10.564" timestamp_utc="2026-05-18T17:56:10.564" last_modified="2026-05-18T18:56:15" version="1779126971145">
+      <Q id="6427539809" qualifier_id="56" value="Back"/>
+      <Q id="6427539811" qualifier_id="140" value="38.1"/>
+      <Q id="6427539813" qualifier_id="141" value="75.1"/>
+      <Q id="6427539815" qualifier_id="212" value="21.2"/>
+      <Q id="6427539817" qualifier_id="213" value="1.34"/>
+    </Event>
+    <Event id="2939641245" event_id="378" type_id="1" period_id="1" min="38" sec="52" player_id="575855" team_id="244" outcome="1" x="37.6" y="81.4" timestamp="2026-05-18T18:56:14.972" timestamp_utc="2026-05-18T17:56:14.972" last_modified="2026-05-18T18:56:17" version="1779126975406">
+      <Q id="6427539931" qualifier_id="56" value="Back"/>
+      <Q id="6427539933" qualifier_id="140" value="33.8"/>
+      <Q id="6427539935" qualifier_id="141" value="66.3"/>
+      <Q id="6427539937" qualifier_id="212" value="11.0"/>
+      <Q id="6427539939" qualifier_id="213" value="4.34"/>
+    </Event>
+    <Event id="2939641267" event_id="379" type_id="1" period_id="1" min="38" sec="54" player_id="180662" team_id="244" outcome="1" x="31.4" y="60.0" timestamp="2026-05-18T18:56:17.468" timestamp_utc="2026-05-18T17:56:17.468" last_modified="2026-05-18T18:56:19" version="1779126977662">
+      <Q id="6427540055" qualifier_id="56" value="Back"/>
+      <Q id="6427540057" qualifier_id="140" value="35.8"/>
+      <Q id="6427540059" qualifier_id="141" value="63.7"/>
+      <Q id="6427540061" qualifier_id="212" value="5.3"/>
+      <Q id="6427540063" qualifier_id="213" value="0.50"/>
+    </Event>
+    <Event id="2939641305" event_id="380" type_id="1" period_id="1" min="38" sec="57" player_id="207884" team_id="244" outcome="1" x="35.0" y="60.9" timestamp="2026-05-18T18:56:19.829" timestamp_utc="2026-05-18T17:56:19.829" last_modified="2026-05-18T18:56:24" version="1779126982817">
+      <Q id="6427540295" qualifier_id="1"/>
+      <Q id="6427540285" qualifier_id="56" value="Left"/>
+      <Q id="6427540287" qualifier_id="140" value="82.7"/>
+      <Q id="6427540289" qualifier_id="141" value="85.7"/>
+      <Q id="6427540283" qualifier_id="155"/>
+      <Q id="6427540291" qualifier_id="212" value="52.8"/>
+      <Q id="6427540293" qualifier_id="213" value="0.32"/>
+    </Event>
+    <Event id="2939641307" event_id="381" type_id="61" period_id="1" min="39" sec="1" player_id="479433" team_id="244" outcome="0" x="83.4" y="85.3" timestamp="2026-05-18T18:56:24.052" timestamp_utc="2026-05-18T17:56:24.052" last_modified="2026-05-18T18:56:24" version="1779126984053">
+      <Q id="6427540299" qualifier_id="56" value="Left"/>
+    </Event>
+    <Event id="2939641453" event_id="241" type_id="1" period_id="1" min="39" sec="2" player_id="61812" team_id="417" outcome="0" x="20.3" y="41.9" timestamp="2026-05-18T18:56:25.313" timestamp_utc="2026-05-18T17:56:25.313" last_modified="2026-05-18T18:56:39" version="1779126998963">
+      <Q id="6427541075" qualifier_id="1"/>
+      <Q id="6427541065" qualifier_id="56" value="Right"/>
+      <Q id="6427541067" qualifier_id="140" value="51.1"/>
+      <Q id="6427541069" qualifier_id="141" value="0.0"/>
+      <Q id="6427541063" qualifier_id="157"/>
+      <Q id="6427541071" qualifier_id="212" value="43.1"/>
+      <Q id="6427541073" qualifier_id="213" value="5.56"/>
+    </Event>
+    <Event id="2939641455" event_id="242" type_id="43" period_id="1" min="39" sec="4" player_id="61812" team_id="417" outcome="1" x="0.0" y="0.0" timestamp="2026-05-18T18:56:26.971" timestamp_utc="2026-05-18T17:56:26.971" last_modified="2026-05-19T14:23:33" version="1779197011174">
+      <Q id="6427541081" qualifier_id="56" value="Back"/>
+      <Q id="6428639709" qualifier_id="144" value="5"/>
+      <Q id="6427541083" qualifier_id="347" value="0"/>
+    </Event>
+    <Event id="2939642067" event_id="382" type_id="43" period_id="1" min="39" sec="4" player_id="479433" team_id="244" outcome="1" x="0.0" y="0.0" timestamp="2026-05-18T18:56:26.971" timestamp_utc="2026-05-18T17:56:26.971" last_modified="2026-05-19T14:23:31" version="1779193014503">
+      <Q id="6427544705" qualifier_id="56" value="Left"/>
+      <Q id="6428639647" qualifier_id="144" value="5"/>
+      <Q id="6427551181" qualifier_id="233" value="242"/>
+      <Q id="6427544707" qualifier_id="347" value="0"/>
+    </Event>
+    <Event id="2939816623" event_id="263" type_id="76" period_id="1" min="39" sec="10" team_id="417" outcome="1" x="0.0" y="0.0" timestamp="2026-05-18T18:56:32.947" timestamp_utc="2026-05-18T17:56:32.947" last_modified="2026-05-19T14:00:57" version="1779195657691">
+      <Q id="6428523647" qualifier_id="54" value="2"/>
+      <Q id="6428523649" qualifier_id="226"/>
+      <Q id="6428604915" qualifier_id="227"/>
+      <Q id="6428523701" qualifier_id="233" value="389"/>
+    </Event>
+    <Event id="2939816629" event_id="389" type_id="76" period_id="1" min="39" sec="10" team_id="244" outcome="1" x="0.0" y="0.0" timestamp="2026-05-18T18:56:32.947" timestamp_utc="2026-05-18T17:56:32.947" last_modified="2026-05-19T14:00:58" version="1779195657933">
+      <Q id="6428523667" qualifier_id="54" value="2"/>
+      <Q id="6428523669" qualifier_id="226"/>
+      <Q id="6428604917" qualifier_id="227"/>
+      <Q id="6428523683" qualifier_id="233" value="263"/>
+    </Event>
+    <Event id="2939830699" event_id="392" type_id="64" period_id="1" min="39" sec="10" team_id="244" outcome="0" x="0.0" y="0.0" timestamp="2026-05-19T14:00:58.072" timestamp_utc="2026-05-19T13:00:58.072" last_modified="2026-05-19T14:01:00" version="1779195659670">
+      <Q id="6428604919" qualifier_id="55" value="389"/>
+      <Q id="6428604945" qualifier_id="233" value="266"/>
+    </Event>
+    <Event id="2939830703" event_id="266" type_id="64" period_id="1" min="39" sec="10" team_id="417" outcome="0" x="0.0" y="0.0" timestamp="2026-05-19T14:00:58.072" timestamp_utc="2026-05-19T13:00:58.072" last_modified="2026-05-19T14:00:59" version="1779195659081">
+      <Q id="6428604929" qualifier_id="55" value="263"/>
+      <Q id="6428604947" qualifier_id="233" value="392"/>
+    </Event>
+    <Event id="2939836705" event_id="498" type_id="68" period_id="1" min="39" sec="11" team_id="244" outcome="0" x="50.0" y="50.0" timestamp="2026-05-19T14:00:58.795" timestamp_utc="2026-05-19T13:00:58.795" last_modified="2026-05-19T14:23:41" version="1779197021533"/>
+    <Event id="2939836695" event_id="363" type_id="68" period_id="1" min="39" sec="11" team_id="417" outcome="1" x="50.0" y="50.0" timestamp="2026-05-19T14:00:58.909" timestamp_utc="2026-05-19T13:00:58.909" last_modified="2026-05-19T14:23:39" version="1779197019053"/>
+    <Event id="2939830707" event_id="267" type_id="49" period_id="1" min="39" sec="12" player_id="61812" team_id="417" outcome="1" x="23.8" y="33.6" timestamp="2026-05-19T14:01:00.537" timestamp_utc="2026-05-19T13:01:00.537" last_modified="2026-05-19T14:01:00" version="1779195660545"/>
+    <Event id="2939830713" event_id="268" type_id="1" period_id="1" min="39" sec="12" player_id="61812" team_id="417" outcome="0" x="23.8" y="33.6" timestamp="2026-05-19T14:01:00.737" timestamp_utc="2026-05-19T13:01:00.737" last_modified="2026-05-19T14:01:01" version="1779195661168">
+      <Q id="6428604979" qualifier_id="1"/>
+      <Q id="6428604969" qualifier_id="56" value="Center"/>
+      <Q id="6428604971" qualifier_id="140" value="63.8"/>
+      <Q id="6428604973" qualifier_id="141" value="32.2"/>
+      <Q id="6428604967" qualifier_id="157"/>
+      <Q id="6428604975" qualifier_id="212" value="42.0"/>
+      <Q id="6428604977" qualifier_id="213" value="6.26"/>
+    </Event>
+    <Event id="2939830715" event_id="393" type_id="8" period_id="1" min="39" sec="14" player_id="627127" team_id="244" outcome="1" x="36.2" y="67.8" timestamp="2026-05-19T14:01:02.698" timestamp_utc="2026-05-19T13:01:02.698" last_modified="2026-05-19T15:45:56" version="1779201956326">
+      <Q id="6428604993" qualifier_id="56" value="Back"/>
+    </Event>
+    <Event id="2939830723" event_id="269" type_id="1" period_id="1" min="39" sec="15" player_id="685390" team_id="417" outcome="1" x="60.2" y="30.3" timestamp="2026-05-19T14:01:02.809" timestamp_utc="2026-05-19T13:01:02.809" last_modified="2026-05-19T14:01:04" version="1779195662946">
+      <Q id="6428605039" qualifier_id="56" value="Center"/>
+      <Q id="6428605041" qualifier_id="140" value="59.4"/>
+      <Q id="6428605043" qualifier_id="141" value="47.9"/>
+      <Q id="6428605045" qualifier_id="212" value="12.0"/>
+      <Q id="6428605047" qualifier_id="213" value="1.64"/>
+    </Event>
+    <Event id="2939830725" event_id="270" type_id="1" period_id="1" min="39" sec="17" player_id="61778" team_id="417" outcome="0" x="59.4" y="47.9" timestamp="2026-05-19T14:01:04.795" timestamp_utc="2026-05-19T13:01:04.795" last_modified="2026-05-19T14:01:05" version="1779195665108">
+      <Q id="6428605063" qualifier_id="1"/>
+      <Q id="6428605053" qualifier_id="56" value="Center"/>
+      <Q id="6428605055" qualifier_id="140" value="67.9"/>
+      <Q id="6428605057" qualifier_id="141" value="54.6"/>
+      <Q id="6428605051" qualifier_id="157"/>
+      <Q id="6428605059" qualifier_id="212" value="10.0"/>
+      <Q id="6428605061" qualifier_id="213" value="0.47"/>
+    </Event>
+    <Event id="2939830731" event_id="394" type_id="1" period_id="1" min="39" sec="19" player_id="240166" team_id="244" outcome="0" x="32.7" y="46.4" timestamp="2026-05-19T14:01:07.362" timestamp_utc="2026-05-19T13:01:07.362" last_modified="2026-05-19T14:01:07" version="1779195667707">
+      <Q id="6428605085" qualifier_id="3"/>
+      <Q id="6428605087" qualifier_id="56" value="Back"/>
+      <Q id="6428605089" qualifier_id="140" value="48.3"/>
+      <Q id="6428605091" qualifier_id="141" value="51.0"/>
+      <Q id="6428605093" qualifier_id="212" value="16.7"/>
+      <Q id="6428605095" qualifier_id="213" value="0.19"/>
+    </Event>
+    <Event id="2939830743" event_id="271" type_id="1" period_id="1" min="39" sec="19" player_id="720682" team_id="417" outcome="0" x="56.8" y="50.1" timestamp="2026-05-19T14:01:07.480" timestamp_utc="2026-05-19T13:01:07.480" last_modified="2026-05-19T14:02:50" version="1779195770616">
+      <Q id="6428605161" qualifier_id="3"/>
+      <Q id="6428605163" qualifier_id="56" value="Center"/>
+      <Q id="6428605165" qualifier_id="140" value="65.8"/>
+      <Q id="6428605167" qualifier_id="141" value="51.6"/>
+      <Q id="6428605169" qualifier_id="212" value="9.5"/>
+      <Q id="6428605171" qualifier_id="213" value="0.11"/>
+    </Event>
+    <Event id="2939643013" event_id="245" type_id="43" period_id="1" min="39" sec="20" team_id="417" outcome="1" x="0.0" y="0.0" timestamp="2026-05-18T18:56:42.947" timestamp_utc="2026-05-18T17:56:42.947" last_modified="2026-05-19T13:13:37" version="1779129252690">
+      <Q id="6427659461" qualifier_id="57" value="0"/>
+      <Q id="6428523623" qualifier_id="144" value="30"/>
+      <Q id="6427659463" qualifier_id="209" value="0"/>
+      <Q id="6427659465" qualifier_id="325" value="0"/>
+    </Event>
+    <Event id="2939643077" event_id="383" type_id="43" period_id="1" min="39" sec="20" team_id="244" outcome="1" x="0.0" y="0.0" timestamp="2026-05-18T18:56:42.947" timestamp_utc="2026-05-18T17:56:42.947" last_modified="2026-05-19T13:13:37" version="1779129252711">
+      <Q id="6427659479" qualifier_id="57" value="0"/>
+      <Q id="6428523629" qualifier_id="144" value="30"/>
+      <Q id="6427659481" qualifier_id="209" value="0"/>
+      <Q id="6427659483" qualifier_id="325" value="0"/>
+    </Event>
+    <Event id="2939830741" event_id="395" type_id="44" period_id="1" min="39" sec="21" player_id="240166" team_id="244" outcome="1" x="34.2" y="48.4" timestamp="2026-05-19T14:01:08.802" timestamp_utc="2026-05-19T13:01:08.802" last_modified="2026-05-19T15:45:55" version="1779201955767">
+      <Q id="6428605153" qualifier_id="56" value="Back"/>
+      <Q id="6428605217" qualifier_id="233" value="272"/>
+      <Q id="6428605155" qualifier_id="285"/>
+    </Event>
+    <Event id="2939830745" event_id="272" type_id="44" period_id="1" min="39" sec="21" player_id="445539" team_id="417" outcome="0" x="65.8" y="51.6" timestamp="2026-05-19T14:01:08.803" timestamp_utc="2026-05-19T13:01:08.803" last_modified="2026-05-19T15:45:56" version="1779201956047">
+      <Q id="6428605175" qualifier_id="56" value="Center"/>
+      <Q id="6428605213" qualifier_id="233" value="395"/>
+      <Q id="6428605177" qualifier_id="286"/>
+    </Event>
+    <Event id="2939831187" event_id="425" type_id="61" period_id="1" min="39" sec="21" player_id="240166" team_id="244" outcome="1" x="29.1" y="46.8" timestamp="2026-05-19T14:01:09.004" timestamp_utc="2026-05-19T13:01:09.004" last_modified="2026-05-19T14:22:07" version="1779196927422">
+      <Q id="6428607687" qualifier_id="56" value="Back"/>
+    </Event>
+    <Event id="2939830749" event_id="273" type_id="43" period_id="1" min="39" sec="22" player_id="445539" team_id="417" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T14:01:10.008" timestamp_utc="2026-05-19T13:01:10.008" last_modified="2026-05-19T14:03:09" version="1779195670368">
+      <Q id="6428605199" qualifier_id="3" value="0"/>
+      <Q id="6428605203" qualifier_id="56" value="Center"/>
+      <Q id="6428605205" qualifier_id="140" value="77.5"/>
+      <Q id="6428605207" qualifier_id="141" value="36.9"/>
+      <Q id="6428607833" qualifier_id="144" value="1"/>
+      <Q id="6428605201" qualifier_id="168" value="0"/>
+      <Q id="6428605209" qualifier_id="212" value="9.8"/>
+      <Q id="6428605211" qualifier_id="213" value="5.32"/>
+    </Event>
+    <Event id="2939830759" event_id="396" type_id="1" period_id="1" min="39" sec="22" player_id="575855" team_id="244" outcome="0" x="29.8" y="69.9" timestamp="2026-05-19T14:01:10.323" timestamp_utc="2026-05-19T13:01:10.323" last_modified="2026-05-19T14:01:13" version="1779195673499">
+      <Q id="6428605267" qualifier_id="1"/>
+      <Q id="6428605257" qualifier_id="56" value="Back"/>
+      <Q id="6428605259" qualifier_id="140" value="43.4"/>
+      <Q id="6428605261" qualifier_id="141" value="70.5"/>
+      <Q id="6428605255" qualifier_id="157"/>
+      <Q id="6428605263" qualifier_id="212" value="14.3"/>
+      <Q id="6428605265" qualifier_id="213" value="0.03"/>
+    </Event>
+    <Event id="2939830767" event_id="274" type_id="8" period_id="1" min="39" sec="27" player_id="157851" team_id="417" outcome="1" x="56.6" y="29.5" timestamp="2026-05-19T14:01:14.912" timestamp_utc="2026-05-19T13:01:14.912" last_modified="2026-05-19T15:45:56" version="1779201956608">
+      <Q id="6428605309" qualifier_id="15"/>
+      <Q id="6428605307" qualifier_id="56" value="Center"/>
+    </Event>
+    <Event id="2939830777" event_id="397" type_id="1" period_id="1" min="39" sec="28" player_id="207884" team_id="244" outcome="1" x="45.1" y="66.6" timestamp="2026-05-19T14:01:16.674" timestamp_utc="2026-05-19T13:01:16.674" last_modified="2026-05-19T14:01:17" version="1779195677181">
+      <Q id="6428605373" qualifier_id="56" value="Center"/>
+      <Q id="6428605375" qualifier_id="140" value="53.6"/>
+      <Q id="6428605377" qualifier_id="141" value="69.3"/>
+      <Q id="6428605379" qualifier_id="212" value="9.1"/>
+      <Q id="6428605381" qualifier_id="213" value="0.20"/>
+    </Event>
+    <Event id="2939830783" event_id="398" type_id="1" period_id="1" min="39" sec="29" player_id="648131" team_id="244" outcome="1" x="53.6" y="69.3" timestamp="2026-05-19T14:01:17.586" timestamp_utc="2026-05-19T13:01:17.586" last_modified="2026-05-19T14:01:19" version="1779195678740">
+      <Q id="6428605393" qualifier_id="3"/>
+      <Q id="6428605395" qualifier_id="56" value="Center"/>
+      <Q id="6428605397" qualifier_id="140" value="66.2"/>
+      <Q id="6428605399" qualifier_id="141" value="78.8"/>
+      <Q id="6428605401" qualifier_id="212" value="14.7"/>
+      <Q id="6428605403" qualifier_id="213" value="0.45"/>
+    </Event>
+    <Event id="2939830785" event_id="399" type_id="49" period_id="1" min="39" sec="30" player_id="479433" team_id="244" outcome="1" x="67.2" y="81.7" timestamp="2026-05-19T14:01:18.426" timestamp_utc="2026-05-19T13:01:18.426" last_modified="2026-05-19T14:04:24" version="1779195864098"/>
+    <Event id="2939830779" event_id="275" type_id="43" period_id="1" min="39" sec="30" player_id="218339" team_id="417" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T14:01:18.762" timestamp_utc="2026-05-19T13:01:18.762" last_modified="2026-05-19T14:05:07" version="1779195678764">
+      <Q id="6428605387" qualifier_id="56" value="Center"/>
+      <Q id="6428610685" qualifier_id="144" value="61"/>
+    </Event>
+    <Event id="2939830795" event_id="400" type_id="43" period_id="1" min="39" sec="33" player_id="479433" team_id="244" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T14:01:20.963" timestamp_utc="2026-05-19T13:01:20.963" last_modified="2026-05-19T14:05:10" version="1779195680965">
+      <Q id="6428605461" qualifier_id="56" value="Left"/>
+      <Q id="6428610797" qualifier_id="144" value="56"/>
+    </Event>
+    <Event id="2939830803" event_id="401" type_id="1" period_id="1" min="39" sec="34" player_id="479433" team_id="244" outcome="1" x="77.1" y="91.8" timestamp="2026-05-19T14:01:22.602" timestamp_utc="2026-05-19T13:01:22.602" last_modified="2026-05-19T14:01:23" version="1779195682859">
+      <Q id="6428605487" qualifier_id="56" value="Left"/>
+      <Q id="6428605489" qualifier_id="140" value="67.6"/>
+      <Q id="6428605491" qualifier_id="141" value="87.5"/>
+      <Q id="6428605493" qualifier_id="212" value="10.4"/>
+      <Q id="6428605495" qualifier_id="213" value="3.43"/>
+    </Event>
+    <Event id="2939830821" event_id="402" type_id="1" period_id="1" min="39" sec="35" player_id="575855" team_id="244" outcome="1" x="64.9" y="87.7" timestamp="2026-05-19T14:01:23.682" timestamp_utc="2026-05-19T13:01:23.682" last_modified="2026-05-19T14:01:27" version="1779195687053">
+      <Q id="6428605569" qualifier_id="56" value="Center"/>
+      <Q id="6428605571" qualifier_id="140" value="63.8"/>
+      <Q id="6428605573" qualifier_id="141" value="74.5"/>
+      <Q id="6428605575" qualifier_id="212" value="9.1"/>
+      <Q id="6428605577" qualifier_id="213" value="4.58"/>
+    </Event>
+    <Event id="2939830829" event_id="403" type_id="1" period_id="1" min="39" sec="39" player_id="515742" team_id="244" outcome="1" x="63.8" y="74.5" timestamp="2026-05-19T14:01:27.546" timestamp_utc="2026-05-19T13:01:27.546" last_modified="2026-05-19T14:01:28" version="1779195688101">
+      <Q id="6428605601" qualifier_id="56" value="Left"/>
+      <Q id="6428605603" qualifier_id="140" value="51.8"/>
+      <Q id="6428605605" qualifier_id="141" value="85.6"/>
+      <Q id="6428605607" qualifier_id="212" value="14.7"/>
+      <Q id="6428605609" qualifier_id="213" value="2.60"/>
+    </Event>
+    <Event id="2939830845" event_id="404" type_id="1" period_id="1" min="39" sec="40" player_id="180662" team_id="244" outcome="1" x="51.8" y="85.6" timestamp="2026-05-19T14:01:28.354" timestamp_utc="2026-05-19T13:01:28.354" last_modified="2026-05-19T14:01:31" version="1779195688788">
+      <Q id="6428605675" qualifier_id="56" value="Back"/>
+      <Q id="6428605677" qualifier_id="140" value="45.6"/>
+      <Q id="6428605679" qualifier_id="141" value="57.3"/>
+      <Q id="6428605681" qualifier_id="212" value="20.3"/>
+      <Q id="6428605683" qualifier_id="213" value="4.39"/>
+    </Event>
+    <Event id="2939830851" event_id="405" type_id="1" period_id="1" min="39" sec="43" player_id="627127" team_id="244" outcome="1" x="46.4" y="44.8" timestamp="2026-05-19T14:01:31.594" timestamp_utc="2026-05-19T13:01:31.594" last_modified="2026-05-19T14:01:33" version="1779195692429">
+      <Q id="6428605727" qualifier_id="56" value="Center"/>
+      <Q id="6428605729" qualifier_id="140" value="52.2"/>
+      <Q id="6428605731" qualifier_id="141" value="22.4"/>
+      <Q id="6428605733" qualifier_id="212" value="16.4"/>
+      <Q id="6428605735" qualifier_id="213" value="5.09"/>
+    </Event>
+    <Event id="2939830863" event_id="406" type_id="1" period_id="1" min="39" sec="45" player_id="240166" team_id="244" outcome="1" x="48.8" y="30.7" timestamp="2026-05-19T14:01:33.698" timestamp_utc="2026-05-19T13:01:33.698" last_modified="2026-05-19T14:01:36" version="1779195694475">
+      <Q id="6428605809" qualifier_id="56" value="Right"/>
+      <Q id="6428605811" qualifier_id="140" value="62.3"/>
+      <Q id="6428605813" qualifier_id="141" value="13.7"/>
+      <Q id="6428605815" qualifier_id="212" value="18.3"/>
+      <Q id="6428605817" qualifier_id="213" value="5.60"/>
+    </Event>
+    <Event id="2939830903" event_id="407" type_id="1" period_id="1" min="39" sec="48" player_id="625775" team_id="244" outcome="1" x="59.1" y="9.7" timestamp="2026-05-19T14:01:36.298" timestamp_utc="2026-05-19T13:01:36.298" last_modified="2026-05-19T14:01:43" version="1779195699924">
+      <Q id="6428605993" qualifier_id="56" value="Back"/>
+      <Q id="6428605995" qualifier_id="140" value="35.8"/>
+      <Q id="6428605997" qualifier_id="141" value="18.9"/>
+      <Q id="6428605999" qualifier_id="212" value="25.3"/>
+      <Q id="6428606001" qualifier_id="213" value="2.89"/>
+    </Event>
+    <Event id="2939830915" event_id="408" type_id="1" period_id="1" min="39" sec="55" player_id="627127" team_id="244" outcome="1" x="35.6" y="20.4" timestamp="2026-05-19T14:01:43.475" timestamp_utc="2026-05-19T13:01:43.475" last_modified="2026-05-19T14:01:47" version="1779195704108">
+      <Q id="6428606077" qualifier_id="56" value="Back"/>
+      <Q id="6428606079" qualifier_id="140" value="15.2"/>
+      <Q id="6428606081" qualifier_id="141" value="48.1"/>
+      <Q id="6428606083" qualifier_id="212" value="28.5"/>
+      <Q id="6428606085" qualifier_id="213" value="2.42"/>
+    </Event>
+    <Event id="2939830925" event_id="409" type_id="1" period_id="1" min="39" sec="59" player_id="578592" team_id="244" outcome="0" x="19.1" y="56.3" timestamp="2026-05-19T14:01:47.291" timestamp_utc="2026-05-19T13:01:47.291" last_modified="2026-05-19T14:01:50" version="1779195709596">
+      <Q id="6428606129" qualifier_id="1"/>
+      <Q id="6428606119" qualifier_id="56" value="Center"/>
+      <Q id="6428606121" qualifier_id="140" value="70.6"/>
+      <Q id="6428606123" qualifier_id="141" value="50.7"/>
+      <Q id="6428606117" qualifier_id="157"/>
+      <Q id="6428606125" qualifier_id="212" value="54.2"/>
+      <Q id="6428606127" qualifier_id="213" value="6.21"/>
+    </Event>
+    <Event id="2939830923" event_id="276" type_id="44" period_id="1" min="40" sec="1" player_id="61812" team_id="417" outcome="1" x="29.4" y="49.3" timestamp="2026-05-19T14:01:48.793" timestamp_utc="2026-05-19T13:01:48.793" last_modified="2026-05-19T15:45:38" version="1779201938513">
+      <Q id="6428606113" qualifier_id="56" value="Back"/>
+      <Q id="6428606165" qualifier_id="233" value="410"/>
+      <Q id="6428606115" qualifier_id="285"/>
+    </Event>
+    <Event id="2939830929" event_id="410" type_id="44" period_id="1" min="40" sec="1" player_id="479433" team_id="244" outcome="0" x="70.6" y="50.7" timestamp="2026-05-19T14:01:48.794" timestamp_utc="2026-05-19T13:01:48.794" last_modified="2026-05-19T15:45:38" version="1779201938792">
+      <Q id="6428606145" qualifier_id="56" value="Center"/>
+      <Q id="6428606167" qualifier_id="233" value="276"/>
+      <Q id="6428606147" qualifier_id="286"/>
+    </Event>
+    <Event id="2939830927" event_id="277" type_id="1" period_id="1" min="40" sec="1" player_id="61812" team_id="417" outcome="0" x="29.4" y="49.3" timestamp="2026-05-19T14:01:49.088" timestamp_utc="2026-05-19T13:01:49.088" last_modified="2026-05-19T15:45:39" version="1779201939061">
+      <Q id="6428606133" qualifier_id="3"/>
+      <Q id="6428606135" qualifier_id="56" value="Back"/>
+      <Q id="6428606137" qualifier_id="140" value="39.9"/>
+      <Q id="6428606139" qualifier_id="141" value="33.0"/>
+      <Q id="6428606141" qualifier_id="212" value="15.6"/>
+      <Q id="6428606143" qualifier_id="213" value="5.50"/>
+    </Event>
+    <Event id="2939830951" event_id="411" type_id="1" period_id="1" min="40" sec="3" player_id="648131" team_id="244" outcome="1" x="60.5" y="69.9" timestamp="2026-05-19T14:01:51.730" timestamp_utc="2026-05-19T13:01:51.730" last_modified="2026-05-19T14:01:58" version="1779195712037">
+      <Q id="6428606297" qualifier_id="56" value="Center"/>
+      <Q id="6428606299" qualifier_id="140" value="57.0"/>
+      <Q id="6428606301" qualifier_id="141" value="76.1"/>
+      <Q id="6428606303" qualifier_id="212" value="5.6"/>
+      <Q id="6428606305" qualifier_id="213" value="2.29"/>
+    </Event>
+    <Event id="2939830945" event_id="278" type_id="83" period_id="1" min="40" sec="9" player_id="157851" team_id="417" outcome="0" x="10.5" y="25.5" timestamp="2026-05-19T14:01:57.344" timestamp_utc="2026-05-19T13:01:57.344" last_modified="2026-05-19T14:02:00" version="1779195719916">
+      <Q id="6428606337" qualifier_id="399" value="207884"/>
+    </Event>
+    <Event id="2939830953" event_id="412" type_id="50" period_id="1" min="40" sec="10" player_id="207884" team_id="244" outcome="1" x="94.9" y="74.8" timestamp="2026-05-19T14:01:58.466" timestamp_utc="2026-05-19T13:01:58.466" last_modified="2026-05-19T14:17:45" version="1779196664951">
+      <Q id="6428606309" qualifier_id="56" value="Center"/>
+      <Q id="6428606397" qualifier_id="233" value="279"/>
+      <Q id="6428606311" qualifier_id="286"/>
+    </Event>
+    <Event id="2939830961" event_id="279" type_id="7" period_id="1" min="40" sec="10" player_id="531784" team_id="417" outcome="1" x="5.1" y="25.2" timestamp="2026-05-19T14:01:58.467" timestamp_utc="2026-05-19T13:01:58.467" last_modified="2026-05-19T14:17:45" version="1779196664942">
+      <Q id="6428606357" qualifier_id="56" value="Back"/>
+      <Q id="6428606361" qualifier_id="178"/>
+      <Q id="6428606383" qualifier_id="233" value="412"/>
+      <Q id="6428606359" qualifier_id="285"/>
+    </Event>
+    <Event id="2939830965" event_id="280" type_id="49" period_id="1" min="40" sec="13" player_id="157851" team_id="417" outcome="1" x="7.0" y="13.5" timestamp="2026-05-19T14:02:00.888" timestamp_utc="2026-05-19T13:02:00.888" last_modified="2026-05-19T14:02:01" version="1779195720889"/>
+    <Event id="2939830979" event_id="281" type_id="1" period_id="1" min="40" sec="13" player_id="157851" team_id="417" outcome="1" x="7.0" y="13.5" timestamp="2026-05-19T14:02:01.168" timestamp_utc="2026-05-19T13:02:01.168" last_modified="2026-05-19T14:02:02" version="1779195721467">
+      <Q id="6428606437" qualifier_id="56" value="Back"/>
+      <Q id="6428606439" qualifier_id="140" value="28.9"/>
+      <Q id="6428606441" qualifier_id="141" value="15.3"/>
+      <Q id="6428606435" qualifier_id="155"/>
+      <Q id="6428606443" qualifier_id="212" value="23.0"/>
+      <Q id="6428606445" qualifier_id="213" value="0.05"/>
+    </Event>
+    <Event id="2939830983" event_id="282" type_id="1" period_id="1" min="40" sec="15" player_id="685390" team_id="417" outcome="0" x="29.3" y="16.5" timestamp="2026-05-19T14:02:02.847" timestamp_utc="2026-05-19T13:02:02.847" last_modified="2026-05-19T14:02:03" version="1779195723280">
+      <Q id="6428606467" qualifier_id="3"/>
+      <Q id="6428606469" qualifier_id="56" value="Back"/>
+      <Q id="6428606471" qualifier_id="140" value="34.7"/>
+      <Q id="6428606473" qualifier_id="141" value="22.7"/>
+      <Q id="6428606475" qualifier_id="212" value="7.1"/>
+      <Q id="6428606477" qualifier_id="213" value="0.64"/>
+    </Event>
+    <Event id="2939831001" event_id="413" type_id="1" period_id="1" min="40" sec="17" player_id="180662" team_id="244" outcome="0" x="57.8" y="83.6" timestamp="2026-05-19T14:02:05.011" timestamp_utc="2026-05-19T13:02:05.011" last_modified="2026-05-19T14:02:05" version="1779195725819">
+      <Q id="6428606541" qualifier_id="1"/>
+      <Q id="6428606531" qualifier_id="56" value="Center"/>
+      <Q id="6428606533" qualifier_id="140" value="72.6"/>
+      <Q id="6428606535" qualifier_id="141" value="68.2"/>
+      <Q id="6428606529" qualifier_id="157"/>
+      <Q id="6428606537" qualifier_id="212" value="18.7"/>
+      <Q id="6428606539" qualifier_id="213" value="5.69"/>
+    </Event>
+    <Event id="2939831013" event_id="283" type_id="1" period_id="1" min="40" sec="18" player_id="218339" team_id="417" outcome="1" x="32.7" y="26.7" timestamp="2026-05-19T14:02:06.639" timestamp_utc="2026-05-19T13:02:06.639" last_modified="2026-05-19T14:02:08" version="1779195726904">
+      <Q id="6428606621" qualifier_id="3"/>
+      <Q id="6428606623" qualifier_id="56" value="Back"/>
+      <Q id="6428606625" qualifier_id="140" value="39.2"/>
+      <Q id="6428606627" qualifier_id="141" value="46.4"/>
+      <Q id="6428606629" qualifier_id="212" value="15.0"/>
+      <Q id="6428606631" qualifier_id="213" value="1.10"/>
+    </Event>
+    <Event id="2939831017" event_id="284" type_id="1" period_id="1" min="40" sec="20" player_id="61778" team_id="417" outcome="1" x="40.4" y="45.8" timestamp="2026-05-19T14:02:07.897" timestamp_utc="2026-05-19T13:02:07.897" last_modified="2026-05-19T14:02:08" version="1779195728239">
+      <Q id="6428606635" qualifier_id="56" value="Back"/>
+      <Q id="6428606637" qualifier_id="140" value="37.0"/>
+      <Q id="6428606639" qualifier_id="141" value="47.2"/>
+      <Q id="6428606647" qualifier_id="156"/>
+      <Q id="6428606641" qualifier_id="212" value="3.7"/>
+      <Q id="6428606643" qualifier_id="213" value="2.88"/>
+    </Event>
+    <Event id="2939831029" event_id="285" type_id="1" period_id="1" min="40" sec="23" player_id="720682" team_id="417" outcome="1" x="26.5" y="57.2" timestamp="2026-05-19T14:02:11.040" timestamp_utc="2026-05-19T13:02:11.040" last_modified="2026-05-19T14:02:13" version="1779195731331">
+      <Q id="6428606747" qualifier_id="56" value="Back"/>
+      <Q id="6428606749" qualifier_id="140" value="10.2"/>
+      <Q id="6428606751" qualifier_id="141" value="41.9"/>
+      <Q id="6428606753" qualifier_id="212" value="20.0"/>
+      <Q id="6428606755" qualifier_id="213" value="3.69"/>
+    </Event>
+    <Event id="2939831041" event_id="286" type_id="1" period_id="1" min="40" sec="25" player_id="565487" team_id="417" outcome="1" x="9.4" y="45.5" timestamp="2026-05-19T14:02:13.280" timestamp_utc="2026-05-19T13:02:13.280" last_modified="2026-05-19T14:02:15" version="1779195733500">
+      <Q id="6428606797" qualifier_id="56" value="Back"/>
+      <Q id="6428606799" qualifier_id="140" value="19.1"/>
+      <Q id="6428606801" qualifier_id="141" value="67.0"/>
+      <Q id="6428606803" qualifier_id="212" value="17.8"/>
+      <Q id="6428606805" qualifier_id="213" value="0.96"/>
+    </Event>
+    <Event id="2939831039" event_id="414" type_id="45" period_id="1" min="40" sec="27" player_id="625775" team_id="244" outcome="0" x="75.9" y="25.6" timestamp="2026-05-19T14:02:14.802" timestamp_utc="2026-05-19T13:02:14.802" last_modified="2026-05-19T14:17:46" version="1779196666258">
+      <Q id="6428606789" qualifier_id="56" value="Center"/>
+      <Q id="6428606949" qualifier_id="233" value="287"/>
+      <Q id="6428606791" qualifier_id="286"/>
+    </Event>
+    <Event id="2939831057" event_id="287" type_id="3" period_id="1" min="40" sec="27" player_id="624620" team_id="417" outcome="1" x="24.1" y="74.4" timestamp="2026-05-19T14:02:14.802" timestamp_utc="2026-05-19T13:02:14.802" last_modified="2026-05-19T14:17:46" version="1779196666246">
+      <Q id="6428606919" qualifier_id="56" value="Back"/>
+      <Q id="6428606941" qualifier_id="233" value="414"/>
+      <Q id="6428606921" qualifier_id="285"/>
+    </Event>
+    <Event id="2939831051" event_id="415" type_id="83" period_id="1" min="40" sec="30" player_id="232091" team_id="244" outcome="0" x="68.9" y="25.8" timestamp="2026-05-19T14:02:18.450" timestamp_utc="2026-05-19T13:02:18.450" last_modified="2026-05-19T14:02:25" version="1779195744560">
+      <Q id="6428606981" qualifier_id="399" value="624620"/>
+    </Event>
+    <Event id="2939831061" event_id="288" type_id="1" period_id="1" min="40" sec="35" player_id="624620" team_id="417" outcome="0" x="22.9" y="95.9" timestamp="2026-05-19T14:02:23.655" timestamp_utc="2026-05-19T13:02:23.655" last_modified="2026-05-19T14:02:25" version="1779195744038">
+      <Q id="6428606939" qualifier_id="1"/>
+      <Q id="6428606929" qualifier_id="56" value="Back"/>
+      <Q id="6428606931" qualifier_id="140" value="23.5"/>
+      <Q id="6428606933" qualifier_id="141" value="95.6"/>
+      <Q id="6428606927" qualifier_id="157"/>
+      <Q id="6428606935" qualifier_id="212" value="0.7"/>
+      <Q id="6428606937" qualifier_id="213" value="5.97"/>
+      <Q id="6428606975" qualifier_id="233" value="416"/>
+      <Q id="6428606969" qualifier_id="236"/>
+      <Q id="6428606973" qualifier_id="286"/>
+    </Event>
+    <Event id="2939831059" event_id="416" type_id="74" period_id="1" min="40" sec="35" player_id="232091" team_id="244" outcome="1" x="76.5" y="4.4" timestamp="2026-05-19T14:02:23.656" timestamp_utc="2026-05-19T13:02:23.656" last_modified="2026-05-19T15:45:51" version="1779201951826">
+      <Q id="6428606923" qualifier_id="56" value="Right"/>
+      <Q id="6428606979" qualifier_id="233" value="288"/>
+      <Q id="6428606925" qualifier_id="285"/>
+    </Event>
+    <Event id="2939831067" event_id="417" type_id="5" period_id="1" min="40" sec="36" player_id="232091" team_id="244" outcome="0" x="76.5" y="-1.6" timestamp="2026-05-19T14:02:24.570" timestamp_utc="2026-05-19T13:02:24.570" last_modified="2026-05-19T14:23:49" version="1779197029533">
+      <Q id="6428606965" qualifier_id="56" value="Right"/>
+      <Q id="6428607117" qualifier_id="233" value="289"/>
+      <Q id="6428606967" qualifier_id="347"/>
+    </Event>
+    <Event id="2939831093" event_id="289" type_id="5" period_id="1" min="40" sec="36" player_id="624620" team_id="417" outcome="1" x="23.5" y="101.6" timestamp="2026-05-19T14:02:24.570" timestamp_utc="2026-05-19T13:02:24.570" last_modified="2026-05-19T14:23:49" version="1779197029522">
+      <Q id="6428607105" qualifier_id="56" value="Back"/>
+      <Q id="6428607113" qualifier_id="233" value="417"/>
+      <Q id="6428607107" qualifier_id="347"/>
+    </Event>
+    <Event id="2939831103" event_id="290" type_id="1" period_id="1" min="40" sec="45" player_id="624620" team_id="417" outcome="1" x="32.2" y="100.0" timestamp="2026-05-19T14:02:33.433" timestamp_utc="2026-05-19T13:02:33.433" last_modified="2026-05-19T14:02:38" version="1779195754272">
+      <Q id="6428607175" qualifier_id="56" value="Back"/>
+      <Q id="6428607173" qualifier_id="107"/>
+      <Q id="6428607177" qualifier_id="140" value="40.5"/>
+      <Q id="6428607179" qualifier_id="141" value="79.9"/>
+      <Q id="6428607181" qualifier_id="212" value="17.2"/>
+      <Q id="6428607183" qualifier_id="213" value="5.24"/>
+    </Event>
+    <Event id="2939831109" event_id="291" type_id="1" period_id="1" min="40" sec="50" player_id="685390" team_id="417" outcome="1" x="43.2" y="75.9" timestamp="2026-05-19T14:02:38.567" timestamp_utc="2026-05-19T13:02:38.567" last_modified="2026-05-19T14:02:40" version="1779195758644">
+      <Q id="6428607199" qualifier_id="56" value="Back"/>
+      <Q id="6428607201" qualifier_id="140" value="43.5"/>
+      <Q id="6428607203" qualifier_id="141" value="80.0"/>
+      <Q id="6428607205" qualifier_id="212" value="2.8"/>
+      <Q id="6428607207" qualifier_id="213" value="1.46"/>
+    </Event>
+    <Event id="2939831105" event_id="418" type_id="43" period_id="1" min="40" sec="51" player_id="515742" team_id="244" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T14:02:39.018" timestamp_utc="2026-05-19T13:02:39.018" last_modified="2026-05-19T14:02:56" version="1779195760131">
+      <Q id="6428607563" qualifier_id="144" value="83"/>
+      <Q id="6428607227" qualifier_id="399" value="61778"/>
+    </Event>
+    <Event id="2939831113" event_id="292" type_id="3" period_id="1" min="40" sec="52" player_id="61778" team_id="417" outcome="0" x="48.7" y="79.0" timestamp="2026-05-19T14:02:39.944" timestamp_utc="2026-05-19T13:02:39.944" last_modified="2026-05-19T14:17:45" version="1779196664990">
+      <Q id="6428607223" qualifier_id="56" value="Back"/>
+      <Q id="6428617917" qualifier_id="233" value="419"/>
+      <Q id="6428607225" qualifier_id="286"/>
+    </Event>
+    <Event id="2939831115" event_id="419" type_id="7" period_id="1" min="40" sec="52" player_id="515742" team_id="244" outcome="0" x="51.3" y="21.0" timestamp="2026-05-19T14:02:39.945" timestamp_utc="2026-05-19T13:02:39.945" last_modified="2026-05-19T14:17:45" version="1779196664981">
+      <Q id="6428607229" qualifier_id="56" value="Right"/>
+      <Q id="6428607233" qualifier_id="178"/>
+      <Q id="6428617921" qualifier_id="233" value="292"/>
+      <Q id="6428607231" qualifier_id="285"/>
+    </Event>
+    <Event id="2939831917" event_id="312" type_id="61" period_id="1" min="40" sec="52" player_id="61778" team_id="417" outcome="1" x="45.9" y="93.2" timestamp="2026-05-19T14:02:40.371" timestamp_utc="2026-05-19T13:02:40.371" last_modified="2026-05-19T14:11:58" version="1779196318247">
+      <Q id="6428611787" qualifier_id="56" value="Back"/>
+    </Event>
+    <Event id="2939831117" event_id="420" type_id="1" period_id="1" min="40" sec="53" player_id="232091" team_id="244" outcome="0" x="39.2" y="27.1" timestamp="2026-05-19T14:02:41.667" timestamp_utc="2026-05-19T13:02:41.667" last_modified="2026-05-19T14:03:47" version="1779195827481">
+      <Q id="6428607259" qualifier_id="1"/>
+      <Q id="6428607249" qualifier_id="56" value="Right"/>
+      <Q id="6428607251" qualifier_id="140" value="66.7"/>
+      <Q id="6428607253" qualifier_id="141" value="9.5"/>
+      <Q id="6428607247" qualifier_id="157"/>
+      <Q id="6428607255" qualifier_id="212" value="31.3"/>
+      <Q id="6428607257" qualifier_id="213" value="5.89"/>
+    </Event>
+    <Event id="2939831121" event_id="293" type_id="1" period_id="1" min="40" sec="55" player_id="61812" team_id="417" outcome="1" x="33.3" y="64.9" timestamp="2026-05-19T14:02:42.783" timestamp_utc="2026-05-19T13:02:42.783" last_modified="2026-05-19T14:02:45" version="1779195762912">
+      <Q id="6428607309" qualifier_id="3"/>
+      <Q id="6428607311" qualifier_id="56" value="Back"/>
+      <Q id="6428607313" qualifier_id="140" value="36.7"/>
+      <Q id="6428607315" qualifier_id="141" value="74.7"/>
+      <Q id="6428607317" qualifier_id="212" value="7.6"/>
+      <Q id="6428607319" qualifier_id="213" value="1.08"/>
+    </Event>
+    <Event id="2939831133" event_id="294" type_id="1" period_id="1" min="40" sec="57" player_id="624620" team_id="417" outcome="1" x="34.7" y="82.7" timestamp="2026-05-19T14:02:45.393" timestamp_utc="2026-05-19T13:02:45.393" last_modified="2026-05-19T14:02:50" version="1779195766163">
+      <Q id="6428607357" qualifier_id="56" value="Center"/>
+      <Q id="6428607359" qualifier_id="140" value="52.7"/>
+      <Q id="6428607361" qualifier_id="141" value="62.7"/>
+      <Q id="6428607355" qualifier_id="155"/>
+      <Q id="6428607363" qualifier_id="212" value="23.3"/>
+      <Q id="6428607365" qualifier_id="213" value="5.66"/>
+    </Event>
+    <Event id="2939831125" event_id="421" type_id="83" period_id="1" min="40" sec="59" player_id="648131" team_id="244" outcome="0" x="50.8" y="25.2" timestamp="2026-05-19T14:02:47.706" timestamp_utc="2026-05-19T13:02:47.706" last_modified="2026-05-19T14:02:51" version="1779195770681">
+      <Q id="6428607399" qualifier_id="399" value="685390"/>
+    </Event>
+    <Event id="2939831137" event_id="295" type_id="1" period_id="1" min="41" sec="2" player_id="685390" team_id="417" outcome="0" x="51.9" y="66.3" timestamp="2026-05-19T14:02:50.162" timestamp_utc="2026-05-19T13:02:50.162" last_modified="2026-05-19T14:02:51" version="1779195771368">
+      <Q id="6428607373" qualifier_id="56" value="Center"/>
+      <Q id="6428607375" qualifier_id="140" value="53.3"/>
+      <Q id="6428607377" qualifier_id="141" value="68.4"/>
+      <Q id="6428607379" qualifier_id="212" value="2.0"/>
+      <Q id="6428607381" qualifier_id="213" value="0.77"/>
+      <Q id="6428607417" qualifier_id="233" value="422"/>
+      <Q id="6428607411" qualifier_id="236"/>
+      <Q id="6428607415" qualifier_id="286"/>
+    </Event>
+    <Event id="2939831141" event_id="422" type_id="74" period_id="1" min="41" sec="2" player_id="232091" team_id="244" outcome="1" x="46.7" y="31.6" timestamp="2026-05-19T14:02:50.163" timestamp_utc="2026-05-19T13:02:50.163" last_modified="2026-05-19T15:45:52" version="1779201952110">
+      <Q id="6428607403" qualifier_id="56" value="Back"/>
+      <Q id="6428607425" qualifier_id="233" value="295"/>
+      <Q id="6428607405" qualifier_id="285"/>
+    </Event>
+    <Event id="2939831773" event_id="440" type_id="3" period_id="1" min="41" sec="3" player_id="207884" team_id="244" outcome="0" x="48.2" y="42.1" timestamp="2026-05-19T14:02:51.410" timestamp_utc="2026-05-19T13:02:51.410" last_modified="2026-05-19T14:17:46" version="1779196665000">
+      <Q id="6428610957" qualifier_id="56" value="Back"/>
+      <Q id="6428611049" qualifier_id="233" value="296"/>
+      <Q id="6428610959" qualifier_id="286"/>
+    </Event>
+    <Event id="2939831157" event_id="296" type_id="7" period_id="1" min="41" sec="3" player_id="720682" team_id="417" outcome="1" x="51.8" y="57.9" timestamp="2026-05-19T14:02:51.411" timestamp_utc="2026-05-19T13:02:51.411" last_modified="2026-05-19T14:17:46" version="1779196664994">
+      <Q id="6428607511" qualifier_id="56" value="Center"/>
+      <Q id="6428611045" qualifier_id="233" value="440"/>
+      <Q id="6428609421" qualifier_id="285"/>
+    </Event>
+    <Event id="2939832033" event_id="450" type_id="61" period_id="1" min="41" sec="3" player_id="207884" team_id="244" outcome="1" x="67.6" y="46.0" timestamp="2026-05-19T14:02:51.531" timestamp_utc="2026-05-19T13:02:51.531" last_modified="2026-05-19T14:06:09" version="1779195969221">
+      <Q id="6428612479" qualifier_id="56" value="Center"/>
+    </Event>
+    <Event id="2939831169" event_id="297" type_id="1" period_id="1" min="41" sec="6" player_id="218339" team_id="417" outcome="1" x="45.3" y="51.5" timestamp="2026-05-19T14:02:54.247" timestamp_utc="2026-05-19T13:02:54.247" last_modified="2026-05-19T14:02:57" version="1779195774969">
+      <Q id="6428607583" qualifier_id="56" value="Right"/>
+      <Q id="6428607585" qualifier_id="140" value="57.7"/>
+      <Q id="6428607587" qualifier_id="141" value="18.0"/>
+      <Q id="6428607589" qualifier_id="212" value="26.2"/>
+      <Q id="6428607591" qualifier_id="213" value="5.23"/>
+    </Event>
+    <Event id="2939831191" event_id="298" type_id="1" period_id="1" min="41" sec="10" player_id="157851" team_id="417" outcome="1" x="58.4" y="8.9" timestamp="2026-05-19T14:02:58.343" timestamp_utc="2026-05-19T13:02:58.343" last_modified="2026-05-19T14:03:04" version="1779195778639">
+      <Q id="6428607703" qualifier_id="56" value="Right"/>
+      <Q id="6428607705" qualifier_id="140" value="79.1"/>
+      <Q id="6428607707" qualifier_id="141" value="13.4"/>
+      <Q id="6428607709" qualifier_id="212" value="21.9"/>
+      <Q id="6428607711" qualifier_id="213" value="0.14"/>
+    </Event>
+    <Event id="2939831179" event_id="423" type_id="83" period_id="1" min="41" sec="12" player_id="180662" team_id="244" outcome="0" x="16.9" y="89.6" timestamp="2026-05-19T14:03:00.363" timestamp_utc="2026-05-19T13:03:00.363" last_modified="2026-05-19T14:03:06" version="1779195786316">
+      <Q id="6428607773" qualifier_id="399" value="445539"/>
+    </Event>
+    <Event id="2939831183" event_id="424" type_id="43" period_id="1" min="41" sec="14" player_id="180662" team_id="244" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T14:03:02.282" timestamp_utc="2026-05-19T13:03:02.282" last_modified="2026-05-19T14:03:12" version="1779195786310">
+      <Q id="6428607921" qualifier_id="144" value="83"/>
+      <Q id="6428607767" qualifier_id="399" value="445539"/>
+    </Event>
+    <Event id="2939831195" event_id="299" type_id="43" period_id="1" min="41" sec="16" player_id="445539" team_id="417" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T14:03:04.583" timestamp_utc="2026-05-19T13:03:04.583" last_modified="2026-05-19T14:03:11" version="1779195784904">
+      <Q id="6428607727" qualifier_id="56" value="Center"/>
+      <Q id="6428607729" qualifier_id="140" value="68.0"/>
+      <Q id="6428607731" qualifier_id="141" value="32.4"/>
+      <Q id="6428607869" qualifier_id="144" value="1"/>
+      <Q id="6428607733" qualifier_id="212" value="6.2"/>
+      <Q id="6428607735" qualifier_id="213" value="1.94"/>
+    </Event>
+    <Event id="2939831207" event_id="300" type_id="4" period_id="1" min="41" sec="19" player_id="445539" team_id="417" outcome="1" x="73.2" y="19.8" timestamp="2026-05-19T14:03:07.055" timestamp_utc="2026-05-19T13:03:07.055" last_modified="2026-05-19T14:03:13" version="1779195793011">
+      <Q id="6428607789" qualifier_id="13"/>
+      <Q id="6428607793" qualifier_id="56" value="Right"/>
+      <Q id="6428607795" qualifier_id="152"/>
+      <Q id="6428607885" qualifier_id="233" value="426"/>
+      <Q id="6428607797" qualifier_id="286"/>
+      <Q id="6428607791" qualifier_id="295"/>
+    </Event>
+    <Event id="2939831211" event_id="426" type_id="4" period_id="1" min="41" sec="19" player_id="180662" team_id="244" outcome="0" x="26.8" y="80.2" timestamp="2026-05-19T14:03:07.056" timestamp_utc="2026-05-19T13:03:07.056" last_modified="2026-05-19T14:03:12" version="1779195791424">
+      <Q id="6428607859" qualifier_id="13"/>
+      <Q id="6428607863" qualifier_id="56" value="Back"/>
+      <Q id="6428607865" qualifier_id="152"/>
+      <Q id="6428607901" qualifier_id="233" value="300"/>
+      <Q id="6428607867" qualifier_id="285"/>
+      <Q id="6428607861" qualifier_id="295"/>
+    </Event>
+    <Event id="2939831455" event_id="301" type_id="1" period_id="1" min="42" sec="2" player_id="685390" team_id="417" outcome="1" x="75.2" y="12.8" timestamp="2026-05-19T14:03:50.160" timestamp_utc="2026-05-19T13:03:50.160" last_modified="2026-05-19T14:04:05" version="1779195833480">
+      <Q id="6428609123" qualifier_id="1"/>
+      <Q id="6428609105" qualifier_id="2"/>
+      <Q id="6428609107" qualifier_id="5"/>
+      <Q id="6428609113" qualifier_id="56" value="Left"/>
+      <Q id="6428609115" qualifier_id="140" value="92.2"/>
+      <Q id="6428609117" qualifier_id="141" value="83.0"/>
+      <Q id="6428609111" qualifier_id="152"/>
+      <Q id="6428609109" qualifier_id="155"/>
+      <Q id="6428609119" qualifier_id="212" value="51.0"/>
+      <Q id="6428609121" qualifier_id="213" value="1.21"/>
+    </Event>
+    <Event id="2939831405" event_id="427" type_id="83" period_id="1" min="42" sec="9" player_id="240166" team_id="244" outcome="0" x="5.2" y="6.8" timestamp="2026-05-19T14:03:57.026" timestamp_utc="2026-05-19T13:03:57.026" last_modified="2026-05-19T14:12:06" version="1779196326556">
+      <Q id="6428623397" qualifier_id="399" value="61812"/>
+    </Event>
+    <Event id="2939831421" event_id="428" type_id="43" period_id="1" min="42" sec="11" player_id="240166" team_id="244" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T14:03:59.522" timestamp_utc="2026-05-19T13:03:59.522" last_modified="2026-05-19T14:04:07" version="1779195840203">
+      <Q id="6428608943" qualifier_id="56" value="Back"/>
+      <Q id="6428609159" qualifier_id="144" value="7"/>
+      <Q id="6428608941" qualifier_id="167" value="0"/>
+      <Q id="6428608947" qualifier_id="178" value="0"/>
+      <Q id="6428608945" qualifier_id="285" value="0"/>
+    </Event>
+    <Event id="2939831457" event_id="302" type_id="61" period_id="1" min="42" sec="17" player_id="61812" team_id="417" outcome="0" x="89.9" y="96.2" timestamp="2026-05-19T14:04:05.718" timestamp_utc="2026-05-19T13:04:05.718" last_modified="2026-05-19T14:04:06" version="1779195845719">
+      <Q id="6428609133" qualifier_id="56" value="Left"/>
+    </Event>
+    <Event id="2939831427" event_id="429" type_id="5" period_id="1" min="42" sec="18" player_id="240166" team_id="244" outcome="1" x="8.8" y="-1.2" timestamp="2026-05-19T14:04:06.203" timestamp_utc="2026-05-19T13:04:06.203" last_modified="2026-05-19T14:12:06" version="1779196326179">
+      <Q id="6428608961" qualifier_id="56" value="Back"/>
+      <Q id="6428623383" qualifier_id="233" value="303"/>
+      <Q id="6428608963" qualifier_id="347"/>
+    </Event>
+    <Event id="2939831463" event_id="303" type_id="5" period_id="1" min="42" sec="18" player_id="61812" team_id="417" outcome="0" x="91.3" y="101.3" timestamp="2026-05-19T14:04:06.203" timestamp_utc="2026-05-19T13:04:06.203" last_modified="2026-05-19T14:23:50" version="1779197029551">
+      <Q id="6428609151" qualifier_id="56" value="Left"/>
+      <Q id="6428623393" qualifier_id="233" value="429"/>
+      <Q id="6428609153" qualifier_id="347"/>
+    </Event>
+    <Event id="2939831551" event_id="430" type_id="1" period_id="1" min="42" sec="36" player_id="240166" team_id="244" outcome="1" x="19.2" y="0.0" timestamp="2026-05-19T14:04:24.714" timestamp_utc="2026-05-19T13:04:24.714" last_modified="2026-05-19T14:04:35" version="1779195875431">
+      <Q id="6428609675" qualifier_id="56" value="Back"/>
+      <Q id="6428609813" qualifier_id="107"/>
+      <Q id="6428609677" qualifier_id="140" value="34.3"/>
+      <Q id="6428609679" qualifier_id="141" value="2.8"/>
+      <Q id="6428609681" qualifier_id="212" value="16.2"/>
+      <Q id="6428609683" qualifier_id="213" value="0.20"/>
+    </Event>
+    <Event id="2939831555" event_id="431" type_id="61" period_id="1" min="42" sec="41" player_id="625775" team_id="244" outcome="1" x="34.3" y="2.8" timestamp="2026-05-19T14:04:29.074" timestamp_utc="2026-05-19T13:04:29.074" last_modified="2026-05-19T14:04:29" version="1779195869076">
+      <Q id="6428609691" qualifier_id="56" value="Back"/>
+    </Event>
+    <Event id="2939831569" event_id="304" type_id="12" period_id="1" min="42" sec="43" player_id="218339" team_id="417" outcome="1" x="59.3" y="94.1" timestamp="2026-05-19T14:04:31.678" timestamp_utc="2026-05-19T13:04:31.678" last_modified="2026-05-19T14:04:32" version="1779195872109">
+      <Q id="6428609757" qualifier_id="56" value="Left"/>
+      <Q id="6428609759" qualifier_id="140" value="58.2"/>
+      <Q id="6428609761" qualifier_id="141" value="100.0"/>
+      <Q id="6428609771" qualifier_id="167"/>
+      <Q id="6428609763" qualifier_id="212" value="5.4"/>
+      <Q id="6428609765" qualifier_id="213" value="1.79"/>
+    </Event>
+    <Event id="2939831571" event_id="305" type_id="5" period_id="1" min="42" sec="44" player_id="218339" team_id="417" outcome="0" x="58.6" y="101.8" timestamp="2026-05-19T14:04:32.080" timestamp_utc="2026-05-19T13:04:32.080" last_modified="2026-05-19T14:13:13" version="1779196392813">
+      <Q id="6428609767" qualifier_id="56" value="Left"/>
+      <Q id="6428609807" qualifier_id="233" value="432"/>
+      <Q id="6428609769" qualifier_id="347"/>
+    </Event>
+    <Event id="2939831577" event_id="432" type_id="5" period_id="1" min="42" sec="44" player_id="625775" team_id="244" outcome="1" x="41.4" y="-1.8" timestamp="2026-05-19T14:04:32.080" timestamp_utc="2026-05-19T13:04:32.080" last_modified="2026-05-19T14:23:50" version="1779197029567">
+      <Q id="6428609797" qualifier_id="56" value="Back"/>
+      <Q id="6428609803" qualifier_id="233" value="305"/>
+      <Q id="6428609799" qualifier_id="347"/>
+    </Event>
+    <Event id="2939831643" event_id="433" type_id="1" period_id="1" min="42" sec="59" player_id="240166" team_id="244" outcome="1" x="48.4" y="0.0" timestamp="2026-05-19T14:04:47.250" timestamp_utc="2026-05-19T13:04:47.250" last_modified="2026-05-19T14:04:48" version="1779195887532">
+      <Q id="6428610217" qualifier_id="56" value="Back"/>
+      <Q id="6428610215" qualifier_id="107"/>
+      <Q id="6428610219" qualifier_id="140" value="40.6"/>
+      <Q id="6428610221" qualifier_id="141" value="9.7"/>
+      <Q id="6428610223" qualifier_id="212" value="11.4"/>
+      <Q id="6428610225" qualifier_id="213" value="2.37"/>
+    </Event>
+    <Event id="2939831655" event_id="434" type_id="1" period_id="1" min="43" sec="0" player_id="515742" team_id="244" outcome="1" x="40.6" y="10.7" timestamp="2026-05-19T14:04:48.450" timestamp_utc="2026-05-19T13:04:48.450" last_modified="2026-05-19T14:04:51" version="1779195889084">
+      <Q id="6428610299" qualifier_id="56" value="Back"/>
+      <Q id="6428610301" qualifier_id="140" value="40.1"/>
+      <Q id="6428610303" qualifier_id="141" value="4.7"/>
+      <Q id="6428610305" qualifier_id="212" value="4.1"/>
+      <Q id="6428610307" qualifier_id="213" value="4.58"/>
+    </Event>
+    <Event id="2939831657" event_id="435" type_id="3" period_id="1" min="43" sec="3" player_id="240166" team_id="244" outcome="1" x="40.4" y="7.0" timestamp="2026-05-19T14:04:51.122" timestamp_utc="2026-05-19T13:04:51.122" last_modified="2026-05-19T14:04:53" version="1779195893043">
+      <Q id="6428610313" qualifier_id="56" value="Back"/>
+      <Q id="6428610323" qualifier_id="233" value="306"/>
+      <Q id="6428610315" qualifier_id="286"/>
+    </Event>
+    <Event id="2939831659" event_id="306" type_id="45" period_id="1" min="43" sec="3" player_id="61778" team_id="417" outcome="0" x="59.6" y="92.9" timestamp="2026-05-19T14:04:51.122" timestamp_utc="2026-05-19T13:04:51.122" last_modified="2026-05-19T14:04:52" version="1779195891755">
+      <Q id="6428610317" qualifier_id="56" value="Left"/>
+      <Q id="6428610331" qualifier_id="233" value="435"/>
+      <Q id="6428610319" qualifier_id="285"/>
+    </Event>
+    <Event id="2939831679" event_id="436" type_id="1" period_id="1" min="43" sec="3" player_id="240166" team_id="244" outcome="1" x="40.4" y="4.9" timestamp="2026-05-19T14:04:51.442" timestamp_utc="2026-05-19T13:04:51.442" last_modified="2026-05-19T14:04:54" version="1779195892189">
+      <Q id="6428610415" qualifier_id="56" value="Back"/>
+      <Q id="6428610417" qualifier_id="140" value="30.5"/>
+      <Q id="6428610419" qualifier_id="141" value="12.9"/>
+      <Q id="6428610421" qualifier_id="212" value="11.7"/>
+      <Q id="6428610423" qualifier_id="213" value="2.66"/>
+    </Event>
+    <Event id="2939831697" event_id="437" type_id="1" period_id="1" min="43" sec="6" player_id="627127" team_id="244" outcome="1" x="28.9" y="17.1" timestamp="2026-05-19T14:04:53.914" timestamp_utc="2026-05-19T13:04:53.914" last_modified="2026-05-19T14:04:58" version="1779195894421">
+      <Q id="6428610505" qualifier_id="56" value="Back"/>
+      <Q id="6428610507" qualifier_id="140" value="15.2"/>
+      <Q id="6428610509" qualifier_id="141" value="46.4"/>
+      <Q id="6428610511" qualifier_id="212" value="24.6"/>
+      <Q id="6428610513" qualifier_id="213" value="2.20"/>
+    </Event>
+    <Event id="2939831705" event_id="438" type_id="1" period_id="1" min="43" sec="10" player_id="578592" team_id="244" outcome="0" x="19.9" y="49.3" timestamp="2026-05-19T14:04:57.947" timestamp_utc="2026-05-19T13:04:57.947" last_modified="2026-05-19T14:05:00" version="1779195899895">
+      <Q id="6428610553" qualifier_id="1"/>
+      <Q id="6428610543" qualifier_id="56" value="Left"/>
+      <Q id="6428610545" qualifier_id="140" value="64.0"/>
+      <Q id="6428610547" qualifier_id="141" value="100.0"/>
+      <Q id="6428610541" qualifier_id="155"/>
+      <Q id="6428610549" qualifier_id="212" value="58.4"/>
+      <Q id="6428610551" qualifier_id="213" value="0.66"/>
+    </Event>
+    <Event id="2939831709" event_id="439" type_id="5" period_id="1" min="43" sec="12" player_id="578592" team_id="244" outcome="0" x="62.0" y="101.8" timestamp="2026-05-19T14:04:59.910" timestamp_utc="2026-05-19T13:04:59.910" last_modified="2026-05-19T14:23:50" version="1779197029575">
+      <Q id="6428610567" qualifier_id="56" value="Left"/>
+      <Q id="6428610595" qualifier_id="233" value="307"/>
+      <Q id="6428610569" qualifier_id="347"/>
+    </Event>
+    <Event id="2939831713" event_id="307" type_id="5" period_id="1" min="43" sec="12" player_id="61778" team_id="417" outcome="1" x="38.0" y="-1.8" timestamp="2026-05-19T14:04:59.910" timestamp_utc="2026-05-19T13:04:59.910" last_modified="2026-05-19T14:23:50" version="1779197029570">
+      <Q id="6428610583" qualifier_id="56" value="Back"/>
+      <Q id="6428610591" qualifier_id="233" value="439"/>
+      <Q id="6428610585" qualifier_id="347"/>
+    </Event>
+    <Event id="2939831743" event_id="308" type_id="1" period_id="1" min="43" sec="19" player_id="531784" team_id="417" outcome="1" x="42.6" y="0.0" timestamp="2026-05-19T14:05:07.029" timestamp_utc="2026-05-19T13:05:07.029" last_modified="2026-05-19T14:05:10" version="1779195908112">
+      <Q id="6428610781" qualifier_id="1"/>
+      <Q id="6428610771" qualifier_id="56" value="Back"/>
+      <Q id="6428610769" qualifier_id="107"/>
+      <Q id="6428610773" qualifier_id="140" value="15.7"/>
+      <Q id="6428610775" qualifier_id="141" value="21.9"/>
+      <Q id="6428610777" qualifier_id="212" value="32.2"/>
+      <Q id="6428610779" qualifier_id="213" value="2.64"/>
+    </Event>
+    <Event id="2939831793" event_id="309" type_id="1" period_id="1" min="43" sec="22" player_id="61812" team_id="417" outcome="1" x="18.7" y="15.6" timestamp="2026-05-19T14:05:10.349" timestamp_utc="2026-05-19T13:05:10.349" last_modified="2026-05-19T14:05:20" version="1779195910806">
+      <Q id="6428611053" qualifier_id="56" value="Back"/>
+      <Q id="6428611055" qualifier_id="140" value="8.6"/>
+      <Q id="6428611057" qualifier_id="141" value="52.8"/>
+      <Q id="6428611059" qualifier_id="212" value="27.4"/>
+      <Q id="6428611061" qualifier_id="213" value="1.97"/>
+    </Event>
+    <Event id="2939831823" event_id="310" type_id="1" period_id="1" min="43" sec="32" player_id="565487" team_id="417" outcome="1" x="12.1" y="56.6" timestamp="2026-05-19T14:05:20.173" timestamp_utc="2026-05-19T13:05:20.173" last_modified="2026-05-19T14:05:25" version="1779195920374">
+      <Q id="6428611201" qualifier_id="56" value="Back"/>
+      <Q id="6428611203" qualifier_id="140" value="18.1"/>
+      <Q id="6428611205" qualifier_id="141" value="76.0"/>
+      <Q id="6428611207" qualifier_id="212" value="14.6"/>
+      <Q id="6428611209" qualifier_id="213" value="1.13"/>
+    </Event>
+    <Event id="2939831829" event_id="311" type_id="1" period_id="1" min="43" sec="37" player_id="624620" team_id="417" outcome="0" x="16.7" y="85.1" timestamp="2026-05-19T14:05:25.421" timestamp_utc="2026-05-19T13:05:25.421" last_modified="2026-05-19T14:05:26" version="1779195926246">
+      <Q id="6428611241" qualifier_id="1"/>
+      <Q id="6428611231" qualifier_id="56" value="Left"/>
+      <Q id="6428611233" qualifier_id="140" value="69.2"/>
+      <Q id="6428611235" qualifier_id="141" value="90.2"/>
+      <Q id="6428611229" qualifier_id="157"/>
+      <Q id="6428611237" qualifier_id="212" value="55.2"/>
+      <Q id="6428611239" qualifier_id="213" value="0.06"/>
+    </Event>
+    <Event id="2939831839" event_id="441" type_id="49" period_id="1" min="43" sec="39" player_id="232091" team_id="244" outcome="1" x="37.7" y="11.7" timestamp="2026-05-19T14:05:27.147" timestamp_utc="2026-05-19T13:05:27.147" last_modified="2026-05-19T14:05:27" version="1779195927148"/>
+    <Event id="2939831863" event_id="442" type_id="1" period_id="1" min="43" sec="40" player_id="232091" team_id="244" outcome="1" x="36.6" y="11.7" timestamp="2026-05-19T14:05:27.971" timestamp_utc="2026-05-19T13:05:27.971" last_modified="2026-05-19T14:05:32" version="1779195929061">
+      <Q id="6428611393" qualifier_id="56" value="Back"/>
+      <Q id="6428611395" qualifier_id="140" value="12.9"/>
+      <Q id="6428611397" qualifier_id="141" value="33.1"/>
+      <Q id="6428611399" qualifier_id="212" value="28.8"/>
+      <Q id="6428611401" qualifier_id="213" value="2.61"/>
+    </Event>
+    <Event id="2939831879" event_id="443" type_id="1" period_id="1" min="43" sec="44" player_id="578592" team_id="244" outcome="1" x="12.3" y="35.1" timestamp="2026-05-19T14:05:32.306" timestamp_utc="2026-05-19T13:05:32.306" last_modified="2026-05-19T14:05:35" version="1779195932781">
+      <Q id="6428611525" qualifier_id="56" value="Back"/>
+      <Q id="6428611527" qualifier_id="140" value="23.7"/>
+      <Q id="6428611529" qualifier_id="141" value="77.9"/>
+      <Q id="6428611531" qualifier_id="212" value="31.5"/>
+      <Q id="6428611533" qualifier_id="213" value="1.18"/>
+    </Event>
+    <Event id="2939831889" event_id="444" type_id="1" period_id="1" min="43" sec="47" player_id="575855" team_id="244" outcome="1" x="24.0" y="75.4" timestamp="2026-05-19T14:05:35.450" timestamp_utc="2026-05-19T13:05:35.450" last_modified="2026-05-19T14:05:37" version="1779195935909">
+      <Q id="6428611577" qualifier_id="56" value="Back"/>
+      <Q id="6428611579" qualifier_id="140" value="13.9"/>
+      <Q id="6428611581" qualifier_id="141" value="66.1"/>
+      <Q id="6428611583" qualifier_id="212" value="12.3"/>
+      <Q id="6428611585" qualifier_id="213" value="3.68"/>
+    </Event>
+    <Event id="2939831903" event_id="445" type_id="1" period_id="1" min="43" sec="50" player_id="627127" team_id="244" outcome="1" x="14.2" y="67.8" timestamp="2026-05-19T14:05:37.842" timestamp_utc="2026-05-19T13:05:37.842" last_modified="2026-05-19T14:05:41" version="1779195938662">
+      <Q id="6428611705" qualifier_id="56" value="Back"/>
+      <Q id="6428611707" qualifier_id="140" value="21.6"/>
+      <Q id="6428611709" qualifier_id="141" value="61.7"/>
+      <Q id="6428611711" qualifier_id="212" value="8.8"/>
+      <Q id="6428611713" qualifier_id="213" value="5.79"/>
+    </Event>
+    <Event id="2939831927" event_id="446" type_id="1" period_id="1" min="43" sec="53" player_id="515742" team_id="244" outcome="1" x="15.6" y="57.9" timestamp="2026-05-19T14:05:41.170" timestamp_utc="2026-05-19T13:05:41.170" last_modified="2026-05-19T14:05:46" version="1779195943349">
+      <Q id="6428611853" qualifier_id="56" value="Back"/>
+      <Q id="6428611855" qualifier_id="140" value="19.2"/>
+      <Q id="6428611857" qualifier_id="141" value="32.4"/>
+      <Q id="6428611859" qualifier_id="212" value="17.7"/>
+      <Q id="6428611861" qualifier_id="213" value="4.93"/>
+    </Event>
+    <Event id="2939831937" event_id="447" type_id="1" period_id="1" min="43" sec="58" player_id="180662" team_id="244" outcome="0" x="29.7" y="30.7" timestamp="2026-05-19T14:05:46.355" timestamp_utc="2026-05-19T13:05:46.355" last_modified="2026-05-19T14:05:48" version="1779195948573">
+      <Q id="6428611917" qualifier_id="1"/>
+      <Q id="6428611907" qualifier_id="56" value="Right"/>
+      <Q id="6428611909" qualifier_id="140" value="63.9"/>
+      <Q id="6428611911" qualifier_id="141" value="0.0"/>
+      <Q id="6428611905" qualifier_id="155"/>
+      <Q id="6428611913" qualifier_id="212" value="42.0"/>
+      <Q id="6428611915" qualifier_id="213" value="5.74"/>
+    </Event>
+    <Event id="2939831939" event_id="448" type_id="5" period_id="1" min="44" sec="0" player_id="180662" team_id="244" outcome="0" x="61.5" y="-1.6" timestamp="2026-05-19T14:05:48.588" timestamp_utc="2026-05-19T13:05:48.588" last_modified="2026-05-19T14:23:51" version="1779197029584">
+      <Q id="6428611921" qualifier_id="56" value="Right"/>
+      <Q id="6428612043" qualifier_id="233" value="313"/>
+      <Q id="6428611923" qualifier_id="347"/>
+    </Event>
+    <Event id="2939831953" event_id="313" type_id="5" period_id="1" min="44" sec="0" player_id="61778" team_id="417" outcome="1" x="38.5" y="101.6" timestamp="2026-05-19T14:05:48.588" timestamp_utc="2026-05-19T13:05:48.588" last_modified="2026-05-19T14:23:51" version="1779197029578">
+      <Q id="6428612027" qualifier_id="56" value="Back"/>
+      <Q id="6428612031" qualifier_id="233" value="448"/>
+      <Q id="6428612029" qualifier_id="347"/>
+    </Event>
+    <Event id="2939831951" event_id="449" type_id="43" period_id="1" min="44" sec="4" player_id="180662" team_id="244" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T14:05:52.603" timestamp_utc="2026-05-19T13:05:52.603" last_modified="2026-05-19T14:06:14" version="1779195952604">
+      <Q id="6428612021" qualifier_id="56" value="Right"/>
+      <Q id="6428612751" qualifier_id="144" value="56"/>
+    </Event>
+    <Event id="2939831957" event_id="314" type_id="1" period_id="1" min="44" sec="4" player_id="624620" team_id="417" outcome="1" x="41.9" y="100.0" timestamp="2026-05-19T14:05:52.653" timestamp_utc="2026-05-19T13:05:52.653" last_modified="2026-05-19T14:05:53" version="1779195952909">
+      <Q id="6428612069" qualifier_id="56" value="Back"/>
+      <Q id="6428612067" qualifier_id="107"/>
+      <Q id="6428612071" qualifier_id="140" value="38.6"/>
+      <Q id="6428612073" qualifier_id="141" value="82.7"/>
+      <Q id="6428612075" qualifier_id="212" value="13.2"/>
+      <Q id="6428612077" qualifier_id="213" value="4.45"/>
+    </Event>
+    <Event id="2939831965" event_id="315" type_id="1" period_id="1" min="44" sec="6" player_id="720682" team_id="417" outcome="1" x="38.6" y="82.7" timestamp="2026-05-19T14:05:53.845" timestamp_utc="2026-05-19T13:05:53.845" last_modified="2026-05-19T14:05:55" version="1779195953942">
+      <Q id="6428612127" qualifier_id="56" value="Back"/>
+      <Q id="6428612129" qualifier_id="140" value="37.5"/>
+      <Q id="6428612131" qualifier_id="141" value="87.5"/>
+      <Q id="6428612133" qualifier_id="212" value="3.5"/>
+      <Q id="6428612135" qualifier_id="213" value="1.91"/>
+    </Event>
+    <Event id="2939831987" event_id="316" type_id="1" period_id="1" min="44" sec="7" player_id="624620" team_id="417" outcome="1" x="39.0" y="92.9" timestamp="2026-05-19T14:05:55.685" timestamp_utc="2026-05-19T13:05:55.685" last_modified="2026-05-19T14:05:59" version="1779195956109">
+      <Q id="6428612265" qualifier_id="56" value="Back"/>
+      <Q id="6428612267" qualifier_id="140" value="24.2"/>
+      <Q id="6428612269" qualifier_id="141" value="78.5"/>
+      <Q id="6428612271" qualifier_id="212" value="18.4"/>
+      <Q id="6428612273" qualifier_id="213" value="3.70"/>
+    </Event>
+    <Event id="2939832011" event_id="317" type_id="1" period_id="1" min="44" sec="11" player_id="61812" team_id="417" outcome="1" x="26.0" y="73.9" timestamp="2026-05-19T14:05:59.309" timestamp_utc="2026-05-19T13:05:59.309" last_modified="2026-05-19T14:06:03" version="1779195959606">
+      <Q id="6428612373" qualifier_id="56" value="Back"/>
+      <Q id="6428612375" qualifier_id="140" value="28.0"/>
+      <Q id="6428612377" qualifier_id="141" value="40.1"/>
+      <Q id="6428612379" qualifier_id="212" value="23.1"/>
+      <Q id="6428612381" qualifier_id="213" value="4.80"/>
+    </Event>
+    <Event id="2939832029" event_id="318" type_id="1" period_id="1" min="44" sec="15" player_id="531784" team_id="417" outcome="1" x="28.8" y="30.7" timestamp="2026-05-19T14:06:03.685" timestamp_utc="2026-05-19T13:06:03.685" last_modified="2026-05-19T14:06:06" version="1779195965310">
+      <Q id="6428612455" qualifier_id="56" value="Back"/>
+      <Q id="6428612457" qualifier_id="140" value="34.2"/>
+      <Q id="6428612459" qualifier_id="141" value="7.7"/>
+      <Q id="6428612461" qualifier_id="212" value="16.6"/>
+      <Q id="6428612463" qualifier_id="213" value="5.06"/>
+    </Event>
+    <Event id="2939832045" event_id="319" type_id="1" period_id="1" min="44" sec="18" player_id="157851" team_id="417" outcome="1" x="35.0" y="8.2" timestamp="2026-05-19T14:06:06.285" timestamp_utc="2026-05-19T13:06:06.285" last_modified="2026-05-19T14:06:08" version="1779195966549">
+      <Q id="6428612543" qualifier_id="56" value="Back"/>
+      <Q id="6428612545" qualifier_id="140" value="26.7"/>
+      <Q id="6428612547" qualifier_id="141" value="32.2"/>
+      <Q id="6428612549" qualifier_id="212" value="18.5"/>
+      <Q id="6428612551" qualifier_id="213" value="2.06"/>
+    </Event>
+    <Event id="2939832057" event_id="320" type_id="1" period_id="1" min="44" sec="20" player_id="531784" team_id="417" outcome="1" x="26.5" y="29.5" timestamp="2026-05-19T14:06:08.501" timestamp_utc="2026-05-19T13:06:08.501" last_modified="2026-05-19T14:06:10" version="1779195968695">
+      <Q id="6428612605" qualifier_id="56" value="Back"/>
+      <Q id="6428612607" qualifier_id="140" value="23.0"/>
+      <Q id="6428612609" qualifier_id="141" value="47.8"/>
+      <Q id="6428612611" qualifier_id="212" value="13.0"/>
+      <Q id="6428612613" qualifier_id="213" value="1.86"/>
+    </Event>
+    <Event id="2939832081" event_id="321" type_id="1" period_id="1" min="44" sec="22" player_id="61812" team_id="417" outcome="1" x="21.3" y="52.7" timestamp="2026-05-19T14:06:10.469" timestamp_utc="2026-05-19T13:06:10.469" last_modified="2026-05-19T14:06:13" version="1779195970805">
+      <Q id="6428612723" qualifier_id="56" value="Back"/>
+      <Q id="6428612725" qualifier_id="140" value="28.8"/>
+      <Q id="6428612727" qualifier_id="141" value="78.5"/>
+      <Q id="6428612729" qualifier_id="212" value="19.2"/>
+      <Q id="6428612731" qualifier_id="213" value="1.15"/>
+    </Event>
+    <Event id="2939832105" event_id="322" type_id="1" period_id="1" min="44" sec="26" player_id="624620" team_id="417" outcome="1" x="27.9" y="84.1" timestamp="2026-05-19T14:06:13.829" timestamp_utc="2026-05-19T13:06:13.829" last_modified="2026-05-19T14:06:17" version="1779195974149">
+      <Q id="6428612855" qualifier_id="56" value="Back"/>
+      <Q id="6428612857" qualifier_id="140" value="37.3"/>
+      <Q id="6428612859" qualifier_id="141" value="76.9"/>
+      <Q id="6428612861" qualifier_id="212" value="11.0"/>
+      <Q id="6428612863" qualifier_id="213" value="5.82"/>
+    </Event>
+    <Event id="2939832087" event_id="451" type_id="43" period_id="1" min="44" sec="26" player_id="207884" team_id="244" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T14:06:14.572" timestamp_utc="2026-05-19T13:06:14.572" last_modified="2026-05-19T14:06:22" version="1779195974573">
+      <Q id="6428612761" qualifier_id="56" value="Center"/>
+      <Q id="6428613033" qualifier_id="144" value="56"/>
+    </Event>
+    <Event id="2939832107" event_id="323" type_id="50" period_id="1" min="44" sec="30" player_id="61778" team_id="417" outcome="1" x="40.0" y="82.8" timestamp="2026-05-19T14:06:17.825" timestamp_utc="2026-05-19T13:06:17.825" last_modified="2026-05-19T14:06:21" version="1779195978885">
+      <Q id="6428612867" qualifier_id="56" value="Back"/>
+      <Q id="6428612919" qualifier_id="233" value="452"/>
+      <Q id="6428612869" qualifier_id="286"/>
+    </Event>
+    <Event id="2939832117" event_id="452" type_id="7" period_id="1" min="44" sec="30" player_id="232091" team_id="244" outcome="1" x="60.0" y="17.2" timestamp="2026-05-19T14:06:17.826" timestamp_utc="2026-05-19T13:06:17.826" last_modified="2026-05-19T14:06:48" version="1779196008769">
+      <Q id="6428612897" qualifier_id="56" value="Right"/>
+      <Q id="6428612895" qualifier_id="167"/>
+      <Q id="6428612901" qualifier_id="178"/>
+      <Q id="6428612903" qualifier_id="233" value="323"/>
+      <Q id="6428612899" qualifier_id="285"/>
+    </Event>
+    <Event id="2939832133" event_id="453" type_id="5" period_id="1" min="44" sec="30" player_id="232091" team_id="244" outcome="0" x="60.8" y="-1.4" timestamp="2026-05-19T14:06:18.741" timestamp_utc="2026-05-19T13:06:18.741" last_modified="2026-05-19T14:23:52" version="1779197029590">
+      <Q id="6428613017" qualifier_id="56" value="Right"/>
+      <Q id="6428613117" qualifier_id="233" value="324"/>
+      <Q id="6428613019" qualifier_id="347"/>
+    </Event>
+    <Event id="2939832157" event_id="324" type_id="5" period_id="1" min="44" sec="30" player_id="61778" team_id="417" outcome="1" x="39.2" y="101.4" timestamp="2026-05-19T14:06:18.741" timestamp_utc="2026-05-19T13:06:18.741" last_modified="2026-05-19T14:23:51" version="1779197029587">
+      <Q id="6428613109" qualifier_id="56" value="Back"/>
+      <Q id="6428613113" qualifier_id="233" value="453"/>
+      <Q id="6428613111" qualifier_id="347"/>
+    </Event>
+    <Event id="2939832165" event_id="325" type_id="1" period_id="1" min="44" sec="37" player_id="624620" team_id="417" outcome="0" x="39.8" y="100.0" timestamp="2026-05-19T14:06:24.828" timestamp_utc="2026-05-19T13:06:24.828" last_modified="2026-05-19T14:12:32" version="1779196351994">
+      <Q id="6428613153" qualifier_id="1"/>
+      <Q id="6428613143" qualifier_id="56" value="Left"/>
+      <Q id="6428613141" qualifier_id="107"/>
+      <Q id="6428613145" qualifier_id="140" value="61.7"/>
+      <Q id="6428613147" qualifier_id="141" value="91.4"/>
+      <Q id="6428613161" qualifier_id="189"/>
+      <Q id="6428613149" qualifier_id="212" value="24.0"/>
+      <Q id="6428613151" qualifier_id="213" value="6.00"/>
+    </Event>
+    <Event id="2939832167" event_id="454" type_id="61" period_id="1" min="44" sec="38" player_id="180662" team_id="244" outcome="1" x="32.4" y="13.7" timestamp="2026-05-19T14:06:26.697" timestamp_utc="2026-05-19T13:06:26.697" last_modified="2026-05-19T14:06:58" version="1779196018240">
+      <Q id="6428613163" qualifier_id="56" value="Back"/>
+    </Event>
+    <Event id="2939832187" event_id="455" type_id="5" period_id="1" min="44" sec="40" player_id="180662" team_id="244" outcome="0" x="37.8" y="-1.8" timestamp="2026-05-19T14:06:28.037" timestamp_utc="2026-05-19T13:06:28.037" last_modified="2026-05-19T14:23:52" version="1779197029596">
+      <Q id="6428613223" qualifier_id="56" value="Back"/>
+      <Q id="6428613291" qualifier_id="233" value="326"/>
+      <Q id="6428613225" qualifier_id="347"/>
+    </Event>
+    <Event id="2939832193" event_id="326" type_id="5" period_id="1" min="44" sec="40" player_id="624620" team_id="417" outcome="1" x="62.2" y="101.8" timestamp="2026-05-19T14:06:28.037" timestamp_utc="2026-05-19T13:06:28.037" last_modified="2026-05-19T14:23:52" version="1779197029593">
+      <Q id="6428613255" qualifier_id="56" value="Left"/>
+      <Q id="6428613285" qualifier_id="233" value="455"/>
+      <Q id="6428613257" qualifier_id="347"/>
+    </Event>
+    <Event id="2939832229" event_id="327" type_id="1" period_id="1" min="44" sec="44" player_id="164593" team_id="417" outcome="1" x="69.2" y="100.0" timestamp="2026-05-19T14:06:32.022" timestamp_utc="2026-05-19T13:06:32.022" last_modified="2026-05-19T14:06:35" version="1779195992262">
+      <Q id="6428613455" qualifier_id="56" value="Left"/>
+      <Q id="6428613453" qualifier_id="107"/>
+      <Q id="6428613457" qualifier_id="140" value="80.2"/>
+      <Q id="6428613459" qualifier_id="141" value="89.0"/>
+      <Q id="6428613461" qualifier_id="212" value="14.2"/>
+      <Q id="6428613463" qualifier_id="213" value="5.66"/>
+    </Event>
+    <Event id="2939832235" event_id="328" type_id="3" period_id="1" min="44" sec="46" player_id="61778" team_id="417" outcome="0" x="94.3" y="89.8" timestamp="2026-05-19T14:06:33.897" timestamp_utc="2026-05-19T13:06:33.897" last_modified="2026-05-19T14:06:37" version="1779195995942">
+      <Q id="6428613483" qualifier_id="56" value="Left"/>
+      <Q id="6428613519" qualifier_id="233" value="456"/>
+      <Q id="6428613485" qualifier_id="286"/>
+    </Event>
+    <Event id="2939832223" event_id="456" type_id="7" period_id="1" min="44" sec="46" player_id="180662" team_id="244" outcome="1" x="5.8" y="10.3" timestamp="2026-05-19T14:06:33.898" timestamp_utc="2026-05-19T13:06:33.898" last_modified="2026-05-19T14:06:37" version="1779195995938">
+      <Q id="6428613435" qualifier_id="56" value="Back"/>
+      <Q id="6428613433" qualifier_id="167"/>
+      <Q id="6428613439" qualifier_id="178"/>
+      <Q id="6428613505" qualifier_id="233" value="328"/>
+      <Q id="6428613437" qualifier_id="285"/>
+    </Event>
+    <Event id="2939832225" event_id="457" type_id="6" period_id="1" min="44" sec="46" player_id="180662" team_id="244" outcome="0" x="6.5" y="10.6" timestamp="2026-05-19T14:06:34.698" timestamp_utc="2026-05-19T13:06:34.698" last_modified="2026-05-19T14:06:39" version="1779195998104">
+      <Q id="6428613595" qualifier_id="56" value="Back"/>
+      <Q id="6428613597" qualifier_id="73"/>
+      <Q id="6428613625" qualifier_id="233" value="329"/>
+    </Event>
+    <Event id="2939832257" event_id="329" type_id="6" period_id="1" min="44" sec="46" player_id="61778" team_id="417" outcome="1" x="93.6" y="89.4" timestamp="2026-05-19T14:06:34.698" timestamp_utc="2026-05-19T13:06:34.698" last_modified="2026-05-19T14:18:38" version="1779196718293">
+      <Q id="6428613603" qualifier_id="56" value="Left"/>
+      <Q id="6428613605" qualifier_id="73"/>
+      <Q id="6428613607" qualifier_id="233" value="457"/>
+    </Event>
+    <Event id="2939832313" event_id="330" type_id="70" period_id="1" min="45" sec="5" team_id="417" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T14:06:53.575" timestamp_utc="2026-05-19T13:06:53.575" last_modified="2026-05-19T14:06:53" version="1779196013576">
+      <Q id="6428613875" qualifier_id="277" value="4"/>
+    </Event>
+    <Event id="2939832427" event_id="331" type_id="1" period_id="1" min="45" sec="25" player_id="685390" team_id="417" outcome="0" x="99.5" y="99.5" timestamp="2026-05-19T14:07:12.965" timestamp_utc="2026-05-19T13:07:12.965" last_modified="2026-05-19T14:07:17" version="1779196036653">
+      <Q id="6428614565" qualifier_id="1"/>
+      <Q id="6428614547" qualifier_id="2"/>
+      <Q id="6428614549" qualifier_id="6"/>
+      <Q id="6428614555" qualifier_id="56" value="Center"/>
+      <Q id="6428614557" qualifier_id="140" value="90.2"/>
+      <Q id="6428614559" qualifier_id="141" value="36.4"/>
+      <Q id="6428614551" qualifier_id="155"/>
+      <Q id="6428614561" qualifier_id="212" value="44.0"/>
+      <Q id="6428614563" qualifier_id="213" value="4.49"/>
+      <Q id="6428614553" qualifier_id="223"/>
+    </Event>
+    <Event id="2939832435" event_id="458" type_id="44" period_id="1" min="45" sec="28" player_id="180662" team_id="244" outcome="1" x="9.8" y="63.6" timestamp="2026-05-19T14:07:16.427" timestamp_utc="2026-05-19T13:07:16.427" last_modified="2026-05-19T15:45:39" version="1779201939331">
+      <Q id="6428614593" qualifier_id="56" value="Back"/>
+      <Q id="6428614641" qualifier_id="233" value="332"/>
+      <Q id="6428614595" qualifier_id="285"/>
+    </Event>
+    <Event id="2939832437" event_id="332" type_id="44" period_id="1" min="45" sec="28" player_id="218339" team_id="417" outcome="0" x="90.2" y="36.4" timestamp="2026-05-19T14:07:16.428" timestamp_utc="2026-05-19T13:07:16.428" last_modified="2026-05-19T15:45:39" version="1779201939601">
+      <Q id="6428614597" qualifier_id="56" value="Center"/>
+      <Q id="6428614647" qualifier_id="233" value="458"/>
+      <Q id="6428614599" qualifier_id="286"/>
+    </Event>
+    <Event id="2939832439" event_id="459" type_id="12" period_id="1" min="45" sec="28" player_id="180662" team_id="244" outcome="1" x="9.8" y="63.6" timestamp="2026-05-19T14:07:16.763" timestamp_utc="2026-05-19T13:07:16.763" last_modified="2026-05-19T15:45:40" version="1779201939868">
+      <Q id="6428614633" qualifier_id="15"/>
+      <Q id="6428614605" qualifier_id="56" value="Back"/>
+      <Q id="6428614607" qualifier_id="140" value="22.9"/>
+      <Q id="6428614609" qualifier_id="141" value="90.0"/>
+      <Q id="6428614611" qualifier_id="212" value="22.6"/>
+      <Q id="6428614613" qualifier_id="213" value="0.92"/>
+    </Event>
+    <Event id="2939832455" event_id="460" type_id="49" period_id="1" min="45" sec="31" player_id="207884" team_id="244" outcome="1" x="22.5" y="90.0" timestamp="2026-05-19T14:07:19.522" timestamp_utc="2026-05-19T13:07:19.522" last_modified="2026-05-19T14:07:20" version="1779196039523"/>
+    <Event id="2939832459" event_id="461" type_id="3" period_id="1" min="45" sec="32" player_id="207884" team_id="244" outcome="0" x="22.4" y="91.0" timestamp="2026-05-19T14:07:19.978" timestamp_utc="2026-05-19T13:07:19.978" last_modified="2026-05-19T14:07:23" version="1779196042508">
+      <Q id="6428614711" qualifier_id="56" value="Back"/>
+      <Q id="6428614793" qualifier_id="233" value="333"/>
+      <Q id="6428614713" qualifier_id="285"/>
+    </Event>
+    <Event id="2939832471" event_id="333" type_id="7" period_id="1" min="45" sec="32" player_id="218339" team_id="417" outcome="1" x="77.6" y="8.8" timestamp="2026-05-19T14:07:19.979" timestamp_utc="2026-05-19T13:07:19.979" last_modified="2026-05-19T14:07:24" version="1779196042511">
+      <Q id="6428614767" qualifier_id="56" value="Right"/>
+      <Q id="6428614765" qualifier_id="167"/>
+      <Q id="6428614771" qualifier_id="178"/>
+      <Q id="6428614787" qualifier_id="233" value="461"/>
+      <Q id="6428614769" qualifier_id="286"/>
+    </Event>
+    <Event id="2939832481" event_id="334" type_id="5" period_id="1" min="45" sec="33" player_id="218339" team_id="417" outcome="0" x="77.9" y="-1.6" timestamp="2026-05-19T14:07:21.475" timestamp_utc="2026-05-19T13:07:21.475" last_modified="2026-05-19T14:23:52" version="1779197029599">
+      <Q id="6428614821" qualifier_id="56" value="Right"/>
+      <Q id="6428615179" qualifier_id="233" value="462"/>
+      <Q id="6428614823" qualifier_id="347"/>
+    </Event>
+    <Event id="2939832525" event_id="462" type_id="5" period_id="1" min="45" sec="33" player_id="207884" team_id="244" outcome="1" x="22.0" y="101.6" timestamp="2026-05-19T14:07:21.475" timestamp_utc="2026-05-19T13:07:21.475" last_modified="2026-05-19T14:07:39" version="1779196058738">
+      <Q id="6428615151" qualifier_id="56" value="Back"/>
+      <Q id="6428615171" qualifier_id="233" value="334"/>
+      <Q id="6428615153" qualifier_id="347"/>
+    </Event>
+    <Event id="2939832541" event_id="463" type_id="1" period_id="1" min="45" sec="50" player_id="575855" team_id="244" outcome="1" x="27.5" y="100.0" timestamp="2026-05-19T14:07:38.475" timestamp_utc="2026-05-19T13:07:38.475" last_modified="2026-05-19T14:07:40" version="1779196059888">
+      <Q id="6428615257" qualifier_id="56" value="Back"/>
+      <Q id="6428615255" qualifier_id="107"/>
+      <Q id="6428615259" qualifier_id="140" value="43.6"/>
+      <Q id="6428615261" qualifier_id="141" value="84.7"/>
+      <Q id="6428615263" qualifier_id="212" value="20.5"/>
+      <Q id="6428615265" qualifier_id="213" value="5.68"/>
+    </Event>
+    <Event id="2939832543" event_id="464" type_id="1" period_id="1" min="45" sec="52" player_id="232091" team_id="244" outcome="0" x="43.6" y="84.7" timestamp="2026-05-19T14:07:40.506" timestamp_utc="2026-05-19T13:07:40.506" last_modified="2026-05-19T14:07:41" version="1779196060987">
+      <Q id="6428615269" qualifier_id="3"/>
+      <Q id="6428615273" qualifier_id="56" value="Left"/>
+      <Q id="6428615275" qualifier_id="140" value="58.2"/>
+      <Q id="6428615277" qualifier_id="141" value="80.9"/>
+      <Q id="6428615271" qualifier_id="168"/>
+      <Q id="6428615279" qualifier_id="212" value="15.5"/>
+      <Q id="6428615281" qualifier_id="213" value="6.12"/>
+    </Event>
+    <Event id="2939832553" event_id="335" type_id="1" period_id="1" min="45" sec="53" player_id="531784" team_id="417" outcome="0" x="43.2" y="9.4" timestamp="2026-05-19T14:07:41.612" timestamp_utc="2026-05-19T13:07:41.612" last_modified="2026-05-19T14:07:42" version="1779196062060">
+      <Q id="6428615327" qualifier_id="3"/>
+      <Q id="6428615329" qualifier_id="56" value="Right"/>
+      <Q id="6428615331" qualifier_id="140" value="55.2"/>
+      <Q id="6428615333" qualifier_id="141" value="9.1"/>
+      <Q id="6428615335" qualifier_id="212" value="12.6"/>
+      <Q id="6428615337" qualifier_id="213" value="6.27"/>
+    </Event>
+    <Event id="2939832573" event_id="465" type_id="1" period_id="1" min="45" sec="54" player_id="232091" team_id="244" outcome="1" x="44.3" y="85.7" timestamp="2026-05-19T14:07:42.626" timestamp_utc="2026-05-19T13:07:42.626" last_modified="2026-05-19T14:07:45" version="1779196063906">
+      <Q id="6428615423" qualifier_id="3"/>
+      <Q id="6428615425" qualifier_id="56" value="Center"/>
+      <Q id="6428615427" qualifier_id="140" value="60.1"/>
+      <Q id="6428615429" qualifier_id="141" value="77.9"/>
+      <Q id="6428615431" qualifier_id="212" value="17.4"/>
+      <Q id="6428615433" qualifier_id="213" value="5.97"/>
+    </Event>
+    <Event id="2939832579" event_id="466" type_id="1" period_id="1" min="45" sec="57" player_id="479433" team_id="244" outcome="1" x="60.1" y="77.9" timestamp="2026-05-19T14:07:45.523" timestamp_utc="2026-05-19T13:07:45.523" last_modified="2026-05-19T14:07:48" version="1779196067130">
+      <Q id="6428615479" qualifier_id="56" value="Center"/>
+      <Q id="6428615481" qualifier_id="140" value="54.5"/>
+      <Q id="6428615483" qualifier_id="141" value="42.4"/>
+      <Q id="6428615477" qualifier_id="155"/>
+      <Q id="6428615485" qualifier_id="212" value="24.8"/>
+      <Q id="6428615487" qualifier_id="213" value="4.47"/>
+    </Event>
+    <Event id="2939832607" event_id="467" type_id="1" period_id="1" min="46" sec="0" player_id="625775" team_id="244" outcome="1" x="53.4" y="40.4" timestamp="2026-05-19T14:07:48.250" timestamp_utc="2026-05-19T13:07:48.250" last_modified="2026-05-19T14:07:53" version="1779196069179">
+      <Q id="6428615643" qualifier_id="56" value="Center"/>
+      <Q id="6428615645" qualifier_id="140" value="59.8"/>
+      <Q id="6428615647" qualifier_id="141" value="21.5"/>
+      <Q id="6428615649" qualifier_id="212" value="14.5"/>
+      <Q id="6428615651" qualifier_id="213" value="5.19"/>
+    </Event>
+    <Event id="2939832615" event_id="468" type_id="1" period_id="1" min="46" sec="6" player_id="240166" team_id="244" outcome="0" x="84.0" y="25.5" timestamp="2026-05-19T14:07:53.858" timestamp_utc="2026-05-19T13:07:53.858" last_modified="2026-05-19T14:17:33" version="1779196653547">
+      <Q id="6428615701" qualifier_id="56" value="Center"/>
+      <Q id="6428615703" qualifier_id="140" value="88.8"/>
+      <Q id="6428615705" qualifier_id="141" value="34.8"/>
+      <Q id="6428615707" qualifier_id="212" value="8.1"/>
+      <Q id="6428615709" qualifier_id="213" value="0.90"/>
+    </Event>
+    <Event id="2939832629" event_id="336" type_id="61" period_id="1" min="46" sec="7" player_id="624620" team_id="417" outcome="1" x="12.1" y="69.0" timestamp="2026-05-19T14:07:54.799" timestamp_utc="2026-05-19T13:07:54.799" last_modified="2026-05-19T14:17:17" version="1779196636925">
+      <Q id="6428615765" qualifier_id="56" value="Back"/>
+    </Event>
+    <Event id="2939832625" event_id="469" type_id="6" period_id="1" min="46" sec="8" player_id="240166" team_id="244" outcome="1" x="88.4" y="32.5" timestamp="2026-05-19T14:07:55.995" timestamp_utc="2026-05-19T13:07:55.995" last_modified="2026-05-19T14:08:01" version="1779196080632">
+      <Q id="6428615793" qualifier_id="56" value="Center"/>
+      <Q id="6428615795" qualifier_id="75"/>
+      <Q id="6428615819" qualifier_id="233" value="337"/>
+    </Event>
+    <Event id="2939832639" event_id="337" type_id="6" period_id="1" min="46" sec="8" player_id="624620" team_id="417" outcome="0" x="11.7" y="67.6" timestamp="2026-05-19T14:07:55.995" timestamp_utc="2026-05-19T13:07:55.995" last_modified="2026-05-19T14:18:38" version="1779196718309">
+      <Q id="6428615801" qualifier_id="56" value="Back"/>
+      <Q id="6428615803" qualifier_id="73"/>
+      <Q id="6428615847" qualifier_id="233" value="469"/>
+    </Event>
+    <Event id="2939835135" event_id="493" type_id="1" period_id="1" min="46" sec="40" player_id="207884" team_id="244" outcome="1" x="99.6" y="0.7" keypass="1" timestamp="2026-05-19T14:08:28.042" timestamp_utc="2026-05-19T13:08:28.042" last_modified="2026-05-19T16:05:44" version="1779203144388">
+      <Q id="6428630095" qualifier_id="2"/>
+      <Q id="6428630097" qualifier_id="6"/>
+      <Q id="6428630101" qualifier_id="56" value="Center"/>
+      <Q id="6428630103" qualifier_id="140" value="94.2"/>
+      <Q id="6428630105" qualifier_id="141" value="40.9"/>
+      <Q id="6428630535" qualifier_id="154"/>
+      <Q id="6428630099" qualifier_id="155"/>
+      <Q id="6428630533" qualifier_id="210" value="13"/>
+      <Q id="6428630107" qualifier_id="212" value="27.9"/>
+      <Q id="6428630109" qualifier_id="213" value="1.78"/>
+      <Q id="6428630201" qualifier_id="224"/>
+    </Event>
+    <Event id="2939832821" event_id="470" type_id="13" period_id="1" min="46" sec="42" player_id="232091" team_id="244" outcome="1" x="94.2" y="40.9" timestamp="2026-05-19T14:08:30.042" timestamp_utc="2026-05-19T13:08:30.042" last_modified="2026-05-19T15:49:45" version="1779202185829">
+      <Q id="6428617055" qualifier_id="15"/>
+      <Q id="6428616829" qualifier_id="17"/>
+      <Q id="6428617051" qualifier_id="25"/>
+      <Q id="6428617059" qualifier_id="29"/>
+      <Q id="6428617063" qualifier_id="55" value="493"/>
+      <Q id="6428616831" qualifier_id="56" value="Center"/>
+      <Q id="6428617057" qualifier_id="73"/>
+      <Q id="6428617067" qualifier_id="102" value="64.9"/>
+      <Q id="6428617069" qualifier_id="103" value="30.6"/>
+      <Q id="6428617073" qualifier_id="146" value="98.5"/>
+      <Q id="6428617075" qualifier_id="147" value="52.2"/>
+      <Q id="6428616937" qualifier_id="153"/>
+      <Q id="6428617061" qualifier_id="154"/>
+      <Q id="6428617077" qualifier_id="230" value="99.5"/>
+      <Q id="6428617079" qualifier_id="231" value="48.4"/>
+      <Q id="6428617071" qualifier_id="328"/>
+    </Event>
+    <Event id="2939832827" event_id="338" type_id="61" period_id="1" min="46" sec="43" player_id="624620" team_id="417" outcome="1" x="2.9" y="47.2" timestamp="2026-05-19T14:08:30.948" timestamp_utc="2026-05-19T13:08:30.948" last_modified="2026-05-19T14:08:31" version="1779196110950">
+      <Q id="6428616851" qualifier_id="56" value="Back"/>
+    </Event>
+    <Event id="2939832837" event_id="339" type_id="52" period_id="1" min="46" sec="45" player_id="565487" team_id="417" outcome="1" x="3.5" y="51.0" timestamp="2026-05-19T14:08:32.803" timestamp_utc="2026-05-19T13:08:32.803" last_modified="2026-05-19T14:08:32" version="1779196112805"/>
+    <Event id="2939832845" event_id="340" type_id="1" period_id="1" min="46" sec="48" player_id="565487" team_id="417" outcome="1" x="12.0" y="46.9" timestamp="2026-05-19T14:08:36.549" timestamp_utc="2026-05-19T13:08:36.549" last_modified="2026-05-19T14:13:07" version="1779196387669">
+      <Q id="6428616993" qualifier_id="56" value="Back"/>
+      <Q id="6428616991" qualifier_id="123"/>
+      <Q id="6428616995" qualifier_id="140" value="39.5"/>
+      <Q id="6428616997" qualifier_id="141" value="31.6"/>
+      <Q id="6428617309" qualifier_id="189"/>
+      <Q id="6428616999" qualifier_id="212" value="30.7"/>
+      <Q id="6428617001" qualifier_id="213" value="5.94"/>
+    </Event>
+    <Event id="2939832861" event_id="341" type_id="1" period_id="1" min="46" sec="51" player_id="218339" team_id="417" outcome="0" x="39.6" y="34.8" timestamp="2026-05-19T14:08:39.339" timestamp_utc="2026-05-19T13:08:39.339" last_modified="2026-05-19T14:13:06" version="1779196385869">
+      <Q id="6428617117" qualifier_id="56" value="Back"/>
+      <Q id="6428617119" qualifier_id="140" value="46.3"/>
+      <Q id="6428617121" qualifier_id="141" value="45.8"/>
+      <Q id="6428617123" qualifier_id="212" value="10.3"/>
+      <Q id="6428617125" qualifier_id="213" value="0.82"/>
+    </Event>
+    <Event id="2939832857" event_id="471" type_id="49" period_id="1" min="46" sec="51" player_id="627127" team_id="244" outcome="1" x="54.6" y="66.4" timestamp="2026-05-19T14:08:39.474" timestamp_utc="2026-05-19T13:08:39.474" last_modified="2026-05-19T14:08:39" version="1779196119475"/>
+    <Event id="2939832871" event_id="472" type_id="1" period_id="1" min="46" sec="51" player_id="627127" team_id="244" outcome="1" x="54.7" y="67.0" timestamp="2026-05-19T14:08:39.682" timestamp_utc="2026-05-19T13:08:39.682" last_modified="2026-05-19T14:21:52" version="1779196912848">
+      <Q id="6428617171" qualifier_id="56" value="Center"/>
+      <Q id="6428617173" qualifier_id="140" value="59.3"/>
+      <Q id="6428617175" qualifier_id="141" value="73.9"/>
+      <Q id="6428617177" qualifier_id="212" value="6.7"/>
+      <Q id="6428617179" qualifier_id="213" value="0.77"/>
+    </Event>
+    <Event id="2939832879" event_id="473" type_id="1" period_id="1" min="46" sec="54" player_id="575855" team_id="244" outcome="1" x="59.4" y="73.9" timestamp="2026-05-19T14:08:41.946" timestamp_utc="2026-05-19T13:08:41.946" last_modified="2026-05-19T14:08:44" version="1779196122269">
+      <Q id="6428617233" qualifier_id="56" value="Left"/>
+      <Q id="6428617235" qualifier_id="140" value="70.8"/>
+      <Q id="6428617237" qualifier_id="141" value="84.7"/>
+      <Q id="6428617239" qualifier_id="212" value="14.0"/>
+      <Q id="6428617241" qualifier_id="213" value="0.55"/>
+    </Event>
+    <Event id="2939832909" event_id="474" type_id="1" period_id="1" min="46" sec="56" player_id="515742" team_id="244" outcome="1" x="74.3" y="89.4" timestamp="2026-05-19T14:08:44.090" timestamp_utc="2026-05-19T13:08:44.090" last_modified="2026-05-19T14:08:50" version="1779196126013">
+      <Q id="6428617359" qualifier_id="56" value="Left"/>
+      <Q id="6428617361" qualifier_id="140" value="90.6"/>
+      <Q id="6428617363" qualifier_id="141" value="86.9"/>
+      <Q id="6428617365" qualifier_id="212" value="17.2"/>
+      <Q id="6428617367" qualifier_id="213" value="6.18"/>
+    </Event>
+    <Event id="2939832925" event_id="475" type_id="1" period_id="1" min="47" sec="2" player_id="479433" team_id="244" outcome="1" x="90.5" y="87.4" timestamp="2026-05-19T14:08:50.154" timestamp_utc="2026-05-19T13:08:50.154" last_modified="2026-05-19T14:08:52" version="1779196130930">
+      <Q id="6428617485" qualifier_id="56" value="Left"/>
+      <Q id="6428617487" qualifier_id="140" value="76.3"/>
+      <Q id="6428617489" qualifier_id="141" value="83.3"/>
+      <Q id="6428617491" qualifier_id="212" value="15.2"/>
+      <Q id="6428617493" qualifier_id="213" value="3.33"/>
+    </Event>
+    <Event id="2939832935" event_id="476" type_id="1" period_id="1" min="47" sec="4" player_id="575855" team_id="244" outcome="0" x="75.6" y="80.9" timestamp="2026-05-19T14:08:52.714" timestamp_utc="2026-05-19T13:08:52.714" last_modified="2026-05-19T14:08:55" version="1779196134910">
+      <Q id="6428617563" qualifier_id="1"/>
+      <Q id="6428617549" qualifier_id="2"/>
+      <Q id="6428617553" qualifier_id="56" value="Center"/>
+      <Q id="6428617555" qualifier_id="140" value="100.0"/>
+      <Q id="6428617557" qualifier_id="141" value="30.4"/>
+      <Q id="6428617551" qualifier_id="155"/>
+      <Q id="6428617559" qualifier_id="212" value="43.2"/>
+      <Q id="6428617561" qualifier_id="213" value="5.37"/>
+    </Event>
+    <Event id="2939833009" event_id="342" type_id="5" period_id="1" min="47" sec="7" player_id="218339" team_id="417" outcome="1" x="-1.0" y="67.4" timestamp="2026-05-19T14:08:54.923" timestamp_utc="2026-05-19T13:08:54.923" last_modified="2026-05-19T14:23:53" version="1779197029604">
+      <Q id="6428617991" qualifier_id="56" value="Back"/>
+      <Q id="6428618057" qualifier_id="233" value="477"/>
+      <Q id="6428617993" qualifier_id="346"/>
+    </Event>
+    <Event id="2939833021" event_id="477" type_id="5" period_id="1" min="47" sec="7" player_id="575855" team_id="244" outcome="0" x="100.9" y="32.5" timestamp="2026-05-19T14:08:54.923" timestamp_utc="2026-05-19T13:08:54.923" last_modified="2026-05-19T14:09:09" version="1779196148574">
+      <Q id="6428618045" qualifier_id="56" value="Center"/>
+      <Q id="6428618071" qualifier_id="233" value="342"/>
+      <Q id="6428618047" qualifier_id="346"/>
+    </Event>
+    <Event id="2939833013" event_id="343" type_id="1" period_id="1" min="47" sec="15" player_id="565487" team_id="417" outcome="0" x="3.6" y="49.3" timestamp="2026-05-19T14:09:03.125" timestamp_utc="2026-05-19T13:09:03.125" last_modified="2026-05-19T14:09:10" version="1779196148840">
+      <Q id="6428618021" qualifier_id="1"/>
+      <Q id="6428618011" qualifier_id="56" value="Center"/>
+      <Q id="6428618023" qualifier_id="74"/>
+      <Q id="6428618009" qualifier_id="124"/>
+      <Q id="6428618013" qualifier_id="140" value="54.7"/>
+      <Q id="6428618015" qualifier_id="141" value="55.7"/>
+      <Q id="6428618025" qualifier_id="189"/>
+      <Q id="6428618017" qualifier_id="212" value="53.8"/>
+      <Q id="6428618019" qualifier_id="213" value="0.08"/>
+    </Event>
+    <Event id="2939833025" event_id="478" type_id="49" period_id="1" min="47" sec="20" player_id="625775" team_id="244" outcome="1" x="72.6" y="36.7" timestamp="2026-05-19T14:09:08.146" timestamp_utc="2026-05-19T13:09:08.146" last_modified="2026-05-19T14:09:08" version="1779196148148"/>
+    <Event id="2939833045" event_id="479" type_id="1" period_id="1" min="47" sec="20" player_id="625775" team_id="244" outcome="1" x="72.6" y="36.7" timestamp="2026-05-19T14:09:08.322" timestamp_utc="2026-05-19T13:09:08.322" last_modified="2026-05-19T14:09:10" version="1779196148515">
+      <Q id="6428618139" qualifier_id="56" value="Center"/>
+      <Q id="6428618141" qualifier_id="140" value="68.0"/>
+      <Q id="6428618143" qualifier_id="141" value="45.4"/>
+      <Q id="6428618145" qualifier_id="212" value="7.6"/>
+      <Q id="6428618147" qualifier_id="213" value="2.26"/>
+    </Event>
+    <Event id="2939833065" event_id="480" type_id="1" period_id="1" min="47" sec="22" player_id="207884" team_id="244" outcome="0" x="71.9" y="18.6" timestamp="2026-05-19T14:09:10.618" timestamp_utc="2026-05-19T13:09:10.618" last_modified="2026-05-19T14:09:15" version="1779196155167">
+      <Q id="6428618229" qualifier_id="56" value="Right"/>
+      <Q id="6428618231" qualifier_id="140" value="57.7"/>
+      <Q id="6428618233" qualifier_id="141" value="0.0"/>
+      <Q id="6428618235" qualifier_id="212" value="20.3"/>
+      <Q id="6428618237" qualifier_id="213" value="3.89"/>
+    </Event>
+    <Event id="2939833069" event_id="481" type_id="5" period_id="1" min="47" sec="25" player_id="207884" team_id="244" outcome="0" x="55.8" y="-1.8" timestamp="2026-05-19T14:09:13.284" timestamp_utc="2026-05-19T13:09:13.284" last_modified="2026-05-19T14:23:53" version="1779197029622">
+      <Q id="6428618257" qualifier_id="56" value="Right"/>
+      <Q id="6428618929" qualifier_id="233" value="344"/>
+      <Q id="6428618259" qualifier_id="347"/>
+    </Event>
+    <Event id="2939833167" event_id="344" type_id="5" period_id="1" min="47" sec="25" player_id="565487" team_id="417" outcome="1" x="44.2" y="101.8" timestamp="2026-05-19T14:09:13.284" timestamp_utc="2026-05-19T13:09:13.284" last_modified="2026-05-19T14:23:53" version="1779197029617">
+      <Q id="6428618895" qualifier_id="56" value="Back"/>
+      <Q id="6428618911" qualifier_id="233" value="481"/>
+      <Q id="6428618897" qualifier_id="347"/>
+    </Event>
+    <Event id="2939833177" event_id="345" type_id="1" period_id="1" min="47" sec="46" player_id="624620" team_id="417" outcome="1" x="40.8" y="100.0" timestamp="2026-05-19T14:09:34.019" timestamp_utc="2026-05-19T13:09:34.019" last_modified="2026-05-19T14:09:37" version="1779196174515">
+      <Q id="6428618963" qualifier_id="56" value="Left"/>
+      <Q id="6428618961" qualifier_id="107"/>
+      <Q id="6428618965" qualifier_id="140" value="53.5"/>
+      <Q id="6428618967" qualifier_id="141" value="79.1"/>
+      <Q id="6428618969" qualifier_id="212" value="20.3"/>
+      <Q id="6428618971" qualifier_id="213" value="5.43"/>
+    </Event>
+    <Event id="2939833181" event_id="346" type_id="1" period_id="1" min="47" sec="49" player_id="685390" team_id="417" outcome="0" x="58.2" y="78.1" timestamp="2026-05-19T14:09:37.042" timestamp_utc="2026-05-19T13:09:37.042" last_modified="2026-05-19T14:09:38" version="1779196178603">
+      <Q id="6428618981" qualifier_id="56" value="Center"/>
+      <Q id="6428618983" qualifier_id="140" value="61.1"/>
+      <Q id="6428618985" qualifier_id="141" value="75.3"/>
+      <Q id="6428618979" qualifier_id="168"/>
+      <Q id="6428618987" qualifier_id="212" value="3.6"/>
+      <Q id="6428618989" qualifier_id="213" value="5.72"/>
+    </Event>
+    <Event id="2939833185" event_id="482" type_id="1" period_id="1" min="47" sec="49" player_id="575855" team_id="244" outcome="0" x="31.7" y="43.3" timestamp="2026-05-19T14:09:37.338" timestamp_utc="2026-05-19T13:09:37.338" last_modified="2026-05-19T14:09:38" version="1779196177987">
+      <Q id="6428619033" qualifier_id="1"/>
+      <Q id="6428619023" qualifier_id="56" value="Center"/>
+      <Q id="6428619025" qualifier_id="140" value="61.1"/>
+      <Q id="6428619027" qualifier_id="141" value="40.7"/>
+      <Q id="6428619021" qualifier_id="157"/>
+      <Q id="6428619029" qualifier_id="212" value="30.9"/>
+      <Q id="6428619031" qualifier_id="213" value="6.23"/>
+    </Event>
+    <Event id="2939833201" event_id="347" type_id="50" period_id="1" min="47" sec="51" player_id="218339" team_id="417" outcome="1" x="50.0" y="71.4" timestamp="2026-05-19T14:09:39.753" timestamp_utc="2026-05-19T13:09:39.753" last_modified="2026-05-19T14:09:45" version="1779196181941">
+      <Q id="6428619131" qualifier_id="56" value="Center"/>
+      <Q id="6428619153" qualifier_id="233" value="483"/>
+      <Q id="6428619133" qualifier_id="286"/>
+    </Event>
+    <Event id="2939833197" event_id="483" type_id="7" period_id="1" min="47" sec="51" player_id="207884" team_id="244" outcome="1" x="50.0" y="28.6" timestamp="2026-05-19T14:09:39.754" timestamp_utc="2026-05-19T13:09:39.754" last_modified="2026-05-19T14:09:45" version="1779196181937">
+      <Q id="6428619123" qualifier_id="56" value="Center"/>
+      <Q id="6428619127" qualifier_id="178"/>
+      <Q id="6428619137" qualifier_id="233" value="347"/>
+      <Q id="6428619125" qualifier_id="285"/>
+    </Event>
+    <Event id="2939833199" event_id="484" type_id="49" period_id="1" min="47" sec="52" player_id="207884" team_id="244" outcome="1" x="51.2" y="36.0" timestamp="2026-05-19T14:09:40.218" timestamp_utc="2026-05-19T13:09:40.218" last_modified="2026-05-19T14:09:40" version="1779196180219"/>
+    <Event id="2939833215" event_id="485" type_id="1" period_id="1" min="47" sec="55" player_id="207884" team_id="244" outcome="0" x="51.7" y="27.6" timestamp="2026-05-19T14:09:42.939" timestamp_utc="2026-05-19T13:09:42.939" last_modified="2026-05-19T14:09:45" version="1779196184874">
+      <Q id="6428619231" qualifier_id="56" value="Center"/>
+      <Q id="6428619233" qualifier_id="140" value="75.8"/>
+      <Q id="6428619235" qualifier_id="141" value="48.2"/>
+      <Q id="6428619229" qualifier_id="155"/>
+      <Q id="6428619237" qualifier_id="212" value="28.9"/>
+      <Q id="6428619239" qualifier_id="213" value="0.51"/>
+    </Event>
+    <Event id="2939833219" event_id="348" type_id="8" period_id="1" min="47" sec="58" player_id="61812" team_id="417" outcome="1" x="24.2" y="51.8" timestamp="2026-05-19T14:09:46.130" timestamp_utc="2026-05-19T13:09:46.130" last_modified="2026-05-19T14:16:39" version="1779196599728">
+      <Q id="6428619257" qualifier_id="56" value="Back"/>
+    </Event>
+    <Event id="2939833221" event_id="349" type_id="49" period_id="1" min="47" sec="58" player_id="61812" team_id="417" outcome="1" x="24.6" y="40.7" timestamp="2026-05-19T14:09:46.693" timestamp_utc="2026-05-19T13:09:46.693" last_modified="2026-05-19T14:09:46" version="1779196186695"/>
+    <Event id="2939833247" event_id="350" type_id="1" period_id="1" min="47" sec="59" player_id="61812" team_id="417" outcome="1" x="23.1" y="35.8" timestamp="2026-05-19T14:09:46.874" timestamp_utc="2026-05-19T13:09:46.874" last_modified="2026-05-19T14:09:49" version="1779196187065">
+      <Q id="6428619383" qualifier_id="56" value="Back"/>
+      <Q id="6428619385" qualifier_id="140" value="24.8"/>
+      <Q id="6428619387" qualifier_id="141" value="18.2"/>
+      <Q id="6428619389" qualifier_id="212" value="12.1"/>
+      <Q id="6428619391" qualifier_id="213" value="4.86"/>
+    </Event>
+    <Event id="2939833257" event_id="351" type_id="1" period_id="1" min="48" sec="2" player_id="157851" team_id="417" outcome="1" x="26.8" y="21.5" timestamp="2026-05-19T14:09:49.810" timestamp_utc="2026-05-19T13:09:49.810" last_modified="2026-05-19T14:09:52" version="1779196189963">
+      <Q id="6428619443" qualifier_id="56" value="Back"/>
+      <Q id="6428619445" qualifier_id="140" value="31.5"/>
+      <Q id="6428619447" qualifier_id="141" value="39.7"/>
+      <Q id="6428619449" qualifier_id="212" value="13.3"/>
+      <Q id="6428619451" qualifier_id="213" value="1.19"/>
+    </Event>
+    <Event id="2939833271" event_id="352" type_id="1" period_id="1" min="48" sec="4" player_id="218339" team_id="417" outcome="1" x="32.0" y="38.3" timestamp="2026-05-19T14:09:52.498" timestamp_utc="2026-05-19T13:09:52.498" last_modified="2026-05-19T14:09:56" version="1779196193010">
+      <Q id="6428619559" qualifier_id="56" value="Back"/>
+      <Q id="6428619561" qualifier_id="140" value="33.6"/>
+      <Q id="6428619563" qualifier_id="141" value="10.6"/>
+      <Q id="6428619565" qualifier_id="212" value="18.9"/>
+      <Q id="6428619567" qualifier_id="213" value="4.80"/>
+    </Event>
+    <Event id="2939833279" event_id="353" type_id="1" period_id="1" min="48" sec="8" player_id="157851" team_id="417" outcome="0" x="38.7" y="11.3" timestamp="2026-05-19T14:09:56.372" timestamp_utc="2026-05-19T13:09:56.372" last_modified="2026-05-19T14:09:57" version="1779196197675">
+      <Q id="6428619611" qualifier_id="1"/>
+      <Q id="6428619601" qualifier_id="56" value="Center"/>
+      <Q id="6428619603" qualifier_id="140" value="81.9"/>
+      <Q id="6428619605" qualifier_id="141" value="24.6"/>
+      <Q id="6428619599" qualifier_id="155"/>
+      <Q id="6428619607" qualifier_id="212" value="46.3"/>
+      <Q id="6428619609" qualifier_id="213" value="0.20"/>
+    </Event>
+    <Event id="2939833287" event_id="486" type_id="12" period_id="1" min="48" sec="10" player_id="180662" team_id="244" outcome="1" x="19.4" y="85.0" timestamp="2026-05-19T14:09:58.690" timestamp_utc="2026-05-19T13:09:58.690" last_modified="2026-05-19T14:10:37" version="1779196237255">
+      <Q id="6428619737" qualifier_id="15"/>
+      <Q id="6428619653" qualifier_id="56" value="Back"/>
+      <Q id="6428619655" qualifier_id="140" value="28.8"/>
+      <Q id="6428619657" qualifier_id="141" value="88.0"/>
+      <Q id="6428619659" qualifier_id="212" value="10.1"/>
+      <Q id="6428619661" qualifier_id="213" value="0.20"/>
+    </Event>
+    <Event id="2939833349" event_id="354" type_id="1" period_id="1" min="48" sec="17" player_id="61778" team_id="417" outcome="1" x="81.1" y="10.3" timestamp="2026-05-19T14:10:05.274" timestamp_utc="2026-05-19T13:10:05.274" last_modified="2026-05-19T14:10:07" version="1779196205428">
+      <Q id="6428619965" qualifier_id="56" value="Right"/>
+      <Q id="6428619967" qualifier_id="140" value="91.0"/>
+      <Q id="6428619969" qualifier_id="141" value="11.0"/>
+      <Q id="6428619971" qualifier_id="212" value="10.4"/>
+      <Q id="6428619973" qualifier_id="213" value="0.05"/>
+    </Event>
+    <Event id="2939833361" event_id="355" type_id="1" period_id="1" min="48" sec="19" player_id="157851" team_id="417" outcome="0" x="94.1" y="8.2" timestamp="2026-05-19T14:10:07.706" timestamp_utc="2026-05-19T13:10:07.706" last_modified="2026-05-19T14:10:09" version="1779196208906">
+      <Q id="6428620025" qualifier_id="2"/>
+      <Q id="6428620029" qualifier_id="56" value="Center"/>
+      <Q id="6428620031" qualifier_id="140" value="86.4"/>
+      <Q id="6428620033" qualifier_id="141" value="48.7"/>
+      <Q id="6428620027" qualifier_id="155"/>
+      <Q id="6428620035" qualifier_id="212" value="28.7"/>
+      <Q id="6428620037" qualifier_id="213" value="1.86"/>
+    </Event>
+    <Event id="2939833369" event_id="487" type_id="12" period_id="1" min="48" sec="22" player_id="627127" team_id="244" outcome="1" x="10.8" y="61.7" timestamp="2026-05-19T14:10:10.234" timestamp_utc="2026-05-19T13:10:10.234" last_modified="2026-05-19T14:10:15" version="1779196215356">
+      <Q id="6428620073" qualifier_id="15"/>
+      <Q id="6428620059" qualifier_id="56" value="Back"/>
+      <Q id="6428620061" qualifier_id="140" value="0.0"/>
+      <Q id="6428620063" qualifier_id="141" value="71.8"/>
+      <Q id="6428620265" qualifier_id="167"/>
+      <Q id="6428620065" qualifier_id="212" value="14.4"/>
+      <Q id="6428620067" qualifier_id="213" value="2.64"/>
+    </Event>
+    <Event id="2939833393" event_id="356" type_id="6" period_id="1" min="48" sec="27" player_id="157851" team_id="417" outcome="1" x="94.2" y="27.0" timestamp="2026-05-19T14:10:14.810" timestamp_utc="2026-05-19T13:10:14.810" last_modified="2026-05-19T14:10:19" version="1779196216406">
+      <Q id="6428620293" qualifier_id="56" value="Center"/>
+      <Q id="6428620295" qualifier_id="75"/>
+      <Q id="6428620297" qualifier_id="233" value="488"/>
+    </Event>
+    <Event id="2939833395" event_id="488" type_id="6" period_id="1" min="48" sec="27" player_id="627127" team_id="244" outcome="0" x="5.8" y="73.0" timestamp="2026-05-19T14:10:14.810" timestamp_utc="2026-05-19T13:10:14.810" last_modified="2026-05-19T14:18:38" version="1779196718324">
+      <Q id="6428620283" qualifier_id="56" value="Back"/>
+      <Q id="6428620285" qualifier_id="73"/>
+      <Q id="6428620303" qualifier_id="233" value="356"/>
+    </Event>
+    <Event id="2939833531" event_id="357" type_id="1" period_id="1" min="48" sec="52" player_id="164593" team_id="417" outcome="0" x="99.5" y="0.5" timestamp="2026-05-19T14:10:40.466" timestamp_utc="2026-05-19T13:10:40.466" last_modified="2026-05-19T14:10:59" version="1779196259367">
+      <Q id="6428621029" qualifier_id="1"/>
+      <Q id="6428621011" qualifier_id="2"/>
+      <Q id="6428621013" qualifier_id="6"/>
+      <Q id="6428621019" qualifier_id="56" value="Center"/>
+      <Q id="6428621021" qualifier_id="140" value="100.0"/>
+      <Q id="6428621023" qualifier_id="141" value="73.3"/>
+      <Q id="6428621015" qualifier_id="155"/>
+      <Q id="6428621025" qualifier_id="212" value="49.5"/>
+      <Q id="6428621027" qualifier_id="213" value="1.54"/>
+      <Q id="6428621017" qualifier_id="223"/>
+    </Event>
+    <Event id="2939833537" event_id="358" type_id="5" period_id="1" min="48" sec="54" player_id="164593" team_id="417" outcome="0" x="101.0" y="67.4" timestamp="2026-05-19T14:10:42.680" timestamp_utc="2026-05-19T13:10:42.680" last_modified="2026-05-19T14:23:54" version="1779197029628">
+      <Q id="6428621063" qualifier_id="56" value="Center"/>
+      <Q id="6428621189" qualifier_id="233" value="489"/>
+      <Q id="6428621065" qualifier_id="346"/>
+    </Event>
+    <Event id="2939833551" event_id="489" type_id="5" period_id="1" min="48" sec="54" player_id="627127" team_id="244" outcome="1" x="-1.0" y="32.6" timestamp="2026-05-19T14:10:42.680" timestamp_utc="2026-05-19T13:10:42.680" last_modified="2026-05-19T14:23:53" version="1779197029625">
+      <Q id="6428621167" qualifier_id="56" value="Back"/>
+      <Q id="6428621185" qualifier_id="233" value="358"/>
+      <Q id="6428621169" qualifier_id="346"/>
+    </Event>
+    <Event id="2939833565" event_id="490" type_id="1" period_id="1" min="48" sec="59" player_id="578592" team_id="244" outcome="1" x="5.1" y="41.6" timestamp="2026-05-19T14:10:47.194" timestamp_utc="2026-05-19T13:10:47.194" last_modified="2026-05-19T14:10:49" version="1779196248276">
+      <Q id="6428621249" qualifier_id="56" value="Back"/>
+      <Q id="6428621247" qualifier_id="124"/>
+      <Q id="6428621251" qualifier_id="140" value="22.5"/>
+      <Q id="6428621253" qualifier_id="141" value="14.6"/>
+      <Q id="6428621255" qualifier_id="212" value="25.9"/>
+      <Q id="6428621257" qualifier_id="213" value="5.50"/>
+      <Q id="6428621261" qualifier_id="237"/>
+    </Event>
+    <Event id="2939833575" event_id="491" type_id="43" period_id="1" min="49" sec="1" player_id="240166" team_id="244" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T14:10:48.987" timestamp_utc="2026-05-19T13:10:48.987" last_modified="2026-05-19T14:10:55" version="1779196252528">
+      <Q id="6428621361" qualifier_id="1" value="0"/>
+      <Q id="6428621351" qualifier_id="56" value="Center"/>
+      <Q id="6428621353" qualifier_id="140" value="59.0"/>
+      <Q id="6428621355" qualifier_id="141" value="55.7"/>
+      <Q id="6428621461" qualifier_id="144" value="1"/>
+      <Q id="6428621349" qualifier_id="157" value="0"/>
+      <Q id="6428621357" qualifier_id="212" value="47.4"/>
+      <Q id="6428621359" qualifier_id="213" value="0.63"/>
+    </Event>
+    <Event id="2939833659" event_id="359" type_id="30" period_id="1" min="49" sec="15" team_id="417" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T14:11:03.698" timestamp_utc="2026-05-19T13:11:03.698" last_modified="2026-05-19T14:11:03" version="1779196263703">
+      <Q id="6428621783" qualifier_id="57" value="0"/>
+    </Event>
+    <Event id="2939833661" event_id="492" type_id="30" period_id="1" min="49" sec="15" team_id="244" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T14:11:03.698" timestamp_utc="2026-05-19T13:11:03.698" last_modified="2026-05-19T14:11:04" version="1779196264440">
+      <Q id="6428621799" qualifier_id="57" value="0"/>
+    </Event>
+    <Event id="2939836617" event_id="494" type_id="32" period_id="2" min="45" sec="0" team_id="244" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T14:23:00.557" timestamp_utc="2026-05-19T13:23:00.557" last_modified="2026-05-19T14:23:00" version="1779196980559">
+      <Q id="6428638843" qualifier_id="127" value="Left to Right"/>
+    </Event>
+    <Event id="2939836621" event_id="360" type_id="32" period_id="2" min="45" sec="0" team_id="417" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T14:23:00.557" timestamp_utc="2026-05-19T13:23:00.557" last_modified="2026-05-19T14:23:00" version="1779196980805">
+      <Q id="6428638853" qualifier_id="127" value="Right to Left"/>
+    </Event>
+    <Event id="2939836633" event_id="495" type_id="1" period_id="2" min="45" sec="0" player_id="207884" team_id="244" outcome="1" x="49.7" y="49.9" timestamp="2026-05-19T14:23:00.558" timestamp_utc="2026-05-19T13:23:00.558" last_modified="2026-05-19T14:23:03" version="1779196983098">
+      <Q id="6428638905" qualifier_id="56" value="Back"/>
+      <Q id="6428638907" qualifier_id="140" value="33.4"/>
+      <Q id="6428638909" qualifier_id="141" value="58.1"/>
+      <Q id="6428638911" qualifier_id="212" value="18.0"/>
+      <Q id="6428638913" qualifier_id="213" value="2.83"/>
+      <Q id="6428638915" qualifier_id="279" value="S"/>
+    </Event>
+    <Event id="2939836647" event_id="496" type_id="1" period_id="2" min="45" sec="3" player_id="180662" team_id="244" outcome="1" x="33.4" y="58.1" timestamp="2026-05-19T14:23:03.625" timestamp_utc="2026-05-19T13:23:03.625" last_modified="2026-05-19T14:23:06" version="1779196985331">
+      <Q id="6428638987" qualifier_id="1"/>
+      <Q id="6428638977" qualifier_id="56" value="Right"/>
+      <Q id="6428638979" qualifier_id="140" value="65.2"/>
+      <Q id="6428638981" qualifier_id="141" value="18.5"/>
+      <Q id="6428638975" qualifier_id="157"/>
+      <Q id="6428638983" qualifier_id="212" value="42.9"/>
+      <Q id="6428638985" qualifier_id="213" value="5.60"/>
+    </Event>
+    <Event id="2939836663" event_id="497" type_id="1" period_id="2" min="45" sec="5" player_id="232091" team_id="244" outcome="0" x="65.2" y="18.5" timestamp="2026-05-19T14:23:06.185" timestamp_utc="2026-05-19T13:23:06.185" last_modified="2026-05-19T14:23:09" version="1779196989058">
+      <Q id="6428639073" qualifier_id="3"/>
+      <Q id="6428639077" qualifier_id="56" value="Center"/>
+      <Q id="6428639079" qualifier_id="140" value="76.4"/>
+      <Q id="6428639081" qualifier_id="141" value="36.6"/>
+      <Q id="6428639075" qualifier_id="168"/>
+      <Q id="6428639083" qualifier_id="212" value="17.0"/>
+      <Q id="6428639085" qualifier_id="213" value="0.81"/>
+    </Event>
+    <Event id="2939836677" event_id="361" type_id="43" period_id="2" min="45" sec="9" player_id="624620" team_id="417" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T14:23:09.659" timestamp_utc="2026-05-19T13:23:09.659" last_modified="2026-05-19T14:23:16" version="1779196992316">
+      <Q id="6428639119" qualifier_id="3" value="0"/>
+      <Q id="6428639121" qualifier_id="56" value="Back"/>
+      <Q id="6428639123" qualifier_id="140" value="23.0"/>
+      <Q id="6428639125" qualifier_id="141" value="87.7"/>
+      <Q id="6428639191" qualifier_id="144" value="1"/>
+      <Q id="6428639127" qualifier_id="212" value="6.7"/>
+      <Q id="6428639129" qualifier_id="213" value="1.54"/>
+    </Event>
+    <Event id="2939836681" event_id="362" type_id="1" period_id="2" min="45" sec="12" player_id="624620" team_id="417" outcome="0" x="22.9" y="84.1" timestamp="2026-05-19T14:23:12.841" timestamp_utc="2026-05-19T13:23:12.841" last_modified="2026-05-19T14:23:13" version="1779196993812">
+      <Q id="6428639145" qualifier_id="1"/>
+      <Q id="6428639135" qualifier_id="56" value="Center"/>
+      <Q id="6428639137" qualifier_id="140" value="77.9"/>
+      <Q id="6428639139" qualifier_id="141" value="56.9"/>
+      <Q id="6428639133" qualifier_id="157"/>
+      <Q id="6428639141" qualifier_id="212" value="60.6"/>
+      <Q id="6428639143" qualifier_id="213" value="5.97"/>
+    </Event>
+    <Event id="2939836725" event_id="499" type_id="1" period_id="2" min="45" sec="19" player_id="578592" team_id="244" outcome="0" x="26.6" y="49.1" timestamp="2026-05-19T14:23:19.722" timestamp_utc="2026-05-19T13:23:19.722" last_modified="2026-05-19T14:23:23" version="1779197003025">
+      <Q id="6428639321" qualifier_id="1"/>
+      <Q id="6428639311" qualifier_id="56" value="Center"/>
+      <Q id="6428639313" qualifier_id="140" value="70.5"/>
+      <Q id="6428639315" qualifier_id="141" value="74.4"/>
+      <Q id="6428639309" qualifier_id="157"/>
+      <Q id="6428639317" qualifier_id="212" value="49.2"/>
+      <Q id="6428639319" qualifier_id="213" value="0.36"/>
+    </Event>
+    <Event id="2939836745" event_id="500" type_id="61" period_id="2" min="45" sec="24" player_id="648131" team_id="244" outcome="1" x="71.7" y="70.8" timestamp="2026-05-19T14:23:25.136" timestamp_utc="2026-05-19T13:23:25.136" last_modified="2026-05-19T14:23:25" version="1779197005137">
+      <Q id="6428639421" qualifier_id="56" value="Center"/>
+    </Event>
+    <Event id="2939836751" event_id="364" type_id="8" period_id="2" min="45" sec="26" player_id="531784" team_id="417" outcome="1" x="30.1" y="29.5" timestamp="2026-05-19T14:23:26.738" timestamp_utc="2026-05-19T13:23:26.738" last_modified="2026-05-19T14:23:26" version="1779197006739">
+      <Q id="6428639439" qualifier_id="56" value="Back"/>
+    </Event>
+    <Event id="2939836771" event_id="365" type_id="4" period_id="2" min="45" sec="26" player_id="531784" team_id="417" outcome="1" x="27.8" y="29.2" timestamp="2026-05-19T14:23:27.168" timestamp_utc="2026-05-19T13:23:27.168" last_modified="2026-05-19T14:23:33" version="1779197010409">
+      <Q id="6428639577" qualifier_id="13"/>
+      <Q id="6428639581" qualifier_id="56" value="Back"/>
+      <Q id="6428639583" qualifier_id="152"/>
+      <Q id="6428639615" qualifier_id="233" value="501"/>
+      <Q id="6428639585" qualifier_id="285"/>
+      <Q id="6428639579" qualifier_id="295"/>
+    </Event>
+    <Event id="2939836753" event_id="501" type_id="4" period_id="2" min="45" sec="26" player_id="648131" team_id="244" outcome="0" x="72.2" y="70.8" timestamp="2026-05-19T14:23:27.169" timestamp_utc="2026-05-19T13:23:27.169" last_modified="2026-05-19T14:23:32" version="1779197010399">
+      <Q id="6428639565" qualifier_id="13"/>
+      <Q id="6428639569" qualifier_id="56" value="Center"/>
+      <Q id="6428639571" qualifier_id="152"/>
+      <Q id="6428639625" qualifier_id="233" value="365"/>
+      <Q id="6428639573" qualifier_id="286"/>
+      <Q id="6428639567" qualifier_id="295"/>
+    </Event>
+    <Event id="2939836839" event_id="366" type_id="1" period_id="2" min="45" sec="41" player_id="531784" team_id="417" outcome="1" x="29.9" y="21.8" timestamp="2026-05-19T14:23:42.338" timestamp_utc="2026-05-19T13:23:42.338" last_modified="2026-05-19T14:23:45" version="1779197023497">
+      <Q id="6428639919" qualifier_id="1"/>
+      <Q id="6428639901" qualifier_id="5"/>
+      <Q id="6428639909" qualifier_id="56" value="Back"/>
+      <Q id="6428639911" qualifier_id="140" value="33.0"/>
+      <Q id="6428639913" qualifier_id="141" value="85.4"/>
+      <Q id="6428639907" qualifier_id="152"/>
+      <Q id="6428639903" qualifier_id="155"/>
+      <Q id="6428639905" qualifier_id="196"/>
+      <Q id="6428639915" qualifier_id="212" value="43.4"/>
+      <Q id="6428639917" qualifier_id="213" value="1.50"/>
+    </Event>
+    <Event id="2939836855" event_id="367" type_id="1" period_id="2" min="45" sec="44" player_id="164593" team_id="417" outcome="1" x="30.8" y="90.5" timestamp="2026-05-19T14:23:45.314" timestamp_utc="2026-05-19T13:23:45.314" last_modified="2026-05-19T14:23:49" version="1779197025523">
+      <Q id="6428640023" qualifier_id="56" value="Back"/>
+      <Q id="6428640025" qualifier_id="140" value="29.9"/>
+      <Q id="6428640027" qualifier_id="141" value="72.3"/>
+      <Q id="6428640029" qualifier_id="212" value="12.4"/>
+      <Q id="6428640031" qualifier_id="213" value="4.64"/>
+    </Event>
+    <Event id="2939836865" event_id="368" type_id="1" period_id="2" min="45" sec="49" player_id="720682" team_id="417" outcome="1" x="30.5" y="73.0" timestamp="2026-05-19T14:23:49.601" timestamp_utc="2026-05-19T13:23:49.601" last_modified="2026-05-19T14:23:53" version="1779197029891">
+      <Q id="6428640067" qualifier_id="56" value="Back"/>
+      <Q id="6428640069" qualifier_id="140" value="26.0"/>
+      <Q id="6428640071" qualifier_id="141" value="45.8"/>
+      <Q id="6428640073" qualifier_id="212" value="19.1"/>
+      <Q id="6428640075" qualifier_id="213" value="4.46"/>
+    </Event>
+    <Event id="2939836871" event_id="369" type_id="1" period_id="2" min="45" sec="52" player_id="61812" team_id="417" outcome="1" x="19.5" y="50.1" timestamp="2026-05-19T14:23:52.875" timestamp_utc="2026-05-19T13:23:52.875" last_modified="2026-05-19T14:23:57" version="1779197034305">
+      <Q id="6428640119" qualifier_id="56" value="Back"/>
+      <Q id="6428640121" qualifier_id="140" value="29.1"/>
+      <Q id="6428640123" qualifier_id="141" value="24.9"/>
+      <Q id="6428640125" qualifier_id="212" value="19.9"/>
+      <Q id="6428640127" qualifier_id="213" value="5.24"/>
+    </Event>
+    <Event id="2939836881" event_id="370" type_id="1" period_id="2" min="45" sec="56" player_id="157851" team_id="417" outcome="1" x="32.7" y="14.4" timestamp="2026-05-19T14:23:57.130" timestamp_utc="2026-05-19T13:23:57.130" last_modified="2026-05-19T14:23:59" version="1779197037420">
+      <Q id="6428640189" qualifier_id="56" value="Back"/>
+      <Q id="6428640191" qualifier_id="140" value="22.0"/>
+      <Q id="6428640193" qualifier_id="141" value="25.0"/>
+      <Q id="6428640195" qualifier_id="212" value="13.3"/>
+      <Q id="6428640197" qualifier_id="213" value="2.57"/>
+    </Event>
+    <Event id="2939836909" event_id="371" type_id="1" period_id="2" min="45" sec="59" player_id="531784" team_id="417" outcome="1" x="22.4" y="14.1" timestamp="2026-05-19T14:23:59.769" timestamp_utc="2026-05-19T13:23:59.769" last_modified="2026-05-19T14:24:05" version="1779197041563">
+      <Q id="6428640305" qualifier_id="56" value="Back"/>
+      <Q id="6428640307" qualifier_id="140" value="10.2"/>
+      <Q id="6428640309" qualifier_id="141" value="53.7"/>
+      <Q id="6428640311" qualifier_id="212" value="29.8"/>
+      <Q id="6428640313" qualifier_id="213" value="2.01"/>
+    </Event>
+    <Event id="2939836911" event_id="372" type_id="1" period_id="2" min="46" sec="4" player_id="565487" team_id="417" outcome="0" x="7.0" y="67.5" timestamp="2026-05-19T14:24:05.441" timestamp_utc="2026-05-19T13:24:05.441" last_modified="2026-05-19T14:24:06" version="1779197046027">
+      <Q id="6428640357" qualifier_id="1"/>
+      <Q id="6428640347" qualifier_id="56" value="Back"/>
+      <Q id="6428640349" qualifier_id="140" value="37.4"/>
+      <Q id="6428640351" qualifier_id="141" value="74.1"/>
+      <Q id="6428640353" qualifier_id="212" value="32.2"/>
+      <Q id="6428640355" qualifier_id="213" value="0.14"/>
+    </Event>
+    <Event id="2939836917" event_id="502" type_id="1" period_id="2" min="46" sec="6" player_id="240166" team_id="244" outcome="1" x="64.1" y="19.2" timestamp="2026-05-19T14:24:07.281" timestamp_utc="2026-05-19T13:24:07.281" last_modified="2026-05-19T14:24:09" version="1779197049316">
+      <Q id="6428640409" qualifier_id="56" value="Center"/>
+      <Q id="6428640411" qualifier_id="140" value="62.7"/>
+      <Q id="6428640413" qualifier_id="141" value="41.2"/>
+      <Q id="6428640415" qualifier_id="212" value="15.0"/>
+      <Q id="6428640417" qualifier_id="213" value="1.67"/>
+    </Event>
+    <Event id="2939836919" event_id="503" type_id="49" period_id="2" min="46" sec="9" player_id="515742" team_id="244" outcome="1" x="62.7" y="41.2" timestamp="2026-05-19T14:24:09.857" timestamp_utc="2026-05-19T13:24:09.857" last_modified="2026-05-19T14:24:10" version="1779197049859"/>
+    <Event id="2939836921" event_id="504" type_id="1" period_id="2" min="46" sec="9" player_id="515742" team_id="244" outcome="1" x="62.7" y="41.2" timestamp="2026-05-19T14:24:10.057" timestamp_utc="2026-05-19T13:24:10.057" last_modified="2026-05-19T14:24:11" version="1779197050413">
+      <Q id="6428640423" qualifier_id="56" value="Center"/>
+      <Q id="6428640425" qualifier_id="140" value="69.6"/>
+      <Q id="6428640427" qualifier_id="141" value="45.2"/>
+      <Q id="6428640429" qualifier_id="212" value="7.7"/>
+      <Q id="6428640433" qualifier_id="213" value="0.36"/>
+    </Event>
+    <Event id="2939836933" event_id="505" type_id="1" period_id="2" min="46" sec="10" player_id="207884" team_id="244" outcome="1" x="69.6" y="45.2" timestamp="2026-05-19T14:24:10.897" timestamp_utc="2026-05-19T13:24:10.897" last_modified="2026-05-19T14:24:14" version="1779197052426">
+      <Q id="6428640521" qualifier_id="56" value="Center"/>
+      <Q id="6428640523" qualifier_id="140" value="61.6"/>
+      <Q id="6428640525" qualifier_id="141" value="62.3"/>
+      <Q id="6428640527" qualifier_id="212" value="14.3"/>
+      <Q id="6428640529" qualifier_id="213" value="2.20"/>
+    </Event>
+    <Event id="2939836935" event_id="506" type_id="1" period_id="2" min="46" sec="13" player_id="575855" team_id="244" outcome="1" x="62.2" y="60.9" timestamp="2026-05-19T14:24:14.049" timestamp_utc="2026-05-19T13:24:14.049" last_modified="2026-05-19T14:26:15" version="1779197175543">
+      <Q id="6428640533" qualifier_id="56" value="Center"/>
+      <Q id="6428640535" qualifier_id="140" value="58.4"/>
+      <Q id="6428640537" qualifier_id="141" value="56.9"/>
+      <Q id="6428640539" qualifier_id="212" value="4.8"/>
+      <Q id="6428640541" qualifier_id="213" value="3.74"/>
+    </Event>
+    <Event id="2939836957" event_id="507" type_id="1" period_id="2" min="46" sec="16" player_id="515742" team_id="244" outcome="1" x="58.4" y="56.9" timestamp="2026-05-19T14:24:16.810" timestamp_utc="2026-05-19T13:24:16.810" last_modified="2026-05-19T14:24:20" version="1779197057746">
+      <Q id="6428640703" qualifier_id="56" value="Center"/>
+      <Q id="6428640705" qualifier_id="140" value="53.8"/>
+      <Q id="6428640707" qualifier_id="141" value="41.0"/>
+      <Q id="6428640709" qualifier_id="212" value="11.8"/>
+      <Q id="6428640711" qualifier_id="213" value="4.29"/>
+    </Event>
+    <Event id="2939836967" event_id="508" type_id="1" period_id="2" min="46" sec="19" player_id="627127" team_id="244" outcome="1" x="53.8" y="41.0" timestamp="2026-05-19T14:24:19.978" timestamp_utc="2026-05-19T13:24:19.978" last_modified="2026-05-19T14:24:25" version="1779197063202">
+      <Q id="6428640811" qualifier_id="1"/>
+      <Q id="6428640801" qualifier_id="56" value="Left"/>
+      <Q id="6428640803" qualifier_id="140" value="75.8"/>
+      <Q id="6428640805" qualifier_id="141" value="85.9"/>
+      <Q id="6428640799" qualifier_id="155"/>
+      <Q id="6428640807" qualifier_id="212" value="38.3"/>
+      <Q id="6428640809" qualifier_id="213" value="0.92"/>
+    </Event>
+    <Event id="2939836971" event_id="509" type_id="50" period_id="2" min="46" sec="24" player_id="648131" team_id="244" outcome="1" x="72.8" y="83.4" timestamp="2026-05-19T14:24:24.938" timestamp_utc="2026-05-19T13:24:24.938" last_modified="2026-05-19T15:26:44" version="1779200796875">
+      <Q id="6428640831" qualifier_id="56" value="Left"/>
+      <Q id="6428640899" qualifier_id="233" value="373"/>
+      <Q id="6428640833" qualifier_id="286"/>
+    </Event>
+    <Event id="2939836977" event_id="373" type_id="7" period_id="2" min="46" sec="24" player_id="157851" team_id="417" outcome="0" x="27.2" y="16.6" timestamp="2026-05-19T14:24:24.939" timestamp_utc="2026-05-19T13:24:24.939" last_modified="2026-05-19T15:26:43" version="1779200796869">
+      <Q id="6428640865" qualifier_id="56" value="Back"/>
+      <Q id="6428640869" qualifier_id="178"/>
+      <Q id="6428640883" qualifier_id="233" value="509"/>
+      <Q id="6428640867" qualifier_id="285"/>
+    </Event>
+    <Event id="2939837647" event_id="532" type_id="43" period_id="2" min="46" sec="25" player_id="207884" team_id="244" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T14:24:25.924" timestamp_utc="2026-05-19T13:24:25.924" last_modified="2026-05-19T14:28:36" version="1779197222009">
+      <Q id="6428644973" qualifier_id="56" value="Left"/>
+      <Q id="6428647579" qualifier_id="144" value="61"/>
+    </Event>
+    <Event id="2939836981" event_id="374" type_id="49" period_id="2" min="46" sec="26" player_id="685390" team_id="417" outcome="1" x="34.0" y="28.2" timestamp="2026-05-19T14:24:26.745" timestamp_utc="2026-05-19T13:24:26.745" last_modified="2026-05-19T14:24:27" version="1779197066746"/>
+    <Event id="2939836989" event_id="375" type_id="1" period_id="2" min="46" sec="26" player_id="685390" team_id="417" outcome="0" x="32.9" y="28.3" timestamp="2026-05-19T14:24:26.923" timestamp_utc="2026-05-19T13:24:26.923" last_modified="2026-05-19T14:24:29" version="1779197068987">
+      <Q id="6428640925" qualifier_id="56" value="Back"/>
+      <Q id="6428640927" qualifier_id="140" value="34.2"/>
+      <Q id="6428640929" qualifier_id="141" value="26.7"/>
+      <Q id="6428640931" qualifier_id="212" value="1.7"/>
+      <Q id="6428640933" qualifier_id="213" value="5.61"/>
+      <Q id="6428640979" qualifier_id="233" value="510"/>
+      <Q id="6428640973" qualifier_id="236"/>
+      <Q id="6428640977" qualifier_id="286"/>
+    </Event>
+    <Event id="2939836999" event_id="510" type_id="74" period_id="2" min="46" sec="26" player_id="207884" team_id="244" outcome="1" x="65.8" y="73.3" timestamp="2026-05-19T14:24:26.924" timestamp_utc="2026-05-19T13:24:26.924" last_modified="2026-05-19T15:45:52" version="1779201952390">
+      <Q id="6428640969" qualifier_id="56" value="Center"/>
+      <Q id="6428641003" qualifier_id="233" value="375"/>
+      <Q id="6428640971" qualifier_id="285"/>
+    </Event>
+    <Event id="2939837007" event_id="511" type_id="49" period_id="2" min="46" sec="28" player_id="207884" team_id="244" outcome="1" x="69.6" y="84.5" timestamp="2026-05-19T14:24:29.418" timestamp_utc="2026-05-19T13:24:29.418" last_modified="2026-05-19T14:24:29" version="1779197069419"/>
+    <Event id="2939837017" event_id="376" type_id="83" period_id="2" min="46" sec="30" player_id="685390" team_id="417" outcome="0" x="24.9" y="24.3" timestamp="2026-05-19T14:24:31.537" timestamp_utc="2026-05-19T13:24:31.537" last_modified="2026-05-19T14:24:39" version="1779197079160">
+      <Q id="6428641209" qualifier_id="399" value="207884"/>
+    </Event>
+    <Event id="2939837027" event_id="512" type_id="1" period_id="2" min="46" sec="33" player_id="207884" team_id="244" outcome="1" x="80.4" y="83.3" timestamp="2026-05-19T14:24:33.705" timestamp_utc="2026-05-19T13:24:33.705" last_modified="2026-05-19T14:24:36" version="1779197073955">
+      <Q id="6428641149" qualifier_id="56" value="Left"/>
+      <Q id="6428641151" qualifier_id="140" value="75.1"/>
+      <Q id="6428641153" qualifier_id="141" value="80.9"/>
+      <Q id="6428641155" qualifier_id="212" value="5.8"/>
+      <Q id="6428641157" qualifier_id="213" value="3.43"/>
+    </Event>
+    <Event id="2939837033" event_id="513" type_id="1" period_id="2" min="46" sec="36" player_id="515742" team_id="244" outcome="0" x="70.5" y="73.6" timestamp="2026-05-19T14:24:36.777" timestamp_utc="2026-05-19T13:24:36.777" last_modified="2026-05-19T14:24:38" version="1779197078319">
+      <Q id="6428641191" qualifier_id="1"/>
+      <Q id="6428641177" qualifier_id="2"/>
+      <Q id="6428641181" qualifier_id="56" value="Center"/>
+      <Q id="6428641183" qualifier_id="140" value="100.0"/>
+      <Q id="6428641185" qualifier_id="141" value="34.0"/>
+      <Q id="6428641179" qualifier_id="155"/>
+      <Q id="6428641187" qualifier_id="212" value="41.4"/>
+      <Q id="6428641189" qualifier_id="213" value="5.57"/>
+    </Event>
+    <Event id="2939837035" event_id="514" type_id="5" period_id="2" min="46" sec="37" player_id="515742" team_id="244" outcome="0" x="100.4" y="33.2" timestamp="2026-05-19T14:24:38.330" timestamp_utc="2026-05-19T13:24:38.330" last_modified="2026-05-19T15:26:30" version="1779200790067">
+      <Q id="6428641195" qualifier_id="56" value="Center"/>
+      <Q id="6428641829" qualifier_id="233" value="377"/>
+      <Q id="6428641197" qualifier_id="346"/>
+    </Event>
+    <Event id="2939837139" event_id="377" type_id="5" period_id="2" min="46" sec="37" player_id="685390" team_id="417" outcome="1" x="-0.4" y="66.8" timestamp="2026-05-19T14:24:38.330" timestamp_utc="2026-05-19T13:24:38.330" last_modified="2026-05-19T15:26:30" version="1779200790046">
+      <Q id="6428641815" qualifier_id="56" value="Back"/>
+      <Q id="6428641819" qualifier_id="233" value="514"/>
+      <Q id="6428641817" qualifier_id="346"/>
+    </Event>
+    <Event id="2939837149" event_id="378" type_id="1" period_id="2" min="46" sec="59" player_id="565487" team_id="417" outcome="1" x="4.8" y="48.4" timestamp="2026-05-19T14:25:00.114" timestamp_utc="2026-05-19T13:25:00.114" last_modified="2026-05-19T14:25:04" version="1779197102858">
+      <Q id="6428641931" qualifier_id="1"/>
+      <Q id="6428641921" qualifier_id="56" value="Center"/>
+      <Q id="6428641935" qualifier_id="74"/>
+      <Q id="6428641919" qualifier_id="124"/>
+      <Q id="6428641923" qualifier_id="140" value="54.1"/>
+      <Q id="6428641925" qualifier_id="141" value="68.4"/>
+      <Q id="6428641927" qualifier_id="212" value="53.5"/>
+      <Q id="6428641929" qualifier_id="213" value="0.26"/>
+    </Event>
+    <Event id="2939837161" event_id="380" type_id="44" period_id="2" min="47" sec="4" player_id="61778" team_id="417" outcome="1" x="54.1" y="68.4" timestamp="2026-05-19T14:25:04.824" timestamp_utc="2026-05-19T13:25:04.824" last_modified="2026-05-19T15:45:40" version="1779201940151">
+      <Q id="6428641975" qualifier_id="56" value="Center"/>
+      <Q id="6428642005" qualifier_id="233" value="516"/>
+      <Q id="6428641977" qualifier_id="286"/>
+    </Event>
+    <Event id="2939837159" event_id="516" type_id="44" period_id="2" min="47" sec="4" player_id="515742" team_id="244" outcome="0" x="45.9" y="31.6" timestamp="2026-05-19T14:25:04.825" timestamp_utc="2026-05-19T13:25:04.825" last_modified="2026-05-19T15:45:40" version="1779201940419">
+      <Q id="6428641971" qualifier_id="56" value="Back"/>
+      <Q id="6428642115" qualifier_id="233" value="380"/>
+      <Q id="6428641973" qualifier_id="285"/>
+    </Event>
+    <Event id="2939837151" event_id="379" type_id="1" period_id="2" min="47" sec="5" player_id="61778" team_id="417" outcome="0" x="54.1" y="68.4" timestamp="2026-05-19T14:25:05.649" timestamp_utc="2026-05-19T13:25:05.649" last_modified="2026-05-19T15:45:40" version="1779201940700">
+      <Q id="6428641937" qualifier_id="3"/>
+      <Q id="6428641941" qualifier_id="56" value="Center"/>
+      <Q id="6428641943" qualifier_id="140" value="55.6"/>
+      <Q id="6428641945" qualifier_id="141" value="63.7"/>
+      <Q id="6428641939" qualifier_id="168"/>
+      <Q id="6428641947" qualifier_id="212" value="3.6"/>
+      <Q id="6428641949" qualifier_id="213" value="5.17"/>
+    </Event>
+    <Event id="2939837153" event_id="515" type_id="61" period_id="2" min="47" sec="5" player_id="515742" team_id="244" outcome="1" x="45.3" y="40.0" timestamp="2026-05-19T14:25:06.543" timestamp_utc="2026-05-19T13:25:06.543" last_modified="2026-05-19T14:25:06" version="1779197106544">
+      <Q id="6428641953" qualifier_id="56" value="Back"/>
+    </Event>
+    <Event id="2939837191" event_id="381" type_id="1" period_id="2" min="47" sec="7" player_id="720682" team_id="417" outcome="1" x="34.8" y="79.4" timestamp="2026-05-19T14:25:08.264" timestamp_utc="2026-05-19T13:25:08.264" last_modified="2026-05-19T14:25:13" version="1779197108462">
+      <Q id="6428642157" qualifier_id="56" value="Back"/>
+      <Q id="6428642159" qualifier_id="140" value="22.2"/>
+      <Q id="6428642161" qualifier_id="141" value="82.7"/>
+      <Q id="6428642163" qualifier_id="212" value="13.4"/>
+      <Q id="6428642165" qualifier_id="213" value="2.97"/>
+    </Event>
+    <Event id="2939837207" event_id="382" type_id="1" period_id="2" min="47" sec="9" player_id="624620" team_id="417" outcome="1" x="23.5" y="83.9" timestamp="2026-05-19T14:25:10.405" timestamp_utc="2026-05-19T13:25:10.405" last_modified="2026-05-19T14:25:15" version="1779197110534">
+      <Q id="6428642207" qualifier_id="56" value="Back"/>
+      <Q id="6428642209" qualifier_id="140" value="22.4"/>
+      <Q id="6428642211" qualifier_id="141" value="65.5"/>
+      <Q id="6428642213" qualifier_id="212" value="12.6"/>
+      <Q id="6428642215" qualifier_id="213" value="4.62"/>
+    </Event>
+    <Event id="2939837229" event_id="383" type_id="1" period_id="2" min="47" sec="11" player_id="61812" team_id="417" outcome="1" x="22.4" y="65.5" timestamp="2026-05-19T14:25:12.032" timestamp_utc="2026-05-19T13:25:12.032" last_modified="2026-05-19T14:25:18" version="1779197113730">
+      <Q id="6428642351" qualifier_id="56" value="Back"/>
+      <Q id="6428642353" qualifier_id="140" value="36.5"/>
+      <Q id="6428642355" qualifier_id="141" value="39.1"/>
+      <Q id="6428642357" qualifier_id="212" value="23.3"/>
+      <Q id="6428642359" qualifier_id="213" value="5.40"/>
+    </Event>
+    <Event id="2939837247" event_id="384" type_id="1" period_id="2" min="47" sec="18" player_id="685390" team_id="417" outcome="1" x="40.2" y="40.4" timestamp="2026-05-19T14:25:18.640" timestamp_utc="2026-05-19T13:25:18.640" last_modified="2026-05-19T15:28:59" version="1779200939390">
+      <Q id="6428642471" qualifier_id="1"/>
+      <Q id="6428642461" qualifier_id="56" value="Left"/>
+      <Q id="6428642463" qualifier_id="140" value="55.2"/>
+      <Q id="6428642465" qualifier_id="141" value="86.6"/>
+      <Q id="6428642459" qualifier_id="155"/>
+      <Q id="6428642467" qualifier_id="212" value="35.1"/>
+      <Q id="6428642469" qualifier_id="213" value="1.11"/>
+    </Event>
+    <Event id="2939837259" event_id="385" type_id="1" period_id="2" min="47" sec="21" player_id="61778" team_id="417" outcome="1" x="72.7" y="82.6" timestamp="2026-05-19T14:25:21.977" timestamp_utc="2026-05-19T13:25:21.977" last_modified="2026-05-19T14:25:24" version="1779197122177">
+      <Q id="6428642549" qualifier_id="56" value="Center"/>
+      <Q id="6428642551" qualifier_id="140" value="70.6"/>
+      <Q id="6428642553" qualifier_id="141" value="66.4"/>
+      <Q id="6428642555" qualifier_id="212" value="11.2"/>
+      <Q id="6428642557" qualifier_id="213" value="4.51"/>
+    </Event>
+    <Event id="2939837269" event_id="386" type_id="1" period_id="2" min="47" sec="23" player_id="720682" team_id="417" outcome="1" x="78.1" y="66.6" timestamp="2026-05-19T14:25:24.221" timestamp_utc="2026-05-19T13:25:24.221" last_modified="2026-05-19T14:25:25" version="1779197124323">
+      <Q id="6428642597" qualifier_id="56" value="Center"/>
+      <Q id="6428642599" qualifier_id="140" value="88.6"/>
+      <Q id="6428642601" qualifier_id="141" value="74.4"/>
+      <Q id="6428642603" qualifier_id="212" value="12.2"/>
+      <Q id="6428642605" qualifier_id="213" value="0.45"/>
+    </Event>
+    <Event id="2939837275" event_id="387" type_id="3" period_id="2" min="47" sec="24" player_id="61778" team_id="417" outcome="0" x="92.2" y="72.6" timestamp="2026-05-19T14:25:25.103" timestamp_utc="2026-05-19T13:25:25.103" last_modified="2026-05-19T15:26:44" version="1779200796888">
+      <Q id="6428642633" qualifier_id="56" value="Center"/>
+      <Q id="6428642681" qualifier_id="233" value="517"/>
+      <Q id="6428642635" qualifier_id="286"/>
+    </Event>
+    <Event id="2939837279" event_id="517" type_id="7" period_id="2" min="47" sec="24" player_id="240166" team_id="244" outcome="1" x="7.8" y="27.4" timestamp="2026-05-19T14:25:25.104" timestamp_utc="2026-05-19T13:25:25.104" last_modified="2026-05-19T15:26:44" version="1779200796882">
+      <Q id="6428642641" qualifier_id="56" value="Back"/>
+      <Q id="6428642645" qualifier_id="178"/>
+      <Q id="6428642673" qualifier_id="233" value="387"/>
+      <Q id="6428642643" qualifier_id="285"/>
+    </Event>
+    <Event id="2939837283" event_id="518" type_id="49" period_id="2" min="47" sec="25" player_id="625775" team_id="244" outcome="1" x="12.3" y="29.5" timestamp="2026-05-19T14:25:26.201" timestamp_utc="2026-05-19T13:25:26.201" last_modified="2026-05-19T14:25:26" version="1779197126202"/>
+    <Event id="2939837301" event_id="519" type_id="1" period_id="2" min="47" sec="25" player_id="625775" team_id="244" outcome="0" x="12.3" y="29.5" timestamp="2026-05-19T14:25:26.393" timestamp_utc="2026-05-19T13:25:26.393" last_modified="2026-05-19T14:25:29" version="1779197129730">
+      <Q id="6428642789" qualifier_id="56" value="Back"/>
+      <Q id="6428642791" qualifier_id="140" value="12.4"/>
+      <Q id="6428642793" qualifier_id="141" value="14.1"/>
+      <Q id="6428642795" qualifier_id="212" value="10.5"/>
+      <Q id="6428642797" qualifier_id="213" value="4.72"/>
+    </Event>
+    <Event id="2939837309" event_id="520" type_id="83" period_id="2" min="47" sec="30" player_id="240166" team_id="244" outcome="0" x="12.5" y="11.4" timestamp="2026-05-19T14:25:31.464" timestamp_utc="2026-05-19T13:25:31.464" last_modified="2026-05-19T15:28:23" version="1779200903352">
+      <Q id="6428642905" qualifier_id="399" value="720682"/>
+    </Event>
+    <Event id="2939837317" event_id="388" type_id="49" period_id="2" min="47" sec="33" player_id="720682" team_id="417" outcome="1" x="76.7" y="88.9" timestamp="2026-05-19T14:25:33.921" timestamp_utc="2026-05-19T13:25:33.921" last_modified="2026-05-19T14:25:34" version="1779197133922"/>
+    <Event id="2939837323" event_id="389" type_id="1" period_id="2" min="47" sec="34" player_id="720682" team_id="417" outcome="1" x="70.4" y="88.9" timestamp="2026-05-19T14:25:34.912" timestamp_utc="2026-05-19T13:25:34.912" last_modified="2026-05-19T14:25:36" version="1779197135080">
+      <Q id="6428642917" qualifier_id="56" value="Center"/>
+      <Q id="6428642919" qualifier_id="140" value="69.5"/>
+      <Q id="6428642921" qualifier_id="141" value="77.5"/>
+      <Q id="6428642923" qualifier_id="212" value="7.8"/>
+      <Q id="6428642925" qualifier_id="213" value="4.59"/>
+    </Event>
+    <Event id="2939837345" event_id="390" type_id="1" period_id="2" min="47" sec="35" player_id="218339" team_id="417" outcome="1" x="68.7" y="76.3" timestamp="2026-05-19T14:25:36.016" timestamp_utc="2026-05-19T13:25:36.016" last_modified="2026-05-19T14:25:38" version="1779197136154">
+      <Q id="6428643019" qualifier_id="56" value="Left"/>
+      <Q id="6428643021" qualifier_id="140" value="66.0"/>
+      <Q id="6428643023" qualifier_id="141" value="88.0"/>
+      <Q id="6428643025" qualifier_id="212" value="8.4"/>
+      <Q id="6428643027" qualifier_id="213" value="1.91"/>
+    </Event>
+    <Event id="2939837361" event_id="391" type_id="1" period_id="2" min="47" sec="38" player_id="720682" team_id="417" outcome="1" x="63.1" y="79.9" timestamp="2026-05-19T14:25:38.776" timestamp_utc="2026-05-19T13:25:38.776" last_modified="2026-05-19T14:25:43" version="1779197139253">
+      <Q id="6428643111" qualifier_id="56" value="Center"/>
+      <Q id="6428643113" qualifier_id="140" value="55.8"/>
+      <Q id="6428643115" qualifier_id="141" value="41.3"/>
+      <Q id="6428643117" qualifier_id="212" value="27.3"/>
+      <Q id="6428643119" qualifier_id="213" value="4.43"/>
+    </Event>
+    <Event id="2939837377" event_id="392" type_id="1" period_id="2" min="47" sec="42" player_id="531784" team_id="417" outcome="1" x="54.7" y="37.0" timestamp="2026-05-19T14:25:43.018" timestamp_utc="2026-05-19T13:25:43.018" last_modified="2026-05-19T14:25:46" version="1779197143408">
+      <Q id="6428643195" qualifier_id="56" value="Right"/>
+      <Q id="6428643197" qualifier_id="140" value="62.0"/>
+      <Q id="6428643199" qualifier_id="141" value="12.9"/>
+      <Q id="6428643201" qualifier_id="212" value="18.1"/>
+      <Q id="6428643203" qualifier_id="213" value="5.15"/>
+    </Event>
+    <Event id="2939837385" event_id="393" type_id="1" period_id="2" min="47" sec="46" player_id="157851" team_id="417" outcome="1" x="63.6" y="13.4" timestamp="2026-05-19T14:25:46.785" timestamp_utc="2026-05-19T13:25:46.785" last_modified="2026-05-19T14:25:48" version="1779197146915">
+      <Q id="6428643231" qualifier_id="56" value="Center"/>
+      <Q id="6428643233" qualifier_id="140" value="56.1"/>
+      <Q id="6428643235" qualifier_id="141" value="22.5"/>
+      <Q id="6428643237" qualifier_id="212" value="10.0"/>
+      <Q id="6428643239" qualifier_id="213" value="2.48"/>
+    </Event>
+    <Event id="2939837393" event_id="394" type_id="1" period_id="2" min="47" sec="48" player_id="531784" team_id="417" outcome="0" x="55.9" y="19.5" timestamp="2026-05-19T14:25:48.737" timestamp_utc="2026-05-19T13:25:48.737" last_modified="2026-05-19T14:25:49" version="1779197149488">
+      <Q id="6428643271" qualifier_id="56" value="Right"/>
+      <Q id="6428643275" qualifier_id="140" value="59.3"/>
+      <Q id="6428643277" qualifier_id="141" value="17.6"/>
+      <Q id="6428643279" qualifier_id="212" value="3.8"/>
+      <Q id="6428643281" qualifier_id="213" value="5.94"/>
+    </Event>
+    <Event id="2939837399" event_id="521" type_id="8" period_id="2" min="47" sec="50" player_id="180662" team_id="244" outcome="1" x="40.7" y="82.4" timestamp="2026-05-19T14:25:51.169" timestamp_utc="2026-05-19T13:25:51.169" last_modified="2026-05-19T15:46:47" version="1779202006881">
+      <Q id="6428643317" qualifier_id="56" value="Back"/>
+    </Event>
+    <Event id="2939837407" event_id="522" type_id="5" period_id="2" min="47" sec="51" player_id="575855" team_id="244" outcome="0" x="43.5" y="101.6" timestamp="2026-05-19T14:25:52.193" timestamp_utc="2026-05-19T13:25:52.193" last_modified="2026-05-19T15:28:24" version="1779200904633">
+      <Q id="6428643373" qualifier_id="56" value="Back"/>
+      <Q id="6428643777" qualifier_id="233" value="395"/>
+      <Q id="6428643375" qualifier_id="347"/>
+    </Event>
+    <Event id="2939837451" event_id="395" type_id="5" period_id="2" min="47" sec="51" player_id="531784" team_id="417" outcome="1" x="56.5" y="-1.6" timestamp="2026-05-19T14:25:52.193" timestamp_utc="2026-05-19T13:25:52.193" last_modified="2026-05-19T15:26:30" version="1779200790072">
+      <Q id="6428643749" qualifier_id="56" value="Right"/>
+      <Q id="6428643765" qualifier_id="233" value="522"/>
+      <Q id="6428643751" qualifier_id="347"/>
+    </Event>
+    <Event id="2939837457" event_id="396" type_id="1" period_id="2" min="48" sec="11" player_id="157851" team_id="417" outcome="1" x="60.2" y="0.0" timestamp="2026-05-19T14:26:12.136" timestamp_utc="2026-05-19T13:26:12.136" last_modified="2026-05-19T14:26:14" version="1779197172392">
+      <Q id="6428643799" qualifier_id="56" value="Right"/>
+      <Q id="6428643797" qualifier_id="107"/>
+      <Q id="6428643801" qualifier_id="140" value="58.0"/>
+      <Q id="6428643803" qualifier_id="141" value="17.6"/>
+      <Q id="6428643805" qualifier_id="212" value="12.9"/>
+      <Q id="6428643807" qualifier_id="213" value="1.75"/>
+    </Event>
+    <Event id="2939837475" event_id="397" type_id="1" period_id="2" min="48" sec="13" player_id="531784" team_id="417" outcome="1" x="57.8" y="11.4" timestamp="2026-05-19T14:26:13.985" timestamp_utc="2026-05-19T13:26:13.985" last_modified="2026-05-19T14:26:19" version="1779197174336">
+      <Q id="6428643901" qualifier_id="56" value="Back"/>
+      <Q id="6428643903" qualifier_id="140" value="35.7"/>
+      <Q id="6428643905" qualifier_id="141" value="22.4"/>
+      <Q id="6428643907" qualifier_id="212" value="24.4"/>
+      <Q id="6428643909" qualifier_id="213" value="2.83"/>
+    </Event>
+    <Event id="2939837487" event_id="398" type_id="1" period_id="2" min="48" sec="19" player_id="61812" team_id="417" outcome="0" x="37.0" y="20.1" timestamp="2026-05-19T14:26:19.832" timestamp_utc="2026-05-19T13:26:19.832" last_modified="2026-05-19T14:27:28" version="1779197247938">
+      <Q id="6428643977" qualifier_id="1"/>
+      <Q id="6428643967" qualifier_id="56" value="Center"/>
+      <Q id="6428643969" qualifier_id="140" value="85.0"/>
+      <Q id="6428643971" qualifier_id="141" value="37.0"/>
+      <Q id="6428643965" qualifier_id="155"/>
+      <Q id="6428643973" qualifier_id="212" value="51.7"/>
+      <Q id="6428643975" qualifier_id="213" value="0.22"/>
+    </Event>
+    <Event id="2939837493" event_id="523" type_id="12" period_id="2" min="48" sec="22" player_id="627127" team_id="244" outcome="1" x="15.0" y="64.4" timestamp="2026-05-19T14:26:23.321" timestamp_utc="2026-05-19T13:26:23.321" last_modified="2026-05-19T14:32:19" version="1779197539811">
+      <Q id="6428654111" qualifier_id="15"/>
+      <Q id="6428643993" qualifier_id="56" value="Back"/>
+      <Q id="6428654039" qualifier_id="140" value="22.9"/>
+      <Q id="6428654041" qualifier_id="141" value="64.6"/>
+      <Q id="6428654043" qualifier_id="212" value="8.3"/>
+      <Q id="6428654045" qualifier_id="213" value="0.02"/>
+    </Event>
+    <Event id="2939837509" event_id="399" type_id="15" period_id="2" min="48" sec="25" player_id="61778" team_id="417" outcome="1" x="81.3" y="34.2" timestamp="2026-05-19T14:26:25.901" timestamp_utc="2026-05-19T13:26:25.901" last_modified="2026-05-19T15:48:18" version="1779202098808">
+      <Q id="6428644089" qualifier_id="18"/>
+      <Q id="6428645563" qualifier_id="20"/>
+      <Q id="6428644087" qualifier_id="22"/>
+      <Q id="6428644091" qualifier_id="56" value="Center"/>
+      <Q id="6428645651" qualifier_id="78"/>
+      <Q id="6428645567" qualifier_id="82"/>
+      <Q id="6428645661" qualifier_id="102" value="49.9"/>
+      <Q id="6428645663" qualifier_id="103" value="19.0"/>
+      <Q id="6428645665" qualifier_id="146" value="82.9"/>
+      <Q id="6428645667" qualifier_id="147" value="35.6"/>
+      <Q id="6428645669" qualifier_id="230" value="98.1"/>
+      <Q id="6428645671" qualifier_id="231" value="48.7"/>
+      <Q id="6428645685" qualifier_id="233" value="524"/>
+      <Q id="6428645759" qualifier_id="458"/>
+    </Event>
+    <Event id="2939837507" event_id="524" type_id="10" period_id="2" min="48" sec="25" player_id="232091" team_id="244" outcome="1" x="17.6" y="60.8" timestamp="2026-05-19T14:26:26.001" timestamp_utc="2026-05-19T13:26:26.001" last_modified="2026-05-19T14:27:25" version="1779197244809">
+      <Q id="6428644079" qualifier_id="56" value="Back"/>
+      <Q id="6428644077" qualifier_id="94"/>
+      <Q id="6428645689" qualifier_id="233" value="399"/>
+    </Event>
+    <Event id="2939839359" event_id="463" type_id="61" period_id="2" min="48" sec="26" player_id="61778" team_id="417" outcome="1" x="83.2" y="35.6" timestamp="2026-05-19T14:26:26.901" timestamp_utc="2026-05-19T13:26:26.901" last_modified="2026-05-19T14:33:14" version="1779197593946">
+      <Q id="6428654895" qualifier_id="56" value="Center"/>
+    </Event>
+    <Event id="2939837513" event_id="525" type_id="12" period_id="2" min="48" sec="27" player_id="515742" team_id="244" outcome="1" x="17.9" y="52.5" timestamp="2026-05-19T14:26:28.257" timestamp_utc="2026-05-19T13:26:28.257" last_modified="2026-05-19T14:26:30" version="1779197188722">
+      <Q id="6428644133" qualifier_id="56" value="Back"/>
+      <Q id="6428644135" qualifier_id="140" value="36.6"/>
+      <Q id="6428644137" qualifier_id="141" value="37.4"/>
+      <Q id="6428644139" qualifier_id="212" value="22.2"/>
+      <Q id="6428644141" qualifier_id="213" value="5.80"/>
+    </Event>
+    <Event id="2939837515" event_id="526" type_id="49" period_id="2" min="48" sec="29" player_id="625775" team_id="244" outcome="1" x="33.4" y="40.1" timestamp="2026-05-19T14:26:30.033" timestamp_utc="2026-05-19T13:26:30.033" last_modified="2026-05-19T14:26:30" version="1779197190034"/>
+    <Event id="2939837519" event_id="527" type_id="1" period_id="2" min="48" sec="29" player_id="625775" team_id="244" outcome="1" x="33.4" y="40.3" timestamp="2026-05-19T14:26:30.217" timestamp_utc="2026-05-19T13:26:30.217" last_modified="2026-05-19T15:28:26" version="1779200906498">
+      <Q id="6428644155" qualifier_id="56" value="Center"/>
+      <Q id="6428644157" qualifier_id="140" value="53.5"/>
+      <Q id="6428644159" qualifier_id="141" value="72.3"/>
+      <Q id="6428644161" qualifier_id="212" value="30.3"/>
+      <Q id="6428644163" qualifier_id="213" value="0.80"/>
+    </Event>
+    <Event id="2939837555" event_id="528" type_id="1" period_id="2" min="48" sec="36" player_id="648131" team_id="244" outcome="1" x="66.0" y="53.0" timestamp="2026-05-19T14:26:37.096" timestamp_utc="2026-05-19T13:26:37.096" last_modified="2026-05-19T14:26:38" version="1779197197707">
+      <Q id="6428644379" qualifier_id="56" value="Center"/>
+      <Q id="6428644381" qualifier_id="140" value="76.8"/>
+      <Q id="6428644383" qualifier_id="141" value="40.1"/>
+      <Q id="6428644385" qualifier_id="212" value="14.3"/>
+      <Q id="6428644387" qualifier_id="213" value="5.62"/>
+    </Event>
+    <Event id="2939837557" event_id="529" type_id="50" period_id="2" min="48" sec="38" player_id="207884" team_id="244" outcome="1" x="77.2" y="47.7" timestamp="2026-05-19T14:26:38.649" timestamp_utc="2026-05-19T13:26:38.649" last_modified="2026-05-19T15:28:27" version="1779200907601">
+      <Q id="6428644393" qualifier_id="56" value="Center"/>
+      <Q id="6428644623" qualifier_id="233" value="400"/>
+      <Q id="6428644611" qualifier_id="286"/>
+    </Event>
+    <Event id="2939837569" event_id="400" type_id="7" period_id="2" min="48" sec="38" player_id="61812" team_id="417" outcome="1" x="22.8" y="52.3" timestamp="2026-05-19T14:26:38.650" timestamp_utc="2026-05-19T13:26:38.650" last_modified="2026-05-19T15:28:56" version="1779200936566">
+      <Q id="6428644455" qualifier_id="56" value="Back"/>
+      <Q id="6428644459" qualifier_id="178"/>
+      <Q id="6428644615" qualifier_id="233" value="529"/>
+      <Q id="6428644457" qualifier_id="285"/>
+    </Event>
+    <Event id="2939837571" event_id="401" type_id="49" period_id="2" min="48" sec="41" player_id="720682" team_id="417" outcome="1" x="28.0" y="70.9" timestamp="2026-05-19T14:26:42.039" timestamp_utc="2026-05-19T13:26:42.039" last_modified="2026-05-19T14:26:42" version="1779197202041"/>
+    <Event id="2939837623" event_id="402" type_id="1" period_id="2" min="48" sec="43" player_id="720682" team_id="417" outcome="1" x="29.3" y="72.6" timestamp="2026-05-19T14:26:43.904" timestamp_utc="2026-05-19T13:26:43.904" last_modified="2026-05-19T14:26:53" version="1779197205954">
+      <Q id="6428644795" qualifier_id="1"/>
+      <Q id="6428644783" qualifier_id="56" value="Left"/>
+      <Q id="6428644785" qualifier_id="140" value="74.0"/>
+      <Q id="6428644787" qualifier_id="141" value="82.4"/>
+      <Q id="6428644781" qualifier_id="155"/>
+      <Q id="6428644791" qualifier_id="212" value="47.4"/>
+      <Q id="6428644793" qualifier_id="213" value="0.14"/>
+    </Event>
+    <Event id="2939837605" event_id="530" type_id="83" period_id="2" min="48" sec="49" player_id="627127" team_id="244" outcome="0" x="7.3" y="20.3" timestamp="2026-05-19T14:26:50.409" timestamp_utc="2026-05-19T13:26:50.409" last_modified="2026-05-19T14:26:54" version="1779197214193">
+      <Q id="6428644813" qualifier_id="399" value="445539"/>
+    </Event>
+    <Event id="2939837625" event_id="403" type_id="1" period_id="2" min="48" sec="52" player_id="445539" team_id="417" outcome="0" x="91.0" y="72.3" timestamp="2026-05-19T14:26:53.448" timestamp_utc="2026-05-19T13:26:53.448" last_modified="2026-05-19T14:26:56" version="1779197216806">
+      <Q id="6428644803" qualifier_id="56" value="Center"/>
+      <Q id="6428644805" qualifier_id="140" value="90.0"/>
+      <Q id="6428644807" qualifier_id="141" value="46.4"/>
+      <Q id="6428644801" qualifier_id="155"/>
+      <Q id="6428644809" qualifier_id="212" value="17.6"/>
+      <Q id="6428644811" qualifier_id="213" value="4.65"/>
+    </Event>
+    <Event id="2939837629" event_id="531" type_id="12" period_id="2" min="48" sec="53" player_id="180662" team_id="244" outcome="1" x="5.9" y="42.8" timestamp="2026-05-19T14:26:54.433" timestamp_utc="2026-05-19T13:26:54.433" last_modified="2026-05-19T14:26:57" version="1779197216978">
+      <Q id="6428644843" qualifier_id="15"/>
+      <Q id="6428644833" qualifier_id="56" value="Back"/>
+      <Q id="6428644835" qualifier_id="140" value="21.8"/>
+      <Q id="6428644837" qualifier_id="141" value="23.7"/>
+      <Q id="6428644839" qualifier_id="212" value="21.2"/>
+      <Q id="6428644841" qualifier_id="213" value="5.62"/>
+    </Event>
+    <Event id="2939837661" event_id="533" type_id="1" period_id="2" min="48" sec="56" player_id="232091" team_id="244" outcome="0" x="21.8" y="23.7" timestamp="2026-05-19T14:26:57.425" timestamp_utc="2026-05-19T13:26:57.425" last_modified="2026-05-19T14:27:00" version="1779197220769">
+      <Q id="6428645033" qualifier_id="1"/>
+      <Q id="6428645023" qualifier_id="56" value="Right"/>
+      <Q id="6428645025" qualifier_id="140" value="52.7"/>
+      <Q id="6428645027" qualifier_id="141" value="0.0"/>
+      <Q id="6428645021" qualifier_id="157"/>
+      <Q id="6428645029" qualifier_id="212" value="36.5"/>
+      <Q id="6428645031" qualifier_id="213" value="5.81"/>
+    </Event>
+    <Event id="2939837667" event_id="534" type_id="5" period_id="2" min="49" sec="0" player_id="232091" team_id="244" outcome="0" x="56.7" y="-1.2" timestamp="2026-05-19T14:27:00.776" timestamp_utc="2026-05-19T13:27:00.776" last_modified="2026-05-19T15:26:31" version="1779200790101">
+      <Q id="6428645065" qualifier_id="56" value="Right"/>
+      <Q id="6428645211" qualifier_id="233" value="404"/>
+      <Q id="6428645067" qualifier_id="347"/>
+    </Event>
+    <Event id="2939837691" event_id="404" type_id="5" period_id="2" min="49" sec="0" player_id="445539" team_id="417" outcome="1" x="43.3" y="101.2" timestamp="2026-05-19T14:27:00.776" timestamp_utc="2026-05-19T13:27:00.776" last_modified="2026-05-19T15:26:31" version="1779200790094">
+      <Q id="6428645189" qualifier_id="56" value="Back"/>
+      <Q id="6428645193" qualifier_id="233" value="534"/>
+      <Q id="6428645191" qualifier_id="347"/>
+    </Event>
+    <Event id="2939837699" event_id="405" type_id="1" period_id="2" min="49" sec="7" player_id="624620" team_id="417" outcome="1" x="34.6" y="100.0" timestamp="2026-05-19T14:27:07.679" timestamp_utc="2026-05-19T13:27:07.679" last_modified="2026-05-19T14:27:09" version="1779197228493">
+      <Q id="6428645227" qualifier_id="56" value="Back"/>
+      <Q id="6428645225" qualifier_id="107"/>
+      <Q id="6428645229" qualifier_id="140" value="37.7"/>
+      <Q id="6428645231" qualifier_id="141" value="73.5"/>
+      <Q id="6428645251" qualifier_id="189"/>
+      <Q id="6428645233" qualifier_id="212" value="19.2"/>
+      <Q id="6428645235" qualifier_id="213" value="4.88"/>
+    </Event>
+    <Event id="2939837733" event_id="406" type_id="1" period_id="2" min="49" sec="9" player_id="218339" team_id="417" outcome="1" x="43.2" y="69.7" timestamp="2026-05-19T14:27:09.863" timestamp_utc="2026-05-19T13:27:09.863" last_modified="2026-05-19T14:27:16" version="1779197230186">
+      <Q id="6428645413" qualifier_id="56" value="Back"/>
+      <Q id="6428645415" qualifier_id="140" value="42.3"/>
+      <Q id="6428645417" qualifier_id="141" value="27.6"/>
+      <Q id="6428645419" qualifier_id="212" value="28.6"/>
+      <Q id="6428645421" qualifier_id="213" value="4.68"/>
+    </Event>
+    <Event id="2939837741" event_id="407" type_id="1" period_id="2" min="49" sec="16" player_id="531784" team_id="417" outcome="0" x="58.0" y="36.0" timestamp="2026-05-19T14:27:16.823" timestamp_utc="2026-05-19T13:27:16.823" last_modified="2026-05-19T14:27:18" version="1779197238304">
+      <Q id="6428645479" qualifier_id="1"/>
+      <Q id="6428645469" qualifier_id="56" value="Center"/>
+      <Q id="6428645471" qualifier_id="140" value="87.8"/>
+      <Q id="6428645473" qualifier_id="141" value="51.9"/>
+      <Q id="6428645467" qualifier_id="155"/>
+      <Q id="6428645475" qualifier_id="212" value="33.1"/>
+      <Q id="6428645477" qualifier_id="213" value="0.33"/>
+    </Event>
+    <Event id="2939837751" event_id="535" type_id="52" period_id="2" min="49" sec="19" player_id="578592" team_id="244" outcome="1" x="11.8" y="46.4" timestamp="2026-05-19T14:27:20.105" timestamp_utc="2026-05-19T13:27:20.105" last_modified="2026-05-19T14:27:20" version="1779197240107"/>
+    <Event id="2939837771" event_id="536" type_id="1" period_id="2" min="49" sec="23" player_id="578592" team_id="244" outcome="1" x="13.1" y="56.6" timestamp="2026-05-19T14:27:23.729" timestamp_utc="2026-05-19T13:27:23.729" last_modified="2026-05-19T14:27:24" version="1779197244476">
+      <Q id="6428645635" qualifier_id="56" value="Back"/>
+      <Q id="6428645633" qualifier_id="123"/>
+      <Q id="6428645637" qualifier_id="140" value="21.3"/>
+      <Q id="6428645639" qualifier_id="141" value="65.7"/>
+      <Q id="6428645641" qualifier_id="212" value="10.6"/>
+      <Q id="6428645643" qualifier_id="213" value="0.62"/>
+    </Event>
+    <Event id="2939837783" event_id="537" type_id="1" period_id="2" min="49" sec="24" player_id="180662" team_id="244" outcome="1" x="21.3" y="65.7" timestamp="2026-05-19T14:27:24.856" timestamp_utc="2026-05-19T13:27:24.856" last_modified="2026-05-19T14:27:27" version="1779197245403">
+      <Q id="6428645731" qualifier_id="56" value="Back"/>
+      <Q id="6428645733" qualifier_id="140" value="24.7"/>
+      <Q id="6428645735" qualifier_id="141" value="80.0"/>
+      <Q id="6428645737" qualifier_id="212" value="10.4"/>
+      <Q id="6428645739" qualifier_id="213" value="1.22"/>
+    </Event>
+    <Event id="2939837785" event_id="538" type_id="1" period_id="2" min="49" sec="26" player_id="575855" team_id="244" outcome="1" x="24.2" y="86.0" timestamp="2026-05-19T14:27:26.889" timestamp_utc="2026-05-19T13:27:26.889" last_modified="2026-05-19T14:27:27" version="1779197247106">
+      <Q id="6428645745" qualifier_id="56" value="Back"/>
+      <Q id="6428645747" qualifier_id="140" value="29.0"/>
+      <Q id="6428645749" qualifier_id="141" value="76.9"/>
+      <Q id="6428645751" qualifier_id="212" value="8.0"/>
+      <Q id="6428645753" qualifier_id="213" value="5.40"/>
+    </Event>
+    <Event id="2939837795" event_id="539" type_id="1" period_id="2" min="49" sec="27" player_id="207884" team_id="244" outcome="1" x="29.0" y="76.4" timestamp="2026-05-19T14:27:27.673" timestamp_utc="2026-05-19T13:27:27.673" last_modified="2026-05-19T14:27:29" version="1779197248972">
+      <Q id="6428645769" qualifier_id="56" value="Back"/>
+      <Q id="6428645771" qualifier_id="140" value="36.3"/>
+      <Q id="6428645773" qualifier_id="141" value="84.1"/>
+      <Q id="6428645775" qualifier_id="212" value="9.3"/>
+      <Q id="6428645777" qualifier_id="213" value="0.60"/>
+    </Event>
+    <Event id="2939837829" event_id="540" type_id="1" period_id="2" min="49" sec="28" player_id="575855" team_id="244" outcome="1" x="36.3" y="84.1" timestamp="2026-05-19T14:27:29.464" timestamp_utc="2026-05-19T13:27:29.464" last_modified="2026-05-19T14:27:34" version="1779197249898">
+      <Q id="6428645939" qualifier_id="56" value="Back"/>
+      <Q id="6428645941" qualifier_id="140" value="42.1"/>
+      <Q id="6428645943" qualifier_id="141" value="92.0"/>
+      <Q id="6428645945" qualifier_id="212" value="8.1"/>
+      <Q id="6428645947" qualifier_id="213" value="0.72"/>
+    </Event>
+    <Event id="2939837847" event_id="541" type_id="1" period_id="2" min="49" sec="33" player_id="648131" team_id="244" outcome="1" x="40.7" y="82.9" timestamp="2026-05-19T14:27:34.513" timestamp_utc="2026-05-19T13:27:34.513" last_modified="2026-05-19T14:27:37" version="1779197254867">
+      <Q id="6428646059" qualifier_id="56" value="Back"/>
+      <Q id="6428646061" qualifier_id="140" value="37.1"/>
+      <Q id="6428646063" qualifier_id="141" value="90.8"/>
+      <Q id="6428646065" qualifier_id="212" value="6.6"/>
+      <Q id="6428646067" qualifier_id="213" value="2.18"/>
+    </Event>
+    <Event id="2939837855" event_id="542" type_id="1" period_id="2" min="49" sec="36" player_id="207884" team_id="244" outcome="1" x="34.1" y="88.6" timestamp="2026-05-19T14:27:37.360" timestamp_utc="2026-05-19T13:27:37.360" last_modified="2026-05-19T14:27:38" version="1779197257609">
+      <Q id="6428646099" qualifier_id="56" value="Back"/>
+      <Q id="6428646101" qualifier_id="140" value="38.0"/>
+      <Q id="6428646103" qualifier_id="141" value="71.4"/>
+      <Q id="6428646105" qualifier_id="212" value="12.4"/>
+      <Q id="6428646107" qualifier_id="213" value="5.05"/>
+    </Event>
+    <Event id="2939837865" event_id="543" type_id="1" period_id="2" min="49" sec="37" player_id="515742" team_id="244" outcome="1" x="37.2" y="72.1" timestamp="2026-05-19T14:27:38.465" timestamp_utc="2026-05-19T13:27:38.465" last_modified="2026-05-19T14:27:41" version="1779197258834">
+      <Q id="6428646155" qualifier_id="56" value="Back"/>
+      <Q id="6428646157" qualifier_id="140" value="29.6"/>
+      <Q id="6428646159" qualifier_id="141" value="80.6"/>
+      <Q id="6428646161" qualifier_id="212" value="9.9"/>
+      <Q id="6428646163" qualifier_id="213" value="2.51"/>
+    </Event>
+    <Event id="2939837875" event_id="544" type_id="1" period_id="2" min="49" sec="40" player_id="207884" team_id="244" outcome="0" x="32.5" y="77.5" timestamp="2026-05-19T14:27:41.081" timestamp_utc="2026-05-19T13:27:41.081" last_modified="2026-05-19T14:27:43" version="1779197263857">
+      <Q id="6428646273" qualifier_id="1"/>
+      <Q id="6428646263" qualifier_id="56" value="Center"/>
+      <Q id="6428646265" qualifier_id="140" value="73.2"/>
+      <Q id="6428646267" qualifier_id="141" value="25.6"/>
+      <Q id="6428646261" qualifier_id="155"/>
+      <Q id="6428646269" qualifier_id="212" value="55.4"/>
+      <Q id="6428646271" qualifier_id="213" value="5.59"/>
+    </Event>
+    <Event id="2939837885" event_id="408" type_id="8" period_id="2" min="49" sec="46" player_id="164593" team_id="417" outcome="1" x="26.8" y="74.4" timestamp="2026-05-19T14:27:47.016" timestamp_utc="2026-05-19T13:27:47.016" last_modified="2026-05-19T15:45:57" version="1779201956875">
+      <Q id="6428646323" qualifier_id="15"/>
+      <Q id="6428646303" qualifier_id="56" value="Back"/>
+    </Event>
+    <Event id="2939837911" event_id="409" type_id="1" period_id="2" min="49" sec="48" player_id="624620" team_id="417" outcome="1" x="20.8" y="80.2" timestamp="2026-05-19T14:27:48.986" timestamp_utc="2026-05-19T13:27:48.986" last_modified="2026-05-19T14:27:50" version="1779197269113">
+      <Q id="6428646429" qualifier_id="56" value="Back"/>
+      <Q id="6428646431" qualifier_id="140" value="25.9"/>
+      <Q id="6428646433" qualifier_id="141" value="88.0"/>
+      <Q id="6428646427" qualifier_id="155"/>
+      <Q id="6428646435" qualifier_id="212" value="7.5"/>
+      <Q id="6428646437" qualifier_id="213" value="0.78"/>
+    </Event>
+    <Event id="2939837915" event_id="410" type_id="49" period_id="2" min="49" sec="49" player_id="164593" team_id="417" outcome="1" x="25.4" y="85.3" timestamp="2026-05-19T14:27:50.152" timestamp_utc="2026-05-19T13:27:50.152" last_modified="2026-05-19T14:27:50" version="1779197270153"/>
+    <Event id="2939837927" event_id="411" type_id="1" period_id="2" min="49" sec="49" player_id="164593" team_id="417" outcome="1" x="25.4" y="85.3" timestamp="2026-05-19T14:27:50.335" timestamp_utc="2026-05-19T13:27:50.335" last_modified="2026-05-19T14:27:54" version="1779197270462">
+      <Q id="6428646499" qualifier_id="56" value="Back"/>
+      <Q id="6428646501" qualifier_id="140" value="12.0"/>
+      <Q id="6428646503" qualifier_id="141" value="70.9"/>
+      <Q id="6428646505" qualifier_id="212" value="17.1"/>
+      <Q id="6428646507" qualifier_id="213" value="3.75"/>
+    </Event>
+    <Event id="2939837931" event_id="412" type_id="1" period_id="2" min="49" sec="53" player_id="624620" team_id="417" outcome="0" x="10.8" y="73.3" timestamp="2026-05-19T14:27:54.127" timestamp_utc="2026-05-19T13:27:54.127" last_modified="2026-05-19T14:27:54" version="1779197274723">
+      <Q id="6428646523" qualifier_id="1"/>
+      <Q id="6428646513" qualifier_id="56" value="Back"/>
+      <Q id="6428646515" qualifier_id="140" value="43.2"/>
+      <Q id="6428646517" qualifier_id="141" value="60.8"/>
+      <Q id="6428646511" qualifier_id="155"/>
+      <Q id="6428646519" qualifier_id="212" value="35.1"/>
+      <Q id="6428646521" qualifier_id="213" value="6.04"/>
+    </Event>
+    <Event id="2939837937" event_id="545" type_id="1" period_id="2" min="49" sec="55" player_id="627127" team_id="244" outcome="1" x="52.6" y="44.2" timestamp="2026-05-19T14:27:56.224" timestamp_utc="2026-05-19T13:27:56.224" last_modified="2026-05-19T14:27:57" version="1779197277131">
+      <Q id="6428646549" qualifier_id="56" value="Center"/>
+      <Q id="6428646551" qualifier_id="140" value="65.7"/>
+      <Q id="6428646553" qualifier_id="141" value="66.6"/>
+      <Q id="6428646547" qualifier_id="155"/>
+      <Q id="6428646555" qualifier_id="212" value="20.5"/>
+      <Q id="6428646557" qualifier_id="213" value="0.84"/>
+    </Event>
+    <Event id="2939837939" event_id="546" type_id="49" period_id="2" min="49" sec="57" player_id="648131" team_id="244" outcome="1" x="65.8" y="66.7" timestamp="2026-05-19T14:27:57.641" timestamp_utc="2026-05-19T13:27:57.641" last_modified="2026-05-19T14:27:58" version="1779197277642"/>
+    <Event id="2939837959" event_id="547" type_id="1" period_id="2" min="49" sec="59" player_id="648131" team_id="244" outcome="1" x="60.9" y="72.4" timestamp="2026-05-19T14:27:59.561" timestamp_utc="2026-05-19T13:27:59.561" last_modified="2026-05-19T14:28:02" version="1779197279801">
+      <Q id="6428646679" qualifier_id="56" value="Center"/>
+      <Q id="6428646681" qualifier_id="140" value="57.5"/>
+      <Q id="6428646683" qualifier_id="141" value="67.2"/>
+      <Q id="6428646685" qualifier_id="212" value="5.0"/>
+      <Q id="6428646687" qualifier_id="213" value="3.92"/>
+    </Event>
+    <Event id="2939837963" event_id="548" type_id="1" period_id="2" min="50" sec="1" player_id="515742" team_id="244" outcome="1" x="63.2" y="65.5" timestamp="2026-05-19T14:28:02.033" timestamp_utc="2026-05-19T13:28:02.033" last_modified="2026-05-19T14:28:04" version="1779197282306">
+      <Q id="6428646713" qualifier_id="56" value="Center"/>
+      <Q id="6428646715" qualifier_id="140" value="66.1"/>
+      <Q id="6428646717" qualifier_id="141" value="49.9"/>
+      <Q id="6428646719" qualifier_id="212" value="11.0"/>
+      <Q id="6428646721" qualifier_id="213" value="4.99"/>
+    </Event>
+    <Event id="2939837971" event_id="549" type_id="1" period_id="2" min="50" sec="3" player_id="207884" team_id="244" outcome="1" x="66.2" y="51.0" timestamp="2026-05-19T14:28:04.041" timestamp_utc="2026-05-19T13:28:04.041" last_modified="2026-05-19T14:28:05" version="1779197284804">
+      <Q id="6428646757" qualifier_id="56" value="Center"/>
+      <Q id="6428646759" qualifier_id="140" value="61.3"/>
+      <Q id="6428646761" qualifier_id="141" value="67.5"/>
+      <Q id="6428646763" qualifier_id="212" value="12.3"/>
+      <Q id="6428646765" qualifier_id="213" value="2.00"/>
+    </Event>
+    <Event id="2939837987" event_id="550" type_id="1" period_id="2" min="50" sec="4" player_id="515742" team_id="244" outcome="1" x="61.4" y="69.1" timestamp="2026-05-19T14:28:05.489" timestamp_utc="2026-05-19T13:28:05.489" last_modified="2026-05-19T14:28:08" version="1779197286275">
+      <Q id="6428646839" qualifier_id="56" value="Left"/>
+      <Q id="6428646841" qualifier_id="140" value="70.3"/>
+      <Q id="6428646843" qualifier_id="141" value="90.3"/>
+      <Q id="6428646845" qualifier_id="212" value="17.2"/>
+      <Q id="6428646847" qualifier_id="213" value="1.00"/>
+    </Event>
+    <Event id="2939837993" event_id="551" type_id="1" period_id="2" min="50" sec="7" player_id="575855" team_id="244" outcome="0" x="67.6" y="87.4" timestamp="2026-05-19T14:28:08.545" timestamp_utc="2026-05-19T13:28:08.545" last_modified="2026-05-19T15:28:04" version="1779200884632">
+      <Q id="6428646893" qualifier_id="1"/>
+      <Q id="6428646879" qualifier_id="2"/>
+      <Q id="6428646883" qualifier_id="56" value="Center"/>
+      <Q id="6428646885" qualifier_id="140" value="100.0"/>
+      <Q id="6428646887" qualifier_id="141" value="37.6"/>
+      <Q id="6428646881" qualifier_id="155"/>
+      <Q id="6428646889" qualifier_id="212" value="48.8"/>
+      <Q id="6428646891" qualifier_id="213" value="5.52"/>
+    </Event>
+    <Event id="2939837997" event_id="552" type_id="5" period_id="2" min="50" sec="9" player_id="648131" team_id="244" outcome="0" x="101.2" y="38.8" timestamp="2026-05-19T14:28:10.392" timestamp_utc="2026-05-19T13:28:10.392" last_modified="2026-05-19T14:28:16" version="1779197296356">
+      <Q id="6428646911" qualifier_id="56" value="Center"/>
+      <Q id="6428646931" qualifier_id="233" value="413"/>
+      <Q id="6428646913" qualifier_id="346"/>
+    </Event>
+    <Event id="2939838001" event_id="413" type_id="5" period_id="2" min="50" sec="9" player_id="624620" team_id="417" outcome="1" x="-1.2" y="61.2" timestamp="2026-05-19T14:28:10.392" timestamp_utc="2026-05-19T13:28:10.392" last_modified="2026-05-19T15:26:31" version="1779200790106">
+      <Q id="6428646921" qualifier_id="56" value="Back"/>
+      <Q id="6428646925" qualifier_id="233" value="552"/>
+      <Q id="6428646923" qualifier_id="346"/>
+    </Event>
+    <Event id="2939838095" event_id="414" type_id="1" period_id="2" min="50" sec="31" player_id="61812" team_id="417" outcome="1" x="4.8" y="48.1" timestamp="2026-05-19T14:28:31.830" timestamp_utc="2026-05-19T13:28:31.830" last_modified="2026-05-19T14:28:35" version="1779197312590">
+      <Q id="6428647531" qualifier_id="1"/>
+      <Q id="6428647521" qualifier_id="56" value="Back"/>
+      <Q id="6428647535" qualifier_id="74"/>
+      <Q id="6428647519" qualifier_id="124"/>
+      <Q id="6428647523" qualifier_id="140" value="35.2"/>
+      <Q id="6428647525" qualifier_id="141" value="64.0"/>
+      <Q id="6428647527" qualifier_id="212" value="33.7"/>
+      <Q id="6428647529" qualifier_id="213" value="0.33"/>
+    </Event>
+    <Event id="2939838107" event_id="415" type_id="1" period_id="2" min="50" sec="34" player_id="61778" team_id="417" outcome="1" x="36.6" y="69.9" timestamp="2026-05-19T14:28:35.319" timestamp_utc="2026-05-19T13:28:35.319" last_modified="2026-05-19T14:28:37" version="1779197315559">
+      <Q id="6428647603" qualifier_id="56" value="Back"/>
+      <Q id="6428647605" qualifier_id="140" value="28.4"/>
+      <Q id="6428647607" qualifier_id="141" value="70.9"/>
+      <Q id="6428647609" qualifier_id="212" value="8.6"/>
+      <Q id="6428647611" qualifier_id="213" value="3.06"/>
+    </Event>
+    <Event id="2939838119" event_id="416" type_id="1" period_id="2" min="50" sec="37" player_id="720682" team_id="417" outcome="1" x="27.8" y="71.4" timestamp="2026-05-19T14:28:37.630" timestamp_utc="2026-05-19T13:28:37.630" last_modified="2026-05-19T14:28:40" version="1779197317999">
+      <Q id="6428647669" qualifier_id="1"/>
+      <Q id="6428647659" qualifier_id="56" value="Back"/>
+      <Q id="6428647661" qualifier_id="140" value="21.5"/>
+      <Q id="6428647663" qualifier_id="141" value="25.3"/>
+      <Q id="6428647665" qualifier_id="212" value="32.0"/>
+      <Q id="6428647667" qualifier_id="213" value="4.50"/>
+    </Event>
+    <Event id="2939838159" event_id="417" type_id="1" period_id="2" min="50" sec="40" player_id="531784" team_id="417" outcome="1" x="26.5" y="31.0" timestamp="2026-05-19T14:28:40.694" timestamp_utc="2026-05-19T13:28:40.694" last_modified="2026-05-19T14:28:49" version="1779197321038">
+      <Q id="6428647879" qualifier_id="56" value="Back"/>
+      <Q id="6428647881" qualifier_id="140" value="38.5"/>
+      <Q id="6428647883" qualifier_id="141" value="11.4"/>
+      <Q id="6428647885" qualifier_id="212" value="18.3"/>
+      <Q id="6428647887" qualifier_id="213" value="5.47"/>
+    </Event>
+    <Event id="2939838147" event_id="553" type_id="43" period_id="2" min="50" sec="46" player_id="648131" team_id="244" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T14:28:46.792" timestamp_utc="2026-05-19T13:28:46.792" last_modified="2026-05-19T14:29:05" version="1779197333229">
+      <Q id="6428648301" qualifier_id="144" value="83"/>
+      <Q id="6428647945" qualifier_id="399" value="157851"/>
+    </Event>
+    <Event id="2939838161" event_id="418" type_id="50" period_id="2" min="50" sec="47" player_id="157851" team_id="417" outcome="1" x="59.2" y="5.2" timestamp="2026-05-19T14:28:48.520" timestamp_utc="2026-05-19T13:28:48.520" last_modified="2026-05-19T14:28:52" version="1779197331704">
+      <Q id="6428647891" qualifier_id="56" value="Right"/>
+      <Q id="6428647917" qualifier_id="233" value="554"/>
+      <Q id="6428647893" qualifier_id="286"/>
+    </Event>
+    <Event id="2939838163" event_id="554" type_id="7" period_id="2" min="50" sec="47" player_id="648131" team_id="244" outcome="1" x="40.7" y="94.7" timestamp="2026-05-19T14:28:48.521" timestamp_utc="2026-05-19T13:28:48.521" last_modified="2026-05-19T14:28:51" version="1779197329664">
+      <Q id="6428647897" qualifier_id="56" value="Back"/>
+      <Q id="6428647895" qualifier_id="167"/>
+      <Q id="6428647901" qualifier_id="178"/>
+      <Q id="6428647913" qualifier_id="233" value="418"/>
+      <Q id="6428647899" qualifier_id="285"/>
+    </Event>
+    <Event id="2939838165" event_id="555" type_id="5" period_id="2" min="50" sec="48" player_id="648131" team_id="244" outcome="0" x="41.0" y="100.9" timestamp="2026-05-19T14:28:49.433" timestamp_utc="2026-05-19T13:28:49.433" last_modified="2026-05-19T15:26:32" version="1779200790122">
+      <Q id="6428647905" qualifier_id="56" value="Back"/>
+      <Q id="6428647971" qualifier_id="233" value="419"/>
+      <Q id="6428647907" qualifier_id="347"/>
+    </Event>
+    <Event id="2939838167" event_id="419" type_id="5" period_id="2" min="50" sec="48" player_id="157851" team_id="417" outcome="1" x="59.0" y="-0.9" timestamp="2026-05-19T14:28:49.433" timestamp_utc="2026-05-19T13:28:49.433" last_modified="2026-05-19T15:26:32" version="1779200790114">
+      <Q id="6428647941" qualifier_id="56" value="Right"/>
+      <Q id="6428647955" qualifier_id="233" value="555"/>
+      <Q id="6428647943" qualifier_id="347"/>
+    </Event>
+    <Event id="2939838185" event_id="420" type_id="1" period_id="2" min="50" sec="51" player_id="157851" team_id="417" outcome="1" x="52.1" y="0.0" timestamp="2026-05-19T14:28:51.870" timestamp_utc="2026-05-19T13:28:51.870" last_modified="2026-05-19T14:28:55" version="1779197332521">
+      <Q id="6428648059" qualifier_id="56" value="Back"/>
+      <Q id="6428648057" qualifier_id="107"/>
+      <Q id="6428648061" qualifier_id="140" value="39.0"/>
+      <Q id="6428648063" qualifier_id="141" value="16.8"/>
+      <Q id="6428648065" qualifier_id="212" value="18.8"/>
+      <Q id="6428648067" qualifier_id="213" value="2.39"/>
+    </Event>
+    <Event id="2939838205" event_id="421" type_id="1" period_id="2" min="50" sec="54" player_id="531784" team_id="417" outcome="1" x="44.5" y="12.9" timestamp="2026-05-19T14:28:55.183" timestamp_utc="2026-05-19T13:28:55.183" last_modified="2026-05-19T14:29:00" version="1779197335553">
+      <Q id="6428648175" qualifier_id="56" value="Back"/>
+      <Q id="6428648177" qualifier_id="140" value="34.5"/>
+      <Q id="6428648179" qualifier_id="141" value="39.5"/>
+      <Q id="6428648181" qualifier_id="212" value="20.9"/>
+      <Q id="6428648183" qualifier_id="213" value="2.10"/>
+    </Event>
+    <Event id="2939838213" event_id="422" type_id="1" period_id="2" min="50" sec="59" player_id="720682" team_id="417" outcome="1" x="43.4" y="40.0" timestamp="2026-05-19T14:28:59.910" timestamp_utc="2026-05-19T13:28:59.910" last_modified="2026-05-19T14:29:02" version="1779197340054">
+      <Q id="6428648229" qualifier_id="56" value="Back"/>
+      <Q id="6428648231" qualifier_id="140" value="40.0"/>
+      <Q id="6428648233" qualifier_id="141" value="23.0"/>
+      <Q id="6428648235" qualifier_id="212" value="12.1"/>
+      <Q id="6428648237" qualifier_id="213" value="4.41"/>
+    </Event>
+    <Event id="2939838243" event_id="423" type_id="1" period_id="2" min="51" sec="1" player_id="531784" team_id="417" outcome="1" x="40.5" y="27.1" timestamp="2026-05-19T14:29:01.910" timestamp_utc="2026-05-19T13:29:01.910" last_modified="2026-05-19T14:29:09" version="1779197342474">
+      <Q id="6428648389" qualifier_id="56" value="Back"/>
+      <Q id="6428648391" qualifier_id="140" value="39.7"/>
+      <Q id="6428648393" qualifier_id="141" value="66.4"/>
+      <Q id="6428648395" qualifier_id="212" value="26.7"/>
+      <Q id="6428648397" qualifier_id="213" value="1.60"/>
+    </Event>
+    <Event id="2939838247" event_id="424" type_id="61" period_id="2" min="51" sec="8" player_id="624620" team_id="417" outcome="1" x="59.2" y="72.7" timestamp="2026-05-19T14:29:09.342" timestamp_utc="2026-05-19T13:29:09.342" last_modified="2026-05-19T15:28:08" version="1779200888631">
+      <Q id="6428648403" qualifier_id="56" value="Center"/>
+    </Event>
+    <Event id="2939838285" event_id="425" type_id="1" period_id="2" min="51" sec="9" player_id="720682" team_id="417" outcome="1" x="60.9" y="68.8" timestamp="2026-05-19T14:29:10.309" timestamp_utc="2026-05-19T13:29:10.309" last_modified="2026-05-19T14:29:20" version="1779197350662">
+      <Q id="6428648665" qualifier_id="56" value="Left"/>
+      <Q id="6428648667" qualifier_id="140" value="68.3"/>
+      <Q id="6428648669" qualifier_id="141" value="79.1"/>
+      <Q id="6428648671" qualifier_id="212" value="10.5"/>
+      <Q id="6428648673" qualifier_id="213" value="0.73"/>
+    </Event>
+    <Event id="2939838263" event_id="556" type_id="83" period_id="2" min="51" sec="10" player_id="625775" team_id="244" outcome="1" x="37.8" y="20.1" timestamp="2026-05-19T14:29:11.017" timestamp_utc="2026-05-19T13:29:11.017" last_modified="2026-05-19T15:27:08" version="1779200828787">
+      <Q id="6428662659" qualifier_id="399" value="61778"/>
+    </Event>
+    <Event id="2939838265" event_id="557" type_id="45" period_id="2" min="51" sec="11" player_id="240166" team_id="244" outcome="0" x="22.2" y="24.8" timestamp="2026-05-19T14:29:12.481" timestamp_utc="2026-05-19T13:29:12.481" last_modified="2026-05-19T14:39:03" version="1779197943649">
+      <Q id="6428664251" qualifier_id="56" value="Back"/>
+      <Q id="6428664757" qualifier_id="233" value="510"/>
+      <Q id="6428664253" qualifier_id="285"/>
+    </Event>
+    <Event id="2939840981" event_id="510" type_id="3" period_id="2" min="51" sec="11" player_id="61778" team_id="417" outcome="1" x="77.8" y="75.2" timestamp="2026-05-19T14:29:12.481" timestamp_utc="2026-05-19T13:29:12.481" last_modified="2026-05-19T14:39:04" version="1779197943656">
+      <Q id="6428664743" qualifier_id="56" value="Center"/>
+      <Q id="6428664749" qualifier_id="233" value="557"/>
+      <Q id="6428664745" qualifier_id="286"/>
+      <Q id="6428664747" qualifier_id="465"/>
+    </Event>
+    <Event id="2939838295" event_id="426" type_id="1" period_id="2" min="51" sec="21" player_id="61778" team_id="417" outcome="1" x="63.6" y="78.8" timestamp="2026-05-19T14:29:21.630" timestamp_utc="2026-05-19T13:29:21.630" last_modified="2026-05-19T14:29:22" version="1779197361834">
+      <Q id="6428648739" qualifier_id="56" value="Center"/>
+      <Q id="6428648741" qualifier_id="140" value="55.7"/>
+      <Q id="6428648743" qualifier_id="141" value="54.3"/>
+      <Q id="6428648745" qualifier_id="212" value="18.6"/>
+      <Q id="6428648747" qualifier_id="213" value="4.25"/>
+    </Event>
+    <Event id="2939838301" event_id="427" type_id="1" period_id="2" min="51" sec="21" player_id="531784" team_id="417" outcome="1" x="52.3" y="50.4" timestamp="2026-05-19T14:29:22.390" timestamp_utc="2026-05-19T13:29:22.390" last_modified="2026-05-19T14:29:23" version="1779197362586">
+      <Q id="6428648775" qualifier_id="56" value="Center"/>
+      <Q id="6428648777" qualifier_id="140" value="51.5"/>
+      <Q id="6428648779" qualifier_id="141" value="72.4"/>
+      <Q id="6428648781" qualifier_id="212" value="15.0"/>
+      <Q id="6428648783" qualifier_id="213" value="1.63"/>
+    </Event>
+    <Event id="2939838319" event_id="428" type_id="1" period_id="2" min="51" sec="23" player_id="61812" team_id="417" outcome="1" x="53.1" y="73.0" timestamp="2026-05-19T14:29:23.615" timestamp_utc="2026-05-19T13:29:23.615" last_modified="2026-05-19T14:29:25" version="1779197363926">
+      <Q id="6428648865" qualifier_id="56" value="Left"/>
+      <Q id="6428648867" qualifier_id="140" value="60.3"/>
+      <Q id="6428648869" qualifier_id="141" value="86.5"/>
+      <Q id="6428648871" qualifier_id="212" value="11.9"/>
+      <Q id="6428648873" qualifier_id="213" value="0.88"/>
+    </Event>
+    <Event id="2939838331" event_id="429" type_id="1" period_id="2" min="51" sec="24" player_id="61778" team_id="417" outcome="1" x="61.9" y="88.1" timestamp="2026-05-19T14:29:25.374" timestamp_utc="2026-05-19T13:29:25.374" last_modified="2026-05-19T14:29:27" version="1779197365526">
+      <Q id="6428648939" qualifier_id="56" value="Center"/>
+      <Q id="6428648941" qualifier_id="140" value="59.9"/>
+      <Q id="6428648943" qualifier_id="141" value="75.3"/>
+      <Q id="6428648945" qualifier_id="212" value="9.0"/>
+      <Q id="6428648947" qualifier_id="213" value="4.48"/>
+    </Event>
+    <Event id="2939838353" event_id="430" type_id="1" period_id="2" min="51" sec="26" player_id="218339" team_id="417" outcome="1" x="59.9" y="75.3" timestamp="2026-05-19T14:29:27.302" timestamp_utc="2026-05-19T13:29:27.302" last_modified="2026-05-19T14:29:29" version="1779197367775">
+      <Q id="6428649057" qualifier_id="56" value="Left"/>
+      <Q id="6428649059" qualifier_id="140" value="70.1"/>
+      <Q id="6428649061" qualifier_id="141" value="84.4"/>
+      <Q id="6428649063" qualifier_id="212" value="12.4"/>
+      <Q id="6428649065" qualifier_id="213" value="0.52"/>
+    </Event>
+    <Event id="2939838367" event_id="431" type_id="1" period_id="2" min="51" sec="29" player_id="624620" team_id="417" outcome="1" x="68.9" y="89.0" timestamp="2026-05-19T14:29:29.837" timestamp_utc="2026-05-19T13:29:29.837" last_modified="2026-05-19T14:29:33" version="1779197370186">
+      <Q id="6428649149" qualifier_id="56" value="Center"/>
+      <Q id="6428649151" qualifier_id="140" value="79.1"/>
+      <Q id="6428649153" qualifier_id="141" value="77.9"/>
+      <Q id="6428649155" qualifier_id="212" value="13.1"/>
+      <Q id="6428649157" qualifier_id="213" value="5.67"/>
+    </Event>
+    <Event id="2939838371" event_id="432" type_id="1" period_id="2" min="51" sec="33" player_id="164593" team_id="417" outcome="0" x="90.5" y="83.9" timestamp="2026-05-19T14:29:33.701" timestamp_utc="2026-05-19T13:29:33.701" last_modified="2026-05-19T14:29:34" version="1779197374062">
+      <Q id="6428649179" qualifier_id="2"/>
+      <Q id="6428649183" qualifier_id="56" value="Center"/>
+      <Q id="6428649185" qualifier_id="140" value="88.0"/>
+      <Q id="6428649187" qualifier_id="141" value="58.7"/>
+      <Q id="6428649181" qualifier_id="155"/>
+      <Q id="6428649189" qualifier_id="212" value="17.3"/>
+      <Q id="6428649191" qualifier_id="213" value="4.56"/>
+    </Event>
+    <Event id="2939838381" event_id="558" type_id="12" period_id="2" min="51" sec="34" player_id="575855" team_id="244" outcome="1" x="9.2" y="50.1" timestamp="2026-05-19T14:29:34.761" timestamp_utc="2026-05-19T13:29:34.761" last_modified="2026-05-19T14:29:45" version="1779197385082">
+      <Q id="6428649277" qualifier_id="15"/>
+      <Q id="6428649251" qualifier_id="56" value="Back"/>
+      <Q id="6428649253" qualifier_id="140" value="30.4"/>
+      <Q id="6428649255" qualifier_id="141" value="48.7"/>
+      <Q id="6428649257" qualifier_id="212" value="22.3"/>
+      <Q id="6428649259" qualifier_id="213" value="6.24"/>
+    </Event>
+    <Event id="2939838411" event_id="433" type_id="1" period_id="2" min="51" sec="36" player_id="531784" team_id="417" outcome="1" x="75.2" y="40.0" timestamp="2026-05-19T14:29:37.453" timestamp_utc="2026-05-19T13:29:37.453" last_modified="2026-05-19T14:29:40" version="1779197377657">
+      <Q id="6428649413" qualifier_id="56" value="Center"/>
+      <Q id="6428649415" qualifier_id="140" value="77.2"/>
+      <Q id="6428649417" qualifier_id="141" value="21.9"/>
+      <Q id="6428649419" qualifier_id="212" value="12.5"/>
+      <Q id="6428649421" qualifier_id="213" value="4.88"/>
+    </Event>
+    <Event id="2939838427" event_id="434" type_id="1" period_id="2" min="51" sec="39" player_id="157851" team_id="417" outcome="1" x="79.7" y="18.6" timestamp="2026-05-19T14:29:40.385" timestamp_utc="2026-05-19T13:29:40.385" last_modified="2026-05-19T14:29:44" version="1779197380585">
+      <Q id="6428649507" qualifier_id="56" value="Center"/>
+      <Q id="6428649509" qualifier_id="140" value="88.3"/>
+      <Q id="6428649511" qualifier_id="141" value="21.2"/>
+      <Q id="6428649513" qualifier_id="212" value="9.2"/>
+      <Q id="6428649515" qualifier_id="213" value="0.19"/>
+    </Event>
+    <Event id="2939838433" event_id="435" type_id="1" period_id="2" min="51" sec="44" player_id="218339" team_id="417" outcome="1" x="81.8" y="16.8" timestamp="2026-05-19T14:29:44.589" timestamp_utc="2026-05-19T13:29:44.589" last_modified="2026-05-19T14:29:47" version="1779197384773">
+      <Q id="6428649553" qualifier_id="56" value="Right"/>
+      <Q id="6428649555" qualifier_id="140" value="71.5"/>
+      <Q id="6428649557" qualifier_id="141" value="15.6"/>
+      <Q id="6428649559" qualifier_id="212" value="10.8"/>
+      <Q id="6428649561" qualifier_id="213" value="3.22"/>
+    </Event>
+    <Event id="2939838445" event_id="436" type_id="1" period_id="2" min="51" sec="46" player_id="531784" team_id="417" outcome="0" x="70.9" y="13.8" timestamp="2026-05-19T14:29:47.541" timestamp_utc="2026-05-19T13:29:47.541" last_modified="2026-05-19T14:29:49" version="1779197388870">
+      <Q id="6428649601" qualifier_id="56" value="Center"/>
+      <Q id="6428649603" qualifier_id="140" value="89.4"/>
+      <Q id="6428649605" qualifier_id="141" value="35.2"/>
+      <Q id="6428649607" qualifier_id="212" value="24.3"/>
+      <Q id="6428649609" qualifier_id="213" value="0.64"/>
+    </Event>
+    <Event id="2939838453" event_id="559" type_id="52" period_id="2" min="51" sec="49" player_id="578592" team_id="244" outcome="1" x="5.5" y="58.8" timestamp="2026-05-19T14:29:50.032" timestamp_utc="2026-05-19T13:29:50.032" last_modified="2026-05-19T14:29:50" version="1779197390038"/>
+    <Event id="2939838501" event_id="560" type_id="1" period_id="2" min="52" sec="0" player_id="578592" team_id="244" outcome="0" x="12.7" y="49.3" timestamp="2026-05-19T14:30:00.617" timestamp_utc="2026-05-19T13:30:00.617" last_modified="2026-05-19T14:30:03" version="1779197402897">
+      <Q id="6428649961" qualifier_id="1"/>
+      <Q id="6428649951" qualifier_id="56" value="Center"/>
+      <Q id="6428649953" qualifier_id="140" value="70.1"/>
+      <Q id="6428649955" qualifier_id="141" value="35.4"/>
+      <Q id="6428649949" qualifier_id="199"/>
+      <Q id="6428649957" qualifier_id="212" value="61.0"/>
+      <Q id="6428649959" qualifier_id="213" value="6.13"/>
+    </Event>
+    <Event id="2939838507" event_id="437" type_id="49" period_id="2" min="52" sec="3" player_id="624620" team_id="417" outcome="1" x="45.6" y="69.4" timestamp="2026-05-19T14:30:04.277" timestamp_utc="2026-05-19T13:30:04.277" last_modified="2026-05-19T14:30:04" version="1779197404279"/>
+    <Event id="2939838529" event_id="438" type_id="1" period_id="2" min="52" sec="3" player_id="624620" team_id="417" outcome="1" x="41.8" y="68.4" timestamp="2026-05-19T14:30:04.477" timestamp_utc="2026-05-19T13:30:04.477" last_modified="2026-05-19T14:30:09" version="1779197404662">
+      <Q id="6428650111" qualifier_id="56" value="Center"/>
+      <Q id="6428650113" qualifier_id="140" value="61.2"/>
+      <Q id="6428650115" qualifier_id="141" value="73.2"/>
+      <Q id="6428650117" qualifier_id="212" value="20.6"/>
+      <Q id="6428650119" qualifier_id="213" value="0.16"/>
+    </Event>
+    <Event id="2939838535" event_id="439" type_id="1" period_id="2" min="52" sec="8" player_id="61778" team_id="417" outcome="0" x="72.3" y="66.9" timestamp="2026-05-19T14:30:09.414" timestamp_utc="2026-05-19T13:30:09.414" last_modified="2026-05-19T14:30:10" version="1779197410512">
+      <Q id="6428650131" qualifier_id="56" value="Center"/>
+      <Q id="6428650133" qualifier_id="140" value="72.3"/>
+      <Q id="6428650135" qualifier_id="141" value="63.1"/>
+      <Q id="6428650137" qualifier_id="212" value="2.6"/>
+      <Q id="6428650139" qualifier_id="213" value="4.71"/>
+      <Q id="6428650195" qualifier_id="233" value="561"/>
+      <Q id="6428650189" qualifier_id="236"/>
+      <Q id="6428650193" qualifier_id="286"/>
+    </Event>
+    <Event id="2939838543" event_id="561" type_id="74" period_id="2" min="52" sec="8" player_id="515742" team_id="244" outcome="1" x="27.7" y="36.9" timestamp="2026-05-19T14:30:09.415" timestamp_utc="2026-05-19T13:30:09.415" last_modified="2026-05-19T15:45:52" version="1779201952671">
+      <Q id="6428650179" qualifier_id="56" value="Back"/>
+      <Q id="6428650197" qualifier_id="233" value="439"/>
+      <Q id="6428650181" qualifier_id="285"/>
+    </Event>
+    <Event id="2939838557" event_id="562" type_id="12" period_id="2" min="52" sec="12" player_id="240166" team_id="244" outcome="1" x="18.0" y="12.2" timestamp="2026-05-19T14:30:12.744" timestamp_utc="2026-05-19T13:30:12.744" last_modified="2026-05-19T14:30:13" version="1779197413301">
+      <Q id="6428650289" qualifier_id="56" value="Back"/>
+      <Q id="6428650291" qualifier_id="140" value="24.8"/>
+      <Q id="6428650293" qualifier_id="141" value="0.0"/>
+      <Q id="6428650325" qualifier_id="167"/>
+      <Q id="6428650295" qualifier_id="212" value="11.5"/>
+      <Q id="6428650297" qualifier_id="213" value="5.38"/>
+    </Event>
+    <Event id="2939838561" event_id="563" type_id="5" period_id="2" min="52" sec="12" player_id="240166" team_id="244" outcome="0" x="24.3" y="-1.0" timestamp="2026-05-19T14:30:13.259" timestamp_utc="2026-05-19T13:30:13.259" last_modified="2026-05-19T14:39:19" version="1779197959683">
+      <Q id="6428650303" qualifier_id="56" value="Back"/>
+      <Q id="6428650349" qualifier_id="233" value="440"/>
+      <Q id="6428650305" qualifier_id="347"/>
+    </Event>
+    <Event id="2939838567" event_id="440" type_id="5" period_id="2" min="52" sec="12" player_id="61778" team_id="417" outcome="1" x="75.7" y="101.0" timestamp="2026-05-19T14:30:13.259" timestamp_utc="2026-05-19T13:30:13.259" last_modified="2026-05-19T15:26:32" version="1779200790128">
+      <Q id="6428650333" qualifier_id="56" value="Left"/>
+      <Q id="6428650339" qualifier_id="233" value="563"/>
+      <Q id="6428650335" qualifier_id="347"/>
+    </Event>
+    <Event id="2939838577" event_id="441" type_id="1" period_id="2" min="52" sec="13" player_id="61778" team_id="417" outcome="1" x="79.7" y="100.0" timestamp="2026-05-19T14:30:14.173" timestamp_utc="2026-05-19T13:30:14.173" last_modified="2026-05-19T14:30:15" version="1779197414353">
+      <Q id="6428650381" qualifier_id="56" value="Left"/>
+      <Q id="6428650379" qualifier_id="107"/>
+      <Q id="6428650383" qualifier_id="140" value="86.7"/>
+      <Q id="6428650385" qualifier_id="141" value="88.4"/>
+      <Q id="6428650387" qualifier_id="212" value="11.4"/>
+      <Q id="6428650389" qualifier_id="213" value="5.41"/>
+    </Event>
+    <Event id="2939838591" event_id="442" type_id="1" period_id="2" min="52" sec="15" player_id="164593" team_id="417" outcome="1" x="86.4" y="89.3" timestamp="2026-05-19T14:30:15.784" timestamp_utc="2026-05-19T13:30:15.784" last_modified="2026-05-19T14:30:20" version="1779197415888">
+      <Q id="6428650479" qualifier_id="56" value="Left"/>
+      <Q id="6428650481" qualifier_id="140" value="86.2"/>
+      <Q id="6428650483" qualifier_id="141" value="95.1"/>
+      <Q id="6428650485" qualifier_id="212" value="3.9"/>
+      <Q id="6428650487" qualifier_id="213" value="1.62"/>
+    </Event>
+    <Event id="2939838621" event_id="443" type_id="1" period_id="2" min="52" sec="19" player_id="61778" team_id="417" outcome="0" x="94.4" y="90.8" timestamp="2026-05-19T14:30:20.197" timestamp_utc="2026-05-19T13:30:20.197" last_modified="2026-05-19T14:41:15" version="1779198075114">
+      <Q id="6428650631" qualifier_id="2"/>
+      <Q id="6428650635" qualifier_id="56" value="Center"/>
+      <Q id="6428650637" qualifier_id="140" value="89.0"/>
+      <Q id="6428650639" qualifier_id="141" value="46.6"/>
+      <Q id="6428650633" qualifier_id="155"/>
+      <Q id="6428650641" qualifier_id="212" value="30.6"/>
+      <Q id="6428650643" qualifier_id="213" value="4.53"/>
+    </Event>
+    <Event id="2939838599" event_id="564" type_id="61" period_id="2" min="52" sec="23" player_id="232091" team_id="244" outcome="1" x="11.9" y="50.0" timestamp="2026-05-19T14:30:23.921" timestamp_utc="2026-05-19T13:30:23.921" last_modified="2026-05-19T14:30:41" version="1779197441303">
+      <Q id="6428650551" qualifier_id="56" value="Back"/>
+    </Event>
+    <Event id="2939838623" event_id="444" type_id="13" period_id="2" min="52" sec="26" player_id="157851" team_id="417" outcome="1" x="93.1" y="50.3" timestamp="2026-05-19T14:30:26.893" timestamp_utc="2026-05-19T13:30:26.893" last_modified="2026-05-19T15:49:21" version="1779202161751">
+      <Q id="6428650655" qualifier_id="17"/>
+      <Q id="6428650961" qualifier_id="20"/>
+      <Q id="6428650657" qualifier_id="56" value="Center"/>
+      <Q id="6428738761" qualifier_id="84"/>
+      <Q id="6428650965" qualifier_id="102" value="40.8"/>
+      <Q id="6428650967" qualifier_id="103" value="6.9"/>
+      <Q id="6428668467" qualifier_id="160"/>
+      <Q id="6428650973" qualifier_id="230" value="95.8"/>
+      <Q id="6428650975" qualifier_id="231" value="50.2"/>
+      <Q id="6428650971" qualifier_id="458"/>
+    </Event>
+    <Event id="2939838611" event_id="565" type_id="5" period_id="2" min="52" sec="28" player_id="232091" team_id="244" outcome="1" x="-1.0" y="60.4" timestamp="2026-05-19T14:30:28.845" timestamp_utc="2026-05-19T13:30:28.845" last_modified="2026-05-19T15:26:32" version="1779200790135">
+      <Q id="6428650601" qualifier_id="56" value="Back"/>
+      <Q id="6428650959" qualifier_id="233" value="445"/>
+      <Q id="6428650603" qualifier_id="346"/>
+    </Event>
+    <Event id="2939838679" event_id="445" type_id="5" period_id="2" min="52" sec="28" player_id="157851" team_id="417" outcome="0" x="101.0" y="39.6" timestamp="2026-05-19T14:30:28.845" timestamp_utc="2026-05-19T13:30:28.845" last_modified="2026-05-19T14:30:44" version="1779197442479">
+      <Q id="6428650941" qualifier_id="56" value="Center"/>
+      <Q id="6428650977" qualifier_id="233" value="565"/>
+      <Q id="6428650943" qualifier_id="346"/>
+    </Event>
+    <Event id="2939838763" event_id="566" type_id="1" period_id="2" min="52" sec="48" player_id="627127" team_id="244" outcome="1" x="4.9" y="42.1" timestamp="2026-05-19T14:30:49.136" timestamp_utc="2026-05-19T13:30:49.136" last_modified="2026-05-19T14:30:55" version="1779197449609">
+      <Q id="6428651401" qualifier_id="56" value="Back"/>
+      <Q id="6428651399" qualifier_id="124"/>
+      <Q id="6428651403" qualifier_id="140" value="5.5"/>
+      <Q id="6428651405" qualifier_id="141" value="52.7"/>
+      <Q id="6428651407" qualifier_id="212" value="7.2"/>
+      <Q id="6428651409" qualifier_id="213" value="1.48"/>
+      <Q id="6428651413" qualifier_id="237"/>
+    </Event>
+    <Event id="2939838769" event_id="567" type_id="1" period_id="2" min="52" sec="54" player_id="578592" team_id="244" outcome="0" x="19.8" y="60.2" timestamp="2026-05-19T14:30:55.129" timestamp_utc="2026-05-19T13:30:55.129" last_modified="2026-05-19T14:30:57" version="1779197456905">
+      <Q id="6428651455" qualifier_id="1"/>
+      <Q id="6428651445" qualifier_id="56" value="Center"/>
+      <Q id="6428651447" qualifier_id="140" value="64.1"/>
+      <Q id="6428651449" qualifier_id="141" value="53.0"/>
+      <Q id="6428651443" qualifier_id="157"/>
+      <Q id="6428651451" qualifier_id="212" value="46.8"/>
+      <Q id="6428651453" qualifier_id="213" value="6.18"/>
+    </Event>
+    <Event id="2939838771" event_id="446" type_id="44" period_id="2" min="52" sec="55" player_id="61812" team_id="417" outcome="1" x="35.9" y="47.0" timestamp="2026-05-19T14:30:56.412" timestamp_utc="2026-05-19T13:30:56.412" last_modified="2026-05-19T15:45:41" version="1779201940980">
+      <Q id="6428651459" qualifier_id="56" value="Back"/>
+      <Q id="6428651527" qualifier_id="233" value="568"/>
+      <Q id="6428651461" qualifier_id="285"/>
+    </Event>
+    <Event id="2939838775" event_id="568" type_id="44" period_id="2" min="52" sec="55" player_id="232091" team_id="244" outcome="0" x="64.1" y="53.0" timestamp="2026-05-19T14:30:56.413" timestamp_utc="2026-05-19T13:30:56.413" last_modified="2026-05-19T15:45:41" version="1779201941260">
+      <Q id="6428651465" qualifier_id="56" value="Center"/>
+      <Q id="6428651573" qualifier_id="233" value="446"/>
+      <Q id="6428651467" qualifier_id="286"/>
+    </Event>
+    <Event id="2939838779" event_id="447" type_id="12" period_id="2" min="52" sec="56" player_id="61812" team_id="417" outcome="1" x="35.9" y="47.0" timestamp="2026-05-19T14:30:56.718" timestamp_utc="2026-05-19T13:30:56.718" last_modified="2026-05-19T15:45:41" version="1779201941527">
+      <Q id="6428652791" qualifier_id="15"/>
+      <Q id="6428651483" qualifier_id="56" value="Back"/>
+      <Q id="6428651485" qualifier_id="140" value="39.0"/>
+      <Q id="6428651487" qualifier_id="141" value="57.2"/>
+      <Q id="6428651489" qualifier_id="212" value="7.7"/>
+      <Q id="6428651491" qualifier_id="213" value="1.13"/>
+    </Event>
+    <Event id="2939838783" event_id="569" type_id="44" period_id="2" min="52" sec="57" player_id="207884" team_id="244" outcome="1" x="61.0" y="42.8" timestamp="2026-05-19T14:30:58.313" timestamp_utc="2026-05-19T13:30:58.313" last_modified="2026-05-19T15:45:41" version="1779201941792">
+      <Q id="6428651593" qualifier_id="56" value="Center"/>
+      <Q id="6428651641" qualifier_id="233" value="448"/>
+      <Q id="6428651595" qualifier_id="286"/>
+    </Event>
+    <Event id="2939838791" event_id="448" type_id="44" period_id="2" min="52" sec="57" player_id="218339" team_id="417" outcome="0" x="39.0" y="57.2" timestamp="2026-05-19T14:30:58.314" timestamp_utc="2026-05-19T13:30:58.314" last_modified="2026-05-19T15:45:42" version="1779201942059">
+      <Q id="6428651635" qualifier_id="56" value="Back"/>
+      <Q id="6428651649" qualifier_id="233" value="569"/>
+      <Q id="6428651637" qualifier_id="285"/>
+    </Event>
+    <Event id="2939838807" event_id="570" type_id="1" period_id="2" min="52" sec="58" player_id="207884" team_id="244" outcome="1" x="61.0" y="42.8" timestamp="2026-05-19T14:30:58.617" timestamp_utc="2026-05-19T13:30:58.617" last_modified="2026-05-19T15:45:42" version="1779201942343">
+      <Q id="6428651761" qualifier_id="3"/>
+      <Q id="6428651763" qualifier_id="56" value="Center"/>
+      <Q id="6428651765" qualifier_id="140" value="61.0"/>
+      <Q id="6428651767" qualifier_id="141" value="55.7"/>
+      <Q id="6428651769" qualifier_id="212" value="8.8"/>
+      <Q id="6428651771" qualifier_id="213" value="1.57"/>
+    </Event>
+    <Event id="2939838813" event_id="571" type_id="4" period_id="2" min="53" sec="1" player_id="232091" team_id="244" outcome="1" x="61.0" y="59.4" timestamp="2026-05-19T14:31:02.120" timestamp_utc="2026-05-19T13:31:02.120" last_modified="2026-05-19T14:31:11" version="1779197470567">
+      <Q id="6428651779" qualifier_id="13"/>
+      <Q id="6428651783" qualifier_id="56" value="Center"/>
+      <Q id="6428651785" qualifier_id="152"/>
+      <Q id="6428651957" qualifier_id="233" value="449"/>
+      <Q id="6428651787" qualifier_id="286"/>
+      <Q id="6428651781" qualifier_id="295"/>
+    </Event>
+    <Event id="2939838817" event_id="449" type_id="4" period_id="2" min="53" sec="1" player_id="61812" team_id="417" outcome="0" x="39.0" y="40.6" timestamp="2026-05-19T14:31:02.121" timestamp_utc="2026-05-19T13:31:02.121" last_modified="2026-05-19T14:37:35" version="1779197855309">
+      <Q id="6428651945" qualifier_id="13"/>
+      <Q id="6428651949" qualifier_id="56" value="Back"/>
+      <Q id="6428651951" qualifier_id="152"/>
+      <Q id="6428651963" qualifier_id="233" value="571"/>
+      <Q id="6428651953" qualifier_id="285"/>
+      <Q id="6428651947" qualifier_id="295"/>
+    </Event>
+    <Event id="2939839099" event_id="572" type_id="1" period_id="2" min="53" sec="44" player_id="207884" team_id="244" outcome="1" x="70.6" y="67.0" timestamp="2026-05-19T14:31:44.730" timestamp_utc="2026-05-19T13:31:44.730" last_modified="2026-05-19T15:26:17" version="1779200777562">
+      <Q id="6428653241" qualifier_id="5"/>
+      <Q id="6428653247" qualifier_id="56" value="Center"/>
+      <Q id="6428653249" qualifier_id="140" value="90.4"/>
+      <Q id="6428653251" qualifier_id="141" value="35.2"/>
+      <Q id="6428653245" qualifier_id="152"/>
+      <Q id="6428653243" qualifier_id="155"/>
+      <Q id="6428653253" qualifier_id="212" value="30.0"/>
+      <Q id="6428653255" qualifier_id="213" value="5.48"/>
+    </Event>
+    <Event id="2939839101" event_id="573" type_id="1" period_id="2" min="53" sec="47" player_id="515742" team_id="244" outcome="0" x="90.4" y="35.2" timestamp="2026-05-19T14:31:48.137" timestamp_utc="2026-05-19T13:31:48.137" last_modified="2026-05-19T15:26:18" version="1779200778769">
+      <Q id="6428653261" qualifier_id="3"/>
+      <Q id="6428653263" qualifier_id="56" value="Center"/>
+      <Q id="6428653265" qualifier_id="140" value="94.0"/>
+      <Q id="6428653267" qualifier_id="141" value="46.0"/>
+      <Q id="6428653269" qualifier_id="212" value="8.3"/>
+      <Q id="6428653271" qualifier_id="213" value="1.10"/>
+    </Event>
+    <Event id="2939839105" event_id="450" type_id="44" period_id="2" min="53" sec="48" player_id="565487" team_id="417" outcome="1" x="6.0" y="54.0" timestamp="2026-05-19T14:31:49.383" timestamp_utc="2026-05-19T13:31:49.383" last_modified="2026-05-19T15:45:42" version="1779201942622">
+      <Q id="6428653315" qualifier_id="56" value="Back"/>
+      <Q id="6428653337" qualifier_id="233" value="574"/>
+      <Q id="6428653317" qualifier_id="285"/>
+    </Event>
+    <Event id="2939839109" event_id="574" type_id="44" period_id="2" min="53" sec="48" player_id="479433" team_id="244" outcome="0" x="94.0" y="46.0" timestamp="2026-05-19T14:31:49.384" timestamp_utc="2026-05-19T13:31:49.384" last_modified="2026-05-19T15:45:43" version="1779201942905">
+      <Q id="6428653331" qualifier_id="56" value="Center"/>
+      <Q id="6428653339" qualifier_id="233" value="450"/>
+      <Q id="6428653333" qualifier_id="286"/>
+    </Event>
+    <Event id="2939839119" event_id="451" type_id="41" period_id="2" min="53" sec="49" player_id="565487" team_id="417" outcome="1" x="6.0" y="54.0" timestamp="2026-05-19T14:31:50.228" timestamp_utc="2026-05-19T13:31:50.228" last_modified="2026-05-19T15:45:43" version="1779201943172"/>
+    <Event id="2939841325" event_id="519" type_id="44" period_id="2" min="53" sec="49" player_id="164593" team_id="417" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T14:31:50.382" timestamp_utc="2026-05-19T13:31:50.382" last_modified="2026-05-19T15:45:43" version="1779201943454">
+      <Q id="6428666741" qualifier_id="56" value="Back"/>
+      <Q id="6428666763" qualifier_id="233" value="678"/>
+      <Q id="6428737619" qualifier_id="286"/>
+    </Event>
+    <Event id="2939842263" event_id="678" type_id="44" period_id="2" min="53" sec="49" player_id="648131" team_id="244" outcome="0" x="0.0" y="0.0" timestamp="2026-05-19T14:31:50.383" timestamp_utc="2026-05-19T13:31:50.383" last_modified="2026-05-19T15:45:43" version="1779201943737">
+      <Q id="6428672429" qualifier_id="56" value="Back"/>
+      <Q id="6428672433" qualifier_id="233" value="519"/>
+      <Q id="6428672437" qualifier_id="286"/>
+    </Event>
+    <Event id="2939841329" event_id="520" type_id="12" period_id="2" min="53" sec="50" player_id="164593" team_id="417" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T14:31:50.745" timestamp_utc="2026-05-19T13:31:50.745" last_modified="2026-05-19T15:45:44" version="1779201944019">
+      <Q id="6428666781" qualifier_id="15"/>
+      <Q id="6428666769" qualifier_id="56" value="Back"/>
+      <Q id="6428666771" qualifier_id="140" value="15.1"/>
+      <Q id="6428666773" qualifier_id="141" value="58.7"/>
+      <Q id="6428666775" qualifier_id="212" value="0.0"/>
+      <Q id="6428666777" qualifier_id="213" value="0.00"/>
+    </Event>
+    <Event id="2939842421" event_id="564" type_id="12" period_id="2" min="53" sec="51" player_id="685390" team_id="417" outcome="1" x="14.7" y="65.6" timestamp="2026-05-19T14:31:51.745" timestamp_utc="2026-05-19T13:31:51.745" last_modified="2026-05-19T14:44:27" version="1779198266935">
+      <Q id="6428673445" qualifier_id="56" value="Center"/>
+      <Q id="6428673447" qualifier_id="140" value="37.3"/>
+      <Q id="6428673449" qualifier_id="141" value="56.8"/>
+      <Q id="6428673451" qualifier_id="212" value="24.5"/>
+      <Q id="6428673453" qualifier_id="213" value="2.89"/>
+    </Event>
+    <Event id="2939839123" event_id="575" type_id="13" period_id="2" min="53" sec="54" player_id="575855" team_id="244" outcome="1" x="77.2" y="48.9" timestamp="2026-05-19T14:31:54.569" timestamp_utc="2026-05-19T13:31:54.569" last_modified="2026-05-19T15:52:18" version="1779202338478">
+      <Q id="6428653425" qualifier_id="18"/>
+      <Q id="6428653507" qualifier_id="20"/>
+      <Q id="6428653557" qualifier_id="24"/>
+      <Q id="6428653427" qualifier_id="56" value="Center"/>
+      <Q id="6428653559" qualifier_id="77"/>
+      <Q id="6428653561" qualifier_id="102" value="63.4"/>
+      <Q id="6428653563" qualifier_id="103" value="44.4"/>
+      <Q id="6428653567" qualifier_id="230" value="99.0"/>
+      <Q id="6428653569" qualifier_id="231" value="50.7"/>
+      <Q id="6428653565" qualifier_id="458"/>
+    </Event>
+    <Event id="2939839125" event_id="452" type_id="5" period_id="2" min="53" sec="55" player_id="565487" team_id="417" outcome="1" x="-1.0" y="43.0" timestamp="2026-05-19T14:31:55.992" timestamp_utc="2026-05-19T13:31:55.992" last_modified="2026-05-19T15:26:33" version="1779200790143">
+      <Q id="6428653437" qualifier_id="56" value="Back"/>
+      <Q id="6428653503" qualifier_id="233" value="576"/>
+      <Q id="6428653439" qualifier_id="346"/>
+    </Event>
+    <Event id="2939839131" event_id="576" type_id="5" period_id="2" min="53" sec="55" player_id="575855" team_id="244" outcome="0" x="101.0" y="57.0" timestamp="2026-05-19T14:31:55.992" timestamp_utc="2026-05-19T13:31:55.992" last_modified="2026-05-19T14:31:59" version="1779197517608">
+      <Q id="6428653493" qualifier_id="56" value="Center"/>
+      <Q id="6428653511" qualifier_id="233" value="452"/>
+      <Q id="6428653495" qualifier_id="346"/>
+    </Event>
+    <Event id="2939839135" event_id="453" type_id="1" period_id="2" min="53" sec="57" player_id="565487" team_id="417" outcome="1" x="2.8" y="45.1" timestamp="2026-05-19T14:31:58.068" timestamp_utc="2026-05-19T13:31:58.068" last_modified="2026-05-19T14:32:00" version="1779197518274">
+      <Q id="6428653529" qualifier_id="56" value="Back"/>
+      <Q id="6428653527" qualifier_id="124"/>
+      <Q id="6428653531" qualifier_id="140" value="10.0"/>
+      <Q id="6428653533" qualifier_id="141" value="63.0"/>
+      <Q id="6428653535" qualifier_id="212" value="14.3"/>
+      <Q id="6428653537" qualifier_id="213" value="1.02"/>
+      <Q id="6428653541" qualifier_id="237"/>
+    </Event>
+    <Event id="2939839157" event_id="454" type_id="1" period_id="2" min="53" sec="59" player_id="61812" team_id="417" outcome="1" x="8.6" y="59.9" timestamp="2026-05-19T14:31:59.741" timestamp_utc="2026-05-19T13:31:59.741" last_modified="2026-05-19T14:32:04" version="1779197520055">
+      <Q id="6428653667" qualifier_id="56" value="Back"/>
+      <Q id="6428653669" qualifier_id="140" value="12.6"/>
+      <Q id="6428653671" qualifier_id="141" value="80.6"/>
+      <Q id="6428653673" qualifier_id="212" value="14.7"/>
+      <Q id="6428653675" qualifier_id="213" value="1.28"/>
+    </Event>
+    <Event id="2939839169" event_id="455" type_id="1" period_id="2" min="54" sec="3" player_id="624620" team_id="417" outcome="1" x="18.9" y="83.5" timestamp="2026-05-19T14:32:04.092" timestamp_utc="2026-05-19T13:32:04.092" last_modified="2026-05-19T14:32:08" version="1779197524373">
+      <Q id="6428653757" qualifier_id="56" value="Back"/>
+      <Q id="6428653759" qualifier_id="140" value="10.4"/>
+      <Q id="6428653761" qualifier_id="141" value="47.2"/>
+      <Q id="6428653763" qualifier_id="212" value="26.2"/>
+      <Q id="6428653765" qualifier_id="213" value="4.37"/>
+    </Event>
+    <Event id="2939839183" event_id="456" type_id="1" period_id="2" min="54" sec="8" player_id="565487" team_id="417" outcome="0" x="6.2" y="45.5" timestamp="2026-05-19T14:32:08.796" timestamp_utc="2026-05-19T13:32:08.796" last_modified="2026-05-19T14:32:10" version="1779197530821">
+      <Q id="6428653831" qualifier_id="1"/>
+      <Q id="6428653821" qualifier_id="56" value="Center"/>
+      <Q id="6428653823" qualifier_id="140" value="60.0"/>
+      <Q id="6428653825" qualifier_id="141" value="28.2"/>
+      <Q id="6428653819" qualifier_id="157"/>
+      <Q id="6428653827" qualifier_id="212" value="57.7"/>
+      <Q id="6428653829" qualifier_id="213" value="6.08"/>
+    </Event>
+    <Event id="2939839199" event_id="577" type_id="1" period_id="2" min="54" sec="10" player_id="180662" team_id="244" outcome="1" x="43.6" y="75.3" timestamp="2026-05-19T14:32:10.617" timestamp_utc="2026-05-19T13:32:10.617" last_modified="2026-05-19T14:32:14" version="1779197533548">
+      <Q id="6428653931" qualifier_id="3"/>
+      <Q id="6428653933" qualifier_id="56" value="Center"/>
+      <Q id="6428653935" qualifier_id="140" value="62.8"/>
+      <Q id="6428653937" qualifier_id="141" value="74.1"/>
+      <Q id="6428653939" qualifier_id="212" value="20.2"/>
+      <Q id="6428653941" qualifier_id="213" value="6.24"/>
+    </Event>
+    <Event id="2939839213" event_id="578" type_id="1" period_id="2" min="54" sec="14" player_id="207884" team_id="244" outcome="1" x="62.9" y="74.1" timestamp="2026-05-19T14:32:14.648" timestamp_utc="2026-05-19T13:32:14.648" last_modified="2026-05-19T14:32:17" version="1779197534990">
+      <Q id="6428654003" qualifier_id="3"/>
+      <Q id="6428654007" qualifier_id="56" value="Center"/>
+      <Q id="6428654009" qualifier_id="140" value="66.6"/>
+      <Q id="6428654011" qualifier_id="141" value="69.6"/>
+      <Q id="6428654005" qualifier_id="168"/>
+      <Q id="6428654013" qualifier_id="212" value="4.9"/>
+      <Q id="6428654015" qualifier_id="213" value="5.62"/>
+    </Event>
+    <Event id="2939839215" event_id="579" type_id="1" period_id="2" min="54" sec="16" player_id="648131" team_id="244" outcome="0" x="62.8" y="68.5" timestamp="2026-05-19T14:32:17.112" timestamp_utc="2026-05-19T13:32:17.112" last_modified="2026-05-19T14:32:19" version="1779197539105">
+      <Q id="6428654023" qualifier_id="56" value="Center"/>
+      <Q id="6428654025" qualifier_id="140" value="64.0"/>
+      <Q id="6428654027" qualifier_id="141" value="63.9"/>
+      <Q id="6428654029" qualifier_id="212" value="3.4"/>
+      <Q id="6428654031" qualifier_id="213" value="5.10"/>
+      <Q id="6428654091" qualifier_id="233" value="457"/>
+      <Q id="6428654085" qualifier_id="236"/>
+      <Q id="6428654089" qualifier_id="286"/>
+    </Event>
+    <Event id="2939839223" event_id="457" type_id="74" period_id="2" min="54" sec="16" player_id="720682" team_id="417" outcome="1" x="36.0" y="36.1" timestamp="2026-05-19T14:32:17.113" timestamp_utc="2026-05-19T13:32:17.113" last_modified="2026-05-19T15:45:53" version="1779201952940">
+      <Q id="6428654081" qualifier_id="56" value="Back"/>
+      <Q id="6428654097" qualifier_id="233" value="579"/>
+      <Q id="6428654083" qualifier_id="285"/>
+    </Event>
+    <Event id="2939839227" event_id="580" type_id="49" period_id="2" min="54" sec="18" player_id="240166" team_id="244" outcome="1" x="38.3" y="30.1" timestamp="2026-05-19T14:32:19.369" timestamp_utc="2026-05-19T13:32:19.369" last_modified="2026-05-19T14:32:20" version="1779197539370"/>
+    <Event id="2939839247" event_id="581" type_id="1" period_id="2" min="54" sec="20" player_id="240166" team_id="244" outcome="1" x="41.1" y="29.2" timestamp="2026-05-19T14:32:21.064" timestamp_utc="2026-05-19T13:32:21.064" last_modified="2026-05-19T14:32:27" version="1779197544258">
+      <Q id="6428654251" qualifier_id="56" value="Back"/>
+      <Q id="6428654253" qualifier_id="140" value="14.7"/>
+      <Q id="6428654255" qualifier_id="141" value="47.6"/>
+      <Q id="6428654257" qualifier_id="212" value="30.4"/>
+      <Q id="6428654259" qualifier_id="213" value="2.72"/>
+    </Event>
+    <Event id="2939839253" event_id="582" type_id="1" period_id="2" min="54" sec="26" player_id="578592" team_id="244" outcome="1" x="17.6" y="54.8" timestamp="2026-05-19T14:32:27.504" timestamp_utc="2026-05-19T13:32:27.504" last_modified="2026-05-19T14:32:31" version="1779197549852">
+      <Q id="6428654301" qualifier_id="1"/>
+      <Q id="6428654291" qualifier_id="56" value="Left"/>
+      <Q id="6428654293" qualifier_id="140" value="68.9"/>
+      <Q id="6428654295" qualifier_id="141" value="82.0"/>
+      <Q id="6428654289" qualifier_id="155"/>
+      <Q id="6428654297" qualifier_id="212" value="57.0"/>
+      <Q id="6428654299" qualifier_id="213" value="0.33"/>
+    </Event>
+    <Event id="2939839255" event_id="583" type_id="61" period_id="2" min="54" sec="30" player_id="207884" team_id="244" outcome="1" x="68.7" y="81.8" keypass="1" timestamp="2026-05-19T14:32:30.994" timestamp_utc="2026-05-19T13:32:30.994" last_modified="2026-05-19T15:53:21" version="1779202401271">
+      <Q id="6428654305" qualifier_id="56" value="Left"/>
+    </Event>
+    <Event id="2939839263" event_id="584" type_id="15" period_id="2" min="54" sec="34" player_id="648131" team_id="244" outcome="1" x="78.4" y="54.2" timestamp="2026-05-19T14:32:35.064" timestamp_utc="2026-05-19T13:32:35.064" last_modified="2026-05-19T15:53:21" version="1779202401284">
+      <Q id="6428654347" qualifier_id="18"/>
+      <Q id="6428656909" qualifier_id="20"/>
+      <Q id="6428654345" qualifier_id="22"/>
+      <Q id="6428740347" qualifier_id="29"/>
+      <Q id="6428740349" qualifier_id="55" value="583"/>
+      <Q id="6428654349" qualifier_id="56" value="Center"/>
+      <Q id="6428657079" qualifier_id="78"/>
+      <Q id="6428656913" qualifier_id="82"/>
+      <Q id="6428657081" qualifier_id="102" value="48.6"/>
+      <Q id="6428657083" qualifier_id="103" value="19.0"/>
+      <Q id="6428657087" qualifier_id="146" value="82.8"/>
+      <Q id="6428657089" qualifier_id="147" value="53.1"/>
+      <Q id="6428740353" qualifier_id="215"/>
+      <Q id="6428657091" qualifier_id="230" value="98.4"/>
+      <Q id="6428657093" qualifier_id="231" value="50.7"/>
+      <Q id="6428657133" qualifier_id="233" value="458"/>
+    </Event>
+    <Event id="2939839269" event_id="458" type_id="10" period_id="2" min="54" sec="34" player_id="61812" team_id="417" outcome="1" x="14.4" y="47.3" timestamp="2026-05-19T14:32:35.164" timestamp_utc="2026-05-19T13:32:35.164" last_modified="2026-05-19T14:34:32" version="1779197672007">
+      <Q id="6428654387" qualifier_id="56" value="Back"/>
+      <Q id="6428654385" qualifier_id="94"/>
+      <Q id="6428657141" qualifier_id="233" value="584"/>
+    </Event>
+    <Event id="2939839275" event_id="459" type_id="61" period_id="2" min="54" sec="38" player_id="720682" team_id="417" outcome="1" x="24.8" y="40.7" timestamp="2026-05-19T14:32:39.153" timestamp_utc="2026-05-19T13:32:39.153" last_modified="2026-05-19T14:33:25" version="1779197605562">
+      <Q id="6428654421" qualifier_id="56" value="Back"/>
+    </Event>
+    <Event id="2939839295" event_id="460" type_id="1" period_id="2" min="54" sec="39" player_id="624620" team_id="417" outcome="1" x="13.5" y="51.1" timestamp="2026-05-19T14:32:39.819" timestamp_utc="2026-05-19T13:32:39.819" last_modified="2026-05-19T14:34:45" version="1779197685433">
+      <Q id="6428654505" qualifier_id="56" value="Back"/>
+      <Q id="6428654507" qualifier_id="140" value="15.5"/>
+      <Q id="6428654509" qualifier_id="141" value="48.9"/>
+      <Q id="6428654511" qualifier_id="212" value="2.6"/>
+      <Q id="6428654513" qualifier_id="213" value="5.66"/>
+    </Event>
+    <Event id="2939839765" event_id="478" type_id="12" period_id="2" min="54" sec="39" player_id="720682" team_id="417" outcome="1" x="17.1" y="47.8" timestamp="2026-05-19T14:32:40.035" timestamp_utc="2026-05-19T13:32:40.035" last_modified="2026-05-19T15:22:58" version="1779200578655">
+      <Q id="6428657375" qualifier_id="56" value="Back"/>
+      <Q id="6428657377" qualifier_id="140" value="18.8"/>
+      <Q id="6428657379" qualifier_id="141" value="43.7"/>
+      <Q id="6428657381" qualifier_id="212" value="3.3"/>
+      <Q id="6428657383" qualifier_id="213" value="5.28"/>
+    </Event>
+    <Event id="2939839283" event_id="585" type_id="61" period_id="2" min="54" sec="40" player_id="648131" team_id="244" outcome="1" x="79.3" y="55.2" timestamp="2026-05-19T14:32:41.008" timestamp_utc="2026-05-19T13:32:41.008" last_modified="2026-05-19T15:23:05" version="1779200584984">
+      <Q id="6428654467" qualifier_id="56" value="Center"/>
+    </Event>
+    <Event id="2939839313" event_id="586" type_id="1" period_id="2" min="54" sec="41" player_id="575855" team_id="244" outcome="1" x="66.6" y="79.9" timestamp="2026-05-19T14:32:41.704" timestamp_utc="2026-05-19T13:32:41.704" last_modified="2026-05-19T14:32:47" version="1779197567298">
+      <Q id="6428654611" qualifier_id="3"/>
+      <Q id="6428654613" qualifier_id="56" value="Left"/>
+      <Q id="6428654615" qualifier_id="140" value="77.9"/>
+      <Q id="6428654617" qualifier_id="141" value="84.7"/>
+      <Q id="6428654619" qualifier_id="212" value="12.3"/>
+      <Q id="6428654621" qualifier_id="213" value="0.27"/>
+    </Event>
+    <Event id="2939839315" event_id="587" type_id="1" period_id="2" min="54" sec="46" player_id="479433" team_id="244" outcome="1" x="81.3" y="91.6" timestamp="2026-05-19T14:32:47.316" timestamp_utc="2026-05-19T13:32:47.316" last_modified="2026-05-19T14:35:38" version="1779197737968">
+      <Q id="6428659095" qualifier_id="56" value="Left"/>
+      <Q id="6428659097" qualifier_id="140" value="75.2"/>
+      <Q id="6428659099" qualifier_id="141" value="84.2"/>
+      <Q id="6428659101" qualifier_id="212" value="8.1"/>
+      <Q id="6428659103" qualifier_id="213" value="3.81"/>
+    </Event>
+    <Event id="2939839323" event_id="588" type_id="1" period_id="2" min="54" sec="48" player_id="515742" team_id="244" outcome="1" x="71.1" y="77.9" timestamp="2026-05-19T14:32:48.672" timestamp_utc="2026-05-19T13:32:48.672" last_modified="2026-05-19T14:35:49" version="1779197749450">
+      <Q id="6428654669" qualifier_id="56" value="Left"/>
+      <Q id="6428654671" qualifier_id="140" value="79.3"/>
+      <Q id="6428654673" qualifier_id="141" value="89.0"/>
+      <Q id="6428654675" qualifier_id="212" value="11.5"/>
+      <Q id="6428654677" qualifier_id="213" value="0.72"/>
+    </Event>
+    <Event id="2939839327" event_id="589" type_id="1" period_id="2" min="54" sec="49" player_id="479433" team_id="244" outcome="1" x="79.6" y="89.1" timestamp="2026-05-19T14:32:50.304" timestamp_utc="2026-05-19T13:32:50.304" last_modified="2026-05-19T14:35:44" version="1779197744818">
+      <Q id="6428654709" qualifier_id="1"/>
+      <Q id="6428654695" qualifier_id="2"/>
+      <Q id="6428654699" qualifier_id="56" value="Center"/>
+      <Q id="6428654701" qualifier_id="140" value="92.4"/>
+      <Q id="6428654703" qualifier_id="141" value="45.4"/>
+      <Q id="6428654697" qualifier_id="155"/>
+      <Q id="6428654705" qualifier_id="212" value="32.6"/>
+      <Q id="6428654707" qualifier_id="213" value="5.14"/>
+    </Event>
+    <Event id="2939839329" event_id="590" type_id="61" period_id="2" min="54" sec="51" player_id="625775" team_id="244" outcome="0" x="92.4" y="45.4" timestamp="2026-05-19T14:32:52.512" timestamp_utc="2026-05-19T13:32:52.512" last_modified="2026-05-19T14:32:52" version="1779197572514">
+      <Q id="6428654713" qualifier_id="56" value="Center"/>
+    </Event>
+    <Event id="2939839331" event_id="461" type_id="52" period_id="2" min="54" sec="55" player_id="565487" team_id="417" outcome="1" x="8.6" y="50.7" timestamp="2026-05-19T14:32:56.067" timestamp_utc="2026-05-19T13:32:56.067" last_modified="2026-05-19T14:32:56" version="1779197576068"/>
+    <Event id="2939839341" event_id="462" type_id="1" period_id="2" min="54" sec="57" player_id="565487" team_id="417" outcome="0" x="12.5" y="53.0" timestamp="2026-05-19T14:32:58.051" timestamp_utc="2026-05-19T13:32:58.051" last_modified="2026-05-19T14:33:01" version="1779197581132">
+      <Q id="6428654831" qualifier_id="1"/>
+      <Q id="6428654821" qualifier_id="56" value="Center"/>
+      <Q id="6428654823" qualifier_id="140" value="71.0"/>
+      <Q id="6428654825" qualifier_id="141" value="33.3"/>
+      <Q id="6428654819" qualifier_id="199"/>
+      <Q id="6428654827" qualifier_id="212" value="62.9"/>
+      <Q id="6428654829" qualifier_id="213" value="6.07"/>
+    </Event>
+    <Event id="2939839355" event_id="591" type_id="49" period_id="2" min="55" sec="3" player_id="627127" team_id="244" outcome="1" x="36.7" y="71.1" timestamp="2026-05-19T14:33:03.761" timestamp_utc="2026-05-19T13:33:03.761" last_modified="2026-05-19T14:33:03" version="1779197583762"/>
+    <Event id="2939839375" event_id="592" type_id="1" period_id="2" min="55" sec="7" player_id="627127" team_id="244" outcome="1" x="38.5" y="73.5" timestamp="2026-05-19T14:33:08.112" timestamp_utc="2026-05-19T13:33:08.112" last_modified="2026-05-19T14:33:09" version="1779197588633">
+      <Q id="6428655021" qualifier_id="56" value="Back"/>
+      <Q id="6428655023" qualifier_id="140" value="43.0"/>
+      <Q id="6428655025" qualifier_id="141" value="57.8"/>
+      <Q id="6428655027" qualifier_id="212" value="11.7"/>
+      <Q id="6428655029" qualifier_id="213" value="5.13"/>
+    </Event>
+    <Event id="2939839399" event_id="593" type_id="1" period_id="2" min="55" sec="8" player_id="515742" team_id="244" outcome="1" x="43.0" y="57.8" timestamp="2026-05-19T14:33:09.064" timestamp_utc="2026-05-19T13:33:09.064" last_modified="2026-05-19T14:33:12" version="1779197590603">
+      <Q id="6428655161" qualifier_id="56" value="Center"/>
+      <Q id="6428655163" qualifier_id="140" value="50.7"/>
+      <Q id="6428655165" qualifier_id="141" value="50.3"/>
+      <Q id="6428655167" qualifier_id="212" value="9.6"/>
+      <Q id="6428655169" qualifier_id="213" value="5.72"/>
+    </Event>
+    <Event id="2939839411" event_id="594" type_id="1" period_id="2" min="55" sec="11" player_id="207884" team_id="244" outcome="1" x="51.2" y="51.6" timestamp="2026-05-19T14:33:12.024" timestamp_utc="2026-05-19T13:33:12.024" last_modified="2026-05-19T14:33:15" version="1779197593012">
+      <Q id="6428655241" qualifier_id="56" value="Back"/>
+      <Q id="6428655243" qualifier_id="140" value="47.7"/>
+      <Q id="6428655245" qualifier_id="141" value="72.6"/>
+      <Q id="6428655247" qualifier_id="212" value="14.7"/>
+      <Q id="6428655249" qualifier_id="213" value="1.82"/>
+    </Event>
+    <Event id="2939839427" event_id="595" type_id="1" period_id="2" min="55" sec="14" player_id="575855" team_id="244" outcome="1" x="50.7" y="72.1" timestamp="2026-05-19T14:33:15.032" timestamp_utc="2026-05-19T13:33:15.032" last_modified="2026-05-19T14:33:19" version="1779197595499">
+      <Q id="6428655335" qualifier_id="56" value="Center"/>
+      <Q id="6428655337" qualifier_id="140" value="58.0"/>
+      <Q id="6428655339" qualifier_id="141" value="63.0"/>
+      <Q id="6428655341" qualifier_id="212" value="9.9"/>
+      <Q id="6428655343" qualifier_id="213" value="5.60"/>
+    </Event>
+    <Event id="2939839431" event_id="596" type_id="1" period_id="2" min="55" sec="18" player_id="207884" team_id="244" outcome="1" x="53.8" y="67.6" timestamp="2026-05-19T14:33:19.448" timestamp_utc="2026-05-19T13:33:19.448" last_modified="2026-05-19T14:33:22" version="1779197600043">
+      <Q id="6428655369" qualifier_id="56" value="Back"/>
+      <Q id="6428655371" qualifier_id="140" value="42.9"/>
+      <Q id="6428655373" qualifier_id="141" value="54.9"/>
+      <Q id="6428655375" qualifier_id="212" value="14.3"/>
+      <Q id="6428655377" qualifier_id="213" value="3.79"/>
+    </Event>
+    <Event id="2939839447" event_id="597" type_id="1" period_id="2" min="55" sec="21" player_id="515742" team_id="244" outcome="1" x="40.6" y="55.1" timestamp="2026-05-19T14:33:22.112" timestamp_utc="2026-05-19T13:33:22.112" last_modified="2026-05-19T14:33:26" version="1779197603715">
+      <Q id="6428655477" qualifier_id="1"/>
+      <Q id="6428655467" qualifier_id="56" value="Right"/>
+      <Q id="6428655469" qualifier_id="140" value="54.9"/>
+      <Q id="6428655471" qualifier_id="141" value="9.1"/>
+      <Q id="6428655473" qualifier_id="212" value="34.7"/>
+      <Q id="6428655475" qualifier_id="213" value="5.16"/>
+    </Event>
+    <Event id="2939839457" event_id="598" type_id="1" period_id="2" min="55" sec="25" player_id="240166" team_id="244" outcome="1" x="52.1" y="13.8" timestamp="2026-05-19T14:33:26.128" timestamp_utc="2026-05-19T13:33:26.128" last_modified="2026-05-19T14:33:29" version="1779197609043">
+      <Q id="6428655569" qualifier_id="56" value="Back"/>
+      <Q id="6428655571" qualifier_id="140" value="36.2"/>
+      <Q id="6428655573" qualifier_id="141" value="20.3"/>
+      <Q id="6428655575" qualifier_id="212" value="17.3"/>
+      <Q id="6428655577" qualifier_id="213" value="2.88"/>
+    </Event>
+    <Event id="2939839461" event_id="599" type_id="1" period_id="2" min="55" sec="28" player_id="180662" team_id="244" outcome="1" x="36.2" y="20.3" timestamp="2026-05-19T14:33:29.504" timestamp_utc="2026-05-19T13:33:29.504" last_modified="2026-05-19T14:33:30" version="1779197609923">
+      <Q id="6428655603" qualifier_id="56" value="Back"/>
+      <Q id="6428655605" qualifier_id="140" value="41.8"/>
+      <Q id="6428655607" qualifier_id="141" value="30.3"/>
+      <Q id="6428655609" qualifier_id="212" value="9.0"/>
+      <Q id="6428655611" qualifier_id="213" value="0.86"/>
+    </Event>
+    <Event id="2939839467" event_id="600" type_id="1" period_id="2" min="55" sec="29" player_id="207884" team_id="244" outcome="0" x="41.8" y="30.3" timestamp="2026-05-19T14:33:30.360" timestamp_utc="2026-05-19T13:33:30.360" last_modified="2026-05-19T14:33:31" version="1779197611770">
+      <Q id="6428655647" qualifier_id="56" value="Right"/>
+      <Q id="6428655649" qualifier_id="140" value="66.1"/>
+      <Q id="6428655651" qualifier_id="141" value="20.4"/>
+      <Q id="6428655653" qualifier_id="212" value="26.4"/>
+      <Q id="6428655655" qualifier_id="213" value="6.03"/>
+    </Event>
+    <Event id="2939839471" event_id="464" type_id="49" period_id="2" min="55" sec="33" player_id="624620" team_id="417" outcome="1" x="28.8" y="75.4" timestamp="2026-05-19T14:33:33.628" timestamp_utc="2026-05-19T13:33:33.628" last_modified="2026-05-19T14:33:33" version="1779197613629"/>
+    <Event id="2939839483" event_id="465" type_id="50" period_id="2" min="55" sec="36" player_id="624620" team_id="417" outcome="1" x="39.8" y="55.6" timestamp="2026-05-19T14:33:36.939" timestamp_utc="2026-05-19T13:33:36.939" last_modified="2026-05-19T14:33:42" version="1779197622322">
+      <Q id="6428655715" qualifier_id="56" value="Back"/>
+      <Q id="6428655775" qualifier_id="233" value="601"/>
+      <Q id="6428655717" qualifier_id="286"/>
+    </Event>
+    <Event id="2939839491" event_id="601" type_id="7" period_id="2" min="55" sec="36" player_id="232091" team_id="244" outcome="0" x="60.2" y="44.4" timestamp="2026-05-19T14:33:36.940" timestamp_utc="2026-05-19T13:33:36.940" last_modified="2026-05-19T14:33:44" version="1779197624132">
+      <Q id="6428655757" qualifier_id="56" value="Center"/>
+      <Q id="6428655769" qualifier_id="233" value="465"/>
+      <Q id="6428655759" qualifier_id="285"/>
+      <Q id="6428655817" qualifier_id="389"/>
+    </Event>
+    <Event id="2939839523" event_id="466" type_id="1" period_id="2" min="55" sec="40" player_id="685390" team_id="417" outcome="1" x="45.8" y="55.1" timestamp="2026-05-19T14:33:41.148" timestamp_utc="2026-05-19T13:33:41.148" last_modified="2026-05-19T14:33:49" version="1779197621939">
+      <Q id="6428655965" qualifier_id="56" value="Left"/>
+      <Q id="6428655967" qualifier_id="140" value="63.2"/>
+      <Q id="6428655969" qualifier_id="141" value="86.6"/>
+      <Q id="6428655971" qualifier_id="212" value="28.2"/>
+      <Q id="6428655973" qualifier_id="213" value="0.86"/>
+    </Event>
+    <Event id="2939839531" event_id="467" type_id="1" period_id="2" min="55" sec="48" player_id="164593" team_id="417" outcome="1" x="73.2" y="86.9" timestamp="2026-05-19T14:33:49.435" timestamp_utc="2026-05-19T13:33:49.435" last_modified="2026-05-19T14:33:52" version="1779197629620">
+      <Q id="6428656013" qualifier_id="56" value="Center"/>
+      <Q id="6428656015" qualifier_id="140" value="62.2"/>
+      <Q id="6428656017" qualifier_id="141" value="68.5"/>
+      <Q id="6428656019" qualifier_id="212" value="17.0"/>
+      <Q id="6428656021" qualifier_id="213" value="3.97"/>
+    </Event>
+    <Event id="2939839553" event_id="468" type_id="1" period_id="2" min="55" sec="51" player_id="218339" team_id="417" outcome="1" x="63.0" y="67.3" timestamp="2026-05-19T14:33:51.995" timestamp_utc="2026-05-19T13:33:51.995" last_modified="2026-05-19T14:33:56" version="1779197633460">
+      <Q id="6428656113" qualifier_id="56" value="Left"/>
+      <Q id="6428656115" qualifier_id="140" value="72.1"/>
+      <Q id="6428656117" qualifier_id="141" value="87.2"/>
+      <Q id="6428656119" qualifier_id="212" value="16.6"/>
+      <Q id="6428656121" qualifier_id="213" value="0.96"/>
+    </Event>
+    <Event id="2939839565" event_id="469" type_id="1" period_id="2" min="55" sec="55" player_id="61778" team_id="417" outcome="1" x="76.2" y="89.9" timestamp="2026-05-19T14:33:56.259" timestamp_utc="2026-05-19T13:33:56.259" last_modified="2026-05-19T14:33:57" version="1779197636476">
+      <Q id="6428656177" qualifier_id="56" value="Center"/>
+      <Q id="6428656179" qualifier_id="140" value="72.2"/>
+      <Q id="6428656181" qualifier_id="141" value="72.6"/>
+      <Q id="6428656183" qualifier_id="212" value="12.5"/>
+      <Q id="6428656185" qualifier_id="213" value="4.37"/>
+    </Event>
+    <Event id="2939839567" event_id="470" type_id="1" period_id="2" min="55" sec="56" player_id="720682" team_id="417" outcome="1" x="72.2" y="72.6" timestamp="2026-05-19T14:33:57.516" timestamp_utc="2026-05-19T13:33:57.516" last_modified="2026-05-19T14:33:58" version="1779197637889">
+      <Q id="6428656189" qualifier_id="56" value="Center"/>
+      <Q id="6428656191" qualifier_id="140" value="64.6"/>
+      <Q id="6428656193" qualifier_id="141" value="75.0"/>
+      <Q id="6428656201" qualifier_id="156"/>
+      <Q id="6428656195" qualifier_id="212" value="8.1"/>
+      <Q id="6428656197" qualifier_id="213" value="2.94"/>
+    </Event>
+    <Event id="2939839579" event_id="471" type_id="1" period_id="2" min="56" sec="0" player_id="218339" team_id="417" outcome="1" x="67.4" y="76.7" timestamp="2026-05-19T14:34:01.067" timestamp_utc="2026-05-19T13:34:01.067" last_modified="2026-05-19T14:34:03" version="1779197641183">
+      <Q id="6428656259" qualifier_id="56" value="Center"/>
+      <Q id="6428656261" qualifier_id="140" value="63.7"/>
+      <Q id="6428656263" qualifier_id="141" value="62.1"/>
+      <Q id="6428656265" qualifier_id="212" value="10.7"/>
+      <Q id="6428656267" qualifier_id="213" value="4.34"/>
+    </Event>
+    <Event id="2939839583" event_id="472" type_id="1" period_id="2" min="56" sec="2" player_id="624620" team_id="417" outcome="1" x="64.1" y="64.5" timestamp="2026-05-19T14:34:03.475" timestamp_utc="2026-05-19T13:34:03.475" last_modified="2026-05-19T14:34:05" version="1779197643645">
+      <Q id="6428656291" qualifier_id="56" value="Center"/>
+      <Q id="6428656293" qualifier_id="140" value="67.2"/>
+      <Q id="6428656295" qualifier_id="141" value="76.4"/>
+      <Q id="6428656297" qualifier_id="212" value="8.7"/>
+      <Q id="6428656299" qualifier_id="213" value="1.19"/>
+    </Event>
+    <Event id="2939839599" event_id="473" type_id="1" period_id="2" min="56" sec="4" player_id="218339" team_id="417" outcome="1" x="66.8" y="76.3" timestamp="2026-05-19T14:34:05.059" timestamp_utc="2026-05-19T13:34:05.059" last_modified="2026-05-19T14:34:08" version="1779197645372">
+      <Q id="6428656371" qualifier_id="56" value="Left"/>
+      <Q id="6428656373" qualifier_id="140" value="69.6"/>
+      <Q id="6428656375" qualifier_id="141" value="88.3"/>
+      <Q id="6428656377" qualifier_id="212" value="8.7"/>
+      <Q id="6428656379" qualifier_id="213" value="1.22"/>
+    </Event>
+    <Event id="2939839611" event_id="474" type_id="1" period_id="2" min="56" sec="7" player_id="720682" team_id="417" outcome="1" x="70.5" y="82.0" timestamp="2026-05-19T14:34:08.499" timestamp_utc="2026-05-19T13:34:08.499" last_modified="2026-05-19T14:34:12" version="1779197649035">
+      <Q id="6428656437" qualifier_id="56" value="Center"/>
+      <Q id="6428656439" qualifier_id="140" value="89.6"/>
+      <Q id="6428656441" qualifier_id="141" value="73.8"/>
+      <Q id="6428656443" qualifier_id="212" value="20.8"/>
+      <Q id="6428656445" qualifier_id="213" value="6.01"/>
+    </Event>
+    <Event id="2939839623" event_id="475" type_id="1" period_id="2" min="56" sec="11" player_id="61778" team_id="417" outcome="1" x="89.4" y="84.7" timestamp="2026-05-19T14:34:11.866" timestamp_utc="2026-05-19T13:34:11.866" last_modified="2026-05-19T14:34:14" version="1779197652020">
+      <Q id="6428656537" qualifier_id="56" value="Center"/>
+      <Q id="6428656539" qualifier_id="140" value="87.1"/>
+      <Q id="6428656541" qualifier_id="141" value="72.6"/>
+      <Q id="6428656543" qualifier_id="212" value="8.6"/>
+      <Q id="6428656545" qualifier_id="213" value="4.43"/>
+    </Event>
+    <Event id="2939839627" event_id="476" type_id="1" period_id="2" min="56" sec="14" player_id="720682" team_id="417" outcome="0" x="95.7" y="69.3" timestamp="2026-05-19T14:34:14.571" timestamp_utc="2026-05-19T13:34:14.571" last_modified="2026-05-19T15:26:30" version="1779200789920">
+      <Q id="6428656557" qualifier_id="56" value="Center"/>
+      <Q id="6428656559" qualifier_id="140" value="90.9"/>
+      <Q id="6428656561" qualifier_id="141" value="52.8"/>
+      <Q id="6428656563" qualifier_id="212" value="12.3"/>
+      <Q id="6428656565" qualifier_id="213" value="4.29"/>
+    </Event>
+    <Event id="2939839633" event_id="602" type_id="12" period_id="2" min="56" sec="15" player_id="627127" team_id="244" outcome="1" x="6.3" y="39.8" timestamp="2026-05-19T14:34:15.880" timestamp_utc="2026-05-19T13:34:15.880" last_modified="2026-05-19T14:34:19" version="1779197656856">
+      <Q id="6428656595" qualifier_id="15"/>
+      <Q id="6428656583" qualifier_id="56" value="Back"/>
+      <Q id="6428656585" qualifier_id="140" value="13.5"/>
+      <Q id="6428656587" qualifier_id="141" value="34.2"/>
+      <Q id="6428656589" qualifier_id="212" value="8.5"/>
+      <Q id="6428656591" qualifier_id="213" value="5.82"/>
+    </Event>
+    <Event id="2939839653" event_id="603" type_id="4" period_id="2" min="56" sec="19" player_id="207884" team_id="244" outcome="1" x="13.6" y="40.7" timestamp="2026-05-19T14:34:19.672" timestamp_utc="2026-05-19T13:34:19.672" last_modified="2026-05-19T14:34:24" version="1779197662845">
+      <Q id="6428656715" qualifier_id="13"/>
+      <Q id="6428656719" qualifier_id="56" value="Back"/>
+      <Q id="6428656721" qualifier_id="152"/>
+      <Q id="6428656779" qualifier_id="233" value="477"/>
+      <Q id="6428656723" qualifier_id="285"/>
+      <Q id="6428656717" qualifier_id="294"/>
+    </Event>
+    <Event id="2939839655" event_id="477" type_id="4" period_id="2" min="56" sec="19" player_id="218339" team_id="417" outcome="0" x="86.4" y="59.3" timestamp="2026-05-19T14:34:19.673" timestamp_utc="2026-05-19T13:34:19.673" last_modified="2026-05-19T14:35:24" version="1779197724575">
+      <Q id="6428656757" qualifier_id="13"/>
+      <Q id="6428656761" qualifier_id="56" value="Center"/>
+      <Q id="6428656763" qualifier_id="152"/>
+      <Q id="6428656797" qualifier_id="233" value="603"/>
+      <Q id="6428656765" qualifier_id="286"/>
+      <Q id="6428656759" qualifier_id="294"/>
+    </Event>
+    <Event id="2939839811" event_id="604" type_id="1" period_id="2" min="56" sec="48" player_id="578592" team_id="244" outcome="1" x="16.3" y="44.3" timestamp="2026-05-19T14:34:49.504" timestamp_utc="2026-05-19T13:34:49.504" last_modified="2026-05-19T14:34:50" version="1779197690096">
+      <Q id="6428657633" qualifier_id="5"/>
+      <Q id="6428657637" qualifier_id="56" value="Back"/>
+      <Q id="6428657639" qualifier_id="140" value="17.6"/>
+      <Q id="6428657641" qualifier_id="141" value="23.7"/>
+      <Q id="6428657635" qualifier_id="152"/>
+      <Q id="6428657643" qualifier_id="212" value="14.1"/>
+      <Q id="6428657645" qualifier_id="213" value="4.81"/>
+    </Event>
+    <Event id="2939839841" event_id="605" type_id="1" period_id="2" min="56" sec="49" player_id="627127" team_id="244" outcome="1" x="17.6" y="23.7" timestamp="2026-05-19T14:34:50.400" timestamp_utc="2026-05-19T13:34:50.400" last_modified="2026-05-19T14:34:57" version="1779197690706">
+      <Q id="6428657807" qualifier_id="56" value="Back"/>
+      <Q id="6428657809" qualifier_id="140" value="11.9"/>
+      <Q id="6428657811" qualifier_id="141" value="45.7"/>
+      <Q id="6428657813" qualifier_id="212" value="16.1"/>
+      <Q id="6428657815" qualifier_id="213" value="1.95"/>
+    </Event>
+    <Event id="2939839855" event_id="606" type_id="1" period_id="2" min="56" sec="56" player_id="578592" team_id="244" outcome="1" x="21.4" y="55.5" timestamp="2026-05-19T14:34:56.880" timestamp_utc="2026-05-19T13:34:56.880" last_modified="2026-05-19T14:35:00" version="1779197698531">
+      <Q id="6428657923" qualifier_id="1"/>
+      <Q id="6428657913" qualifier_id="56" value="Center"/>
+      <Q id="6428657915" qualifier_id="140" value="65.0"/>
+      <Q id="6428657917" qualifier_id="141" value="46.7"/>
+      <Q id="6428657911" qualifier_id="155"/>
+      <Q id="6428657919" qualifier_id="212" value="46.2"/>
+      <Q id="6428657921" qualifier_id="213" value="6.15"/>
+    </Event>
+    <Event id="2939839865" event_id="607" type_id="1" period_id="2" min="57" sec="0" player_id="479433" team_id="244" outcome="1" x="65.8" y="46.9" timestamp="2026-05-19T14:35:00.736" timestamp_utc="2026-05-19T13:35:00.736" last_modified="2026-05-19T14:35:04" version="1779197701121">
+      <Q id="6428657971" qualifier_id="56" value="Right"/>
+      <Q id="6428657973" qualifier_id="140" value="74.1"/>
+      <Q id="6428657975" qualifier_id="141" value="15.0"/>
+      <Q id="6428657977" qualifier_id="212" value="23.4"/>
+      <Q id="6428657979" qualifier_id="213" value="5.09"/>
+    </Event>
+    <Event id="2939839869" event_id="608" type_id="1" period_id="2" min="57" sec="3" player_id="625775" team_id="244" outcome="1" x="75.7" y="33.6" keypass="1" timestamp="2026-05-19T14:35:04.552" timestamp_utc="2026-05-19T13:35:04.552" last_modified="2026-05-19T14:35:17" version="1779197717816">
+      <Q id="6428658039" qualifier_id="56" value="Center"/>
+      <Q id="6428658041" qualifier_id="140" value="79.5"/>
+      <Q id="6428658043" qualifier_id="141" value="62.9"/>
+      <Q id="6428658319" qualifier_id="210" value="15"/>
+      <Q id="6428658045" qualifier_id="212" value="20.3"/>
+      <Q id="6428658047" qualifier_id="213" value="1.37"/>
+    </Event>
+    <Event id="2939839871" event_id="609" type_id="15" period_id="2" min="57" sec="6" player_id="207884" team_id="244" outcome="1" x="83.1" y="61.5" timestamp="2026-05-19T14:35:07.184" timestamp_utc="2026-05-19T13:35:07.184" last_modified="2026-05-19T15:54:43" version="1779202483827">
+      <Q id="6428658163" qualifier_id="17"/>
+      <Q id="6428658055" qualifier_id="22"/>
+      <Q id="6428658327" qualifier_id="29"/>
+      <Q id="6428658329" qualifier_id="55" value="608"/>
+      <Q id="6428658059" qualifier_id="56" value="Center"/>
+      <Q id="6428658161" qualifier_id="72"/>
+      <Q id="6428658325" qualifier_id="80"/>
+      <Q id="6428658333" qualifier_id="102" value="46.0"/>
+      <Q id="6428658335" qualifier_id="103" value="5.1"/>
+      <Q id="6428658339" qualifier_id="146" value="98.4"/>
+      <Q id="6428658341" qualifier_id="147" value="49.3"/>
+      <Q id="6428658337" qualifier_id="215"/>
+      <Q id="6428658345" qualifier_id="233" value="479"/>
+    </Event>
+    <Event id="2939839875" event_id="479" type_id="10" period_id="2" min="57" sec="6" player_id="565487" team_id="417" outcome="1" x="2.1" y="50.7" timestamp="2026-05-19T14:35:07.284" timestamp_utc="2026-05-19T13:35:07.284" last_modified="2026-05-19T14:35:18" version="1779197717833">
+      <Q id="6428658077" qualifier_id="56" value="Back"/>
+      <Q id="6428658071" qualifier_id="173"/>
+      <Q id="6428658121" qualifier_id="179"/>
+      <Q id="6428658075" qualifier_id="182"/>
+      <Q id="6428658351" qualifier_id="233" value="609"/>
+    </Event>
+    <Event id="2939839873" event_id="610" type_id="6" period_id="2" min="57" sec="8" player_id="207884" team_id="244" outcome="1" x="93.6" y="57.8" timestamp="2026-05-19T14:35:08.801" timestamp_utc="2026-05-19T13:35:08.801" last_modified="2026-05-19T14:35:16" version="1779197713725">
+      <Q id="6428658079" qualifier_id="56" value="Center"/>
+      <Q id="6428658081" qualifier_id="75"/>
+      <Q id="6428658173" qualifier_id="233" value="480"/>
+    </Event>
+    <Event id="2939839887" event_id="480" type_id="6" period_id="2" min="57" sec="8" player_id="565487" team_id="417" outcome="0" x="6.4" y="42.2" timestamp="2026-05-19T14:35:08.801" timestamp_utc="2026-05-19T13:35:08.801" last_modified="2026-05-19T15:27:45" version="1779200864941">
+      <Q id="6428658167" qualifier_id="56" value="Back"/>
+      <Q id="6428658169" qualifier_id="73"/>
+      <Q id="6428658175" qualifier_id="233" value="610"/>
+    </Event>
+    <Event id="2939840159" event_id="611" type_id="1" period_id="2" min="57" sec="50" player_id="207884" team_id="244" outcome="0" x="99.5" y="0.5" timestamp="2026-05-19T14:35:51.377" timestamp_utc="2026-05-19T13:35:51.377" last_modified="2026-05-19T14:35:53" version="1779197753384">
+      <Q id="6428659693" qualifier_id="1"/>
+      <Q id="6428659675" qualifier_id="2"/>
+      <Q id="6428659677" qualifier_id="6"/>
+      <Q id="6428659683" qualifier_id="56" value="Center"/>
+      <Q id="6428659685" qualifier_id="140" value="92.4"/>
+      <Q id="6428659687" qualifier_id="141" value="52.5"/>
+      <Q id="6428659679" qualifier_id="155"/>
+      <Q id="6428659689" qualifier_id="212" value="36.1"/>
+      <Q id="6428659691" qualifier_id="213" value="1.78"/>
+      <Q id="6428659681" qualifier_id="224"/>
+    </Event>
+    <Event id="2939840163" event_id="481" type_id="12" period_id="2" min="57" sec="53" player_id="531784" team_id="417" outcome="1" x="9.8" y="58.2" timestamp="2026-05-19T14:35:54.386" timestamp_utc="2026-05-19T13:35:54.386" last_modified="2026-05-19T14:36:01" version="1779197757548">
+      <Q id="6428659721" qualifier_id="15"/>
+      <Q id="6428659707" qualifier_id="56" value="Back"/>
+      <Q id="6428659709" qualifier_id="140" value="19.9"/>
+      <Q id="6428659711" qualifier_id="141" value="93.0"/>
+      <Q id="6428659713" qualifier_id="212" value="25.9"/>
+      <Q id="6428659715" qualifier_id="213" value="1.15"/>
+    </Event>
+    <Event id="2939840191" event_id="612" type_id="1" period_id="2" min="57" sec="57" player_id="240166" team_id="244" outcome="1" x="75.7" y="7.7" keypass="1" timestamp="2026-05-19T14:35:57.936" timestamp_utc="2026-05-19T13:35:57.936" last_modified="2026-05-19T14:36:12" version="1779197772562">
+      <Q id="6428659861" qualifier_id="56" value="Right"/>
+      <Q id="6428659863" qualifier_id="140" value="92.4"/>
+      <Q id="6428659865" qualifier_id="141" value="10.6"/>
+      <Q id="6428660297" qualifier_id="210" value="13"/>
+      <Q id="6428659867" qualifier_id="212" value="17.6"/>
+      <Q id="6428659869" qualifier_id="213" value="0.11"/>
+    </Event>
+    <Event id="2939840197" event_id="482" type_id="45" period_id="2" min="58" sec="0" player_id="445539" team_id="417" outcome="0" x="11.2" y="86.4" timestamp="2026-05-19T14:36:01.040" timestamp_utc="2026-05-19T13:36:01.040" last_modified="2026-05-19T15:26:47" version="1779200797341">
+      <Q id="6428659897" qualifier_id="56" value="Back"/>
+      <Q id="6428660075" qualifier_id="233" value="613"/>
+      <Q id="6428659899" qualifier_id="285"/>
+    </Event>
+    <Event id="2939840215" event_id="613" type_id="3" period_id="2" min="58" sec="0" player_id="207884" team_id="244" outcome="1" x="88.8" y="13.6" timestamp="2026-05-19T14:36:01.040" timestamp_utc="2026-05-19T13:36:01.040" last_modified="2026-05-19T15:26:47" version="1779200797333">
+      <Q id="6428660009" qualifier_id="56" value="Right"/>
+      <Q id="6428660067" qualifier_id="233" value="482"/>
+      <Q id="6428660011" qualifier_id="286"/>
+    </Event>
+    <Event id="2939840205" event_id="483" type_id="83" period_id="2" min="58" sec="2" player_id="720682" team_id="417" outcome="0" x="16.0" y="73.0" timestamp="2026-05-19T14:36:03.233" timestamp_utc="2026-05-19T13:36:03.233" last_modified="2026-05-19T14:36:09" version="1779197769285">
+      <Q id="6428660193" qualifier_id="399" value="207884"/>
+    </Event>
+    <Event id="2939840217" event_id="614" type_id="13" period_id="2" min="58" sec="3" player_id="207884" team_id="244" outcome="1" x="86.6" y="33.7" timestamp="2026-05-19T14:36:04.032" timestamp_utc="2026-05-19T13:36:04.032" last_modified="2026-05-19T15:55:27" version="1779202527808">
+      <Q id="6428660169" qualifier_id="25"/>
+      <Q id="6428660301" qualifier_id="29"/>
+      <Q id="6428660303" qualifier_id="55" value="612"/>
+      <Q id="6428660031" qualifier_id="56" value="Center"/>
+      <Q id="6428660029" qualifier_id="63"/>
+      <Q id="6428660171" qualifier_id="72"/>
+      <Q id="6428741015" qualifier_id="85"/>
+      <Q id="6428660307" qualifier_id="102" value="54.3"/>
+      <Q id="6428660309" qualifier_id="103" value="56.9"/>
+      <Q id="6428660311" qualifier_id="215"/>
+      <Q id="6428660313" qualifier_id="230" value="99.4"/>
+      <Q id="6428660315" qualifier_id="231" value="47.8"/>
+    </Event>
+    <Event id="2939840233" event_id="615" type_id="5" period_id="2" min="58" sec="4" player_id="207884" team_id="244" outcome="0" x="100.8" y="57.4" timestamp="2026-05-19T14:36:05.536" timestamp_utc="2026-05-19T13:36:05.536" last_modified="2026-05-19T15:26:33" version="1779200790158">
+      <Q id="6428660165" qualifier_id="56" value="Center"/>
+      <Q id="6428660249" qualifier_id="233" value="484"/>
+      <Q id="6428660167" qualifier_id="346"/>
+    </Event>
+    <Event id="2939840243" event_id="484" type_id="5" period_id="2" min="58" sec="4" player_id="720682" team_id="417" outcome="1" x="-0.8" y="42.6" timestamp="2026-05-19T14:36:05.536" timestamp_utc="2026-05-19T13:36:05.536" last_modified="2026-05-19T15:26:33" version="1779200790151">
+      <Q id="6428660225" qualifier_id="56" value="Back"/>
+      <Q id="6428660245" qualifier_id="233" value="615"/>
+      <Q id="6428660227" qualifier_id="346"/>
+    </Event>
+    <Event id="2939840247" event_id="485" type_id="1" period_id="2" min="58" sec="9" player_id="565487" team_id="417" outcome="1" x="2.9" y="46.0" timestamp="2026-05-19T14:36:09.866" timestamp_utc="2026-05-19T13:36:09.866" last_modified="2026-05-19T14:36:12" version="1779197770083">
+      <Q id="6428660281" qualifier_id="56" value="Back"/>
+      <Q id="6428660279" qualifier_id="124"/>
+      <Q id="6428660283" qualifier_id="140" value="5.6"/>
+      <Q id="6428660285" qualifier_id="141" value="58.5"/>
+      <Q id="6428660287" qualifier_id="212" value="9.0"/>
+      <Q id="6428660289" qualifier_id="213" value="1.25"/>
+      <Q id="6428660293" qualifier_id="237"/>
+    </Event>
+    <Event id="2939840275" event_id="486" type_id="1" period_id="2" min="58" sec="11" player_id="61812" team_id="417" outcome="1" x="10.2" y="56.0" timestamp="2026-05-19T14:36:11.970" timestamp_utc="2026-05-19T13:36:11.970" last_modified="2026-05-19T14:36:18" version="1779197772348">
+      <Q id="6428660479" qualifier_id="56" value="Back"/>
+      <Q id="6428660481" qualifier_id="140" value="15.8"/>
+      <Q id="6428660483" qualifier_id="141" value="78.8"/>
+      <Q id="6428660485" qualifier_id="212" value="16.6"/>
+      <Q id="6428660487" qualifier_id="213" value="1.21"/>
+    </Event>
+    <Event id="2939840301" event_id="487" type_id="1" period_id="2" min="58" sec="17" player_id="164593" team_id="417" outcome="1" x="26.2" y="79.1" timestamp="2026-05-19T14:36:18.465" timestamp_utc="2026-05-19T13:36:18.465" last_modified="2026-05-19T14:36:29" version="1779197778907">
+      <Q id="6428660659" qualifier_id="56" value="Back"/>
+      <Q id="6428660661" qualifier_id="140" value="44.2"/>
+      <Q id="6428660663" qualifier_id="141" value="87.8"/>
+      <Q id="6428660665" qualifier_id="212" value="19.8"/>
+      <Q id="6428660667" qualifier_id="213" value="0.30"/>
+    </Event>
+    <Event id="2939840311" event_id="488" type_id="1" period_id="2" min="58" sec="28" player_id="61778" team_id="417" outcome="1" x="39.1" y="77.5" timestamp="2026-05-19T14:36:29.002" timestamp_utc="2026-05-19T13:36:29.002" last_modified="2026-05-19T14:36:33" version="1779197790716">
+      <Q id="6428660723" qualifier_id="1"/>
+      <Q id="6428660713" qualifier_id="56" value="Left"/>
+      <Q id="6428660715" qualifier_id="140" value="81.5"/>
+      <Q id="6428660717" qualifier_id="141" value="91.1"/>
+      <Q id="6428660711" qualifier_id="155"/>
+      <Q id="6428660719" qualifier_id="212" value="45.5"/>
+      <Q id="6428660721" qualifier_id="213" value="0.20"/>
+    </Event>
+    <Event id="2939840313" event_id="489" type_id="1" period_id="2" min="58" sec="33" player_id="164593" team_id="417" outcome="0" x="90.1" y="88.1" timestamp="2026-05-19T14:36:33.618" timestamp_utc="2026-05-19T13:36:33.618" last_modified="2026-05-19T14:36:34" version="1779197794548">
+      <Q id="6428660727" qualifier_id="2"/>
+      <Q id="6428660731" qualifier_id="56" value="Left"/>
+      <Q id="6428660733" qualifier_id="140" value="88.2"/>
+      <Q id="6428660735" qualifier_id="141" value="81.2"/>
+      <Q id="6428660737" qualifier_id="212" value="5.1"/>
+      <Q id="6428660739" qualifier_id="213" value="4.31"/>
+    </Event>
+    <Event id="2939840317" event_id="616" type_id="61" period_id="2" min="58" sec="34" player_id="627127" team_id="244" outcome="1" x="10.7" y="22.5" timestamp="2026-05-19T14:36:34.800" timestamp_utc="2026-05-19T13:36:34.800" last_modified="2026-05-19T14:36:34" version="1779197794801">
+      <Q id="6428660761" qualifier_id="56" value="Back"/>
+    </Event>
+    <Event id="2939840335" event_id="617" type_id="12" period_id="2" min="58" sec="36" player_id="575855" team_id="244" outcome="1" x="12.0" y="42.4" timestamp="2026-05-19T14:36:36.784" timestamp_utc="2026-05-19T13:36:36.784" last_modified="2026-05-19T14:39:06" version="1779197946757">
+      <Q id="6428660879" qualifier_id="56" value="Back"/>
+      <Q id="6428660881" qualifier_id="140" value="25.4"/>
+      <Q id="6428660883" qualifier_id="141" value="12.8"/>
+      <Q id="6428660885" qualifier_id="212" value="24.6"/>
+      <Q id="6428660887" qualifier_id="213" value="5.32"/>
+    </Event>
+    <Event id="2939840337" event_id="618" type_id="49" period_id="2" min="58" sec="39" player_id="625775" team_id="244" outcome="1" x="26.2" y="13.4" timestamp="2026-05-19T14:36:40.433" timestamp_utc="2026-05-19T13:36:40.433" last_modified="2026-05-19T14:36:40" version="1779197800434"/>
+    <Event id="2939840343" event_id="619" type_id="50" period_id="2" min="58" sec="41" player_id="625775" team_id="244" outcome="1" x="28.6" y="20.8" timestamp="2026-05-19T14:36:42.401" timestamp_utc="2026-05-19T13:36:42.401" last_modified="2026-05-19T14:36:44" version="1779197803368">
+      <Q id="6428660909" qualifier_id="56" value="Back"/>
+      <Q id="6428660955" qualifier_id="233" value="490"/>
+      <Q id="6428660911" qualifier_id="285"/>
+    </Event>
+    <Event id="2939840349" event_id="490" type_id="7" period_id="2" min="58" sec="41" player_id="720682" team_id="417" outcome="0" x="71.4" y="79.2" timestamp="2026-05-19T14:36:42.402" timestamp_utc="2026-05-19T13:36:42.402" last_modified="2026-05-19T14:36:45" version="1779197804633">
+      <Q id="6428660937" qualifier_id="56" value="Left"/>
+      <Q id="6428660945" qualifier_id="233" value="619"/>
+      <Q id="6428660939" qualifier_id="286"/>
+      <Q id="6428660997" qualifier_id="389"/>
+    </Event>
+    <Event id="2939840363" event_id="620" type_id="1" period_id="2" min="58" sec="45" player_id="232091" team_id="244" outcome="0" x="32.3" y="32.1" timestamp="2026-05-19T14:36:45.576" timestamp_utc="2026-05-19T13:36:45.576" last_modified="2026-05-19T14:36:46" version="1779197806136">
+      <Q id="6428661003" qualifier_id="56" value="Back"/>
+      <Q id="6428661005" qualifier_id="140" value="44.4"/>
+      <Q id="6428661007" qualifier_id="141" value="64.6"/>
+      <Q id="6428661009" qualifier_id="212" value="25.5"/>
+      <Q id="6428661011" qualifier_id="213" value="1.05"/>
+    </Event>
+    <Event id="2939840373" event_id="491" type_id="49" period_id="2" min="58" sec="46" player_id="531784" team_id="417" outcome="1" x="56.5" y="25.8" timestamp="2026-05-19T14:36:47.529" timestamp_utc="2026-05-19T13:36:47.529" last_modified="2026-05-19T14:36:47" version="1779197807531"/>
+    <Event id="2939840409" event_id="492" type_id="1" period_id="2" min="58" sec="48" player_id="531784" team_id="417" outcome="1" x="57.1" y="23.7" timestamp="2026-05-19T14:36:48.681" timestamp_utc="2026-05-19T13:36:48.681" last_modified="2026-05-19T14:36:54" version="1779197808961">
+      <Q id="6428661241" qualifier_id="56" value="Right"/>
+      <Q id="6428661243" qualifier_id="140" value="81.1"/>
+      <Q id="6428661245" qualifier_id="141" value="20.0"/>
+      <Q id="6428661247" qualifier_id="212" value="25.3"/>
+      <Q id="6428661249" qualifier_id="213" value="6.18"/>
+    </Event>
+    <Event id="2939840413" event_id="493" type_id="1" period_id="2" min="58" sec="53" player_id="685390" team_id="417" outcome="0" x="87.9" y="11.1" timestamp="2026-05-19T14:36:53.866" timestamp_utc="2026-05-19T13:36:53.866" last_modified="2026-05-19T14:36:55" version="1779197814921">
+      <Q id="6428661265" qualifier_id="2"/>
+      <Q id="6428661269" qualifier_id="56" value="Center"/>
+      <Q id="6428661271" qualifier_id="140" value="90.0"/>
+      <Q id="6428661273" qualifier_id="141" value="24.4"/>
+      <Q id="6428661275" qualifier_id="212" value="9.3"/>
+      <Q id="6428661277" qualifier_id="213" value="1.33"/>
+    </Event>
+    <Event id="2939840429" event_id="621" type_id="61" period_id="2" min="58" sec="57" player_id="515742" team_id="244" outcome="1" x="4.1" y="83.2" timestamp="2026-05-19T14:36:58.536" timestamp_utc="2026-05-19T13:36:58.536" last_modified="2026-05-19T14:37:25" version="1779197845326">
+      <Q id="6428661379" qualifier_id="56" value="Back"/>
+    </Event>
+    <Event id="2939840421" event_id="494" type_id="6" period_id="2" min="58" sec="58" player_id="685390" team_id="417" outcome="1" x="93.6" y="18.8" timestamp="2026-05-19T14:36:58.841" timestamp_utc="2026-05-19T13:36:58.841" last_modified="2026-05-19T14:46:05" version="1779198364908">
+      <Q id="6428661349" qualifier_id="56" value="Right"/>
+      <Q id="6428661351" qualifier_id="75"/>
+      <Q id="6428661441" qualifier_id="233" value="622"/>
+    </Event>
+    <Event id="2939840433" event_id="622" type_id="6" period_id="2" min="58" sec="58" player_id="515742" team_id="244" outcome="0" x="6.4" y="81.2" timestamp="2026-05-19T14:36:58.841" timestamp_utc="2026-05-19T13:36:58.841" last_modified="2026-05-19T15:27:45" version="1779200864952">
+      <Q id="6428661435" qualifier_id="56" value="Back"/>
+      <Q id="6428661437" qualifier_id="73"/>
+      <Q id="6428661457" qualifier_id="233" value="494"/>
+    </Event>
+    <Event id="2939840649" event_id="495" type_id="1" period_id="2" min="59" sec="42" player_id="164593" team_id="417" outcome="1" x="99.5" y="0.5" timestamp="2026-05-19T14:37:42.715" timestamp_utc="2026-05-19T13:37:42.715" last_modified="2026-05-19T14:37:50" version="1779197869830">
+      <Q id="6428662625" qualifier_id="6"/>
+      <Q id="6428662627" qualifier_id="56" value="Right"/>
+      <Q id="6428662629" qualifier_id="140" value="85.2"/>
+      <Q id="6428662631" qualifier_id="141" value="14.9"/>
+      <Q id="6428662633" qualifier_id="212" value="17.9"/>
+      <Q id="6428662635" qualifier_id="213" value="2.56"/>
+    </Event>
+    <Event id="2939840657" event_id="496" type_id="1" period_id="2" min="59" sec="45" player_id="685390" team_id="417" outcome="0" x="84.4" y="13.8" timestamp="2026-05-19T14:37:45.616" timestamp_utc="2026-05-19T13:37:45.616" last_modified="2026-05-19T14:37:48" version="1779197868049">
+      <Q id="6428662673" qualifier_id="2"/>
+      <Q id="6428662677" qualifier_id="56" value="Center"/>
+      <Q id="6428662679" qualifier_id="140" value="90.3"/>
+      <Q id="6428662681" qualifier_id="141" value="50.4"/>
+      <Q id="6428662675" qualifier_id="155"/>
+      <Q id="6428662683" qualifier_id="212" value="25.6"/>
+      <Q id="6428662685" qualifier_id="213" value="1.33"/>
+    </Event>
+    <Event id="2939840659" event_id="623" type_id="44" period_id="2" min="59" sec="46" player_id="627127" team_id="244" outcome="1" x="9.7" y="49.6" timestamp="2026-05-19T14:37:47.416" timestamp_utc="2026-05-19T13:37:47.416" last_modified="2026-05-19T15:45:44" version="1779201944314">
+      <Q id="6428662689" qualifier_id="56" value="Back"/>
+      <Q id="6428662751" qualifier_id="233" value="497"/>
+      <Q id="6428662691" qualifier_id="285"/>
+    </Event>
+    <Event id="2939840665" event_id="497" type_id="44" period_id="2" min="59" sec="46" player_id="531784" team_id="417" outcome="0" x="90.3" y="50.4" timestamp="2026-05-19T14:37:47.417" timestamp_utc="2026-05-19T13:37:47.417" last_modified="2026-05-19T15:45:44" version="1779201944615">
+      <Q id="6428662715" qualifier_id="56" value="Center"/>
+      <Q id="6428662765" qualifier_id="233" value="623"/>
+      <Q id="6428662717" qualifier_id="286"/>
+    </Event>
+    <Event id="2939840661" event_id="624" type_id="12" period_id="2" min="59" sec="47" player_id="627127" team_id="244" outcome="1" x="9.7" y="49.6" timestamp="2026-05-19T14:37:47.920" timestamp_utc="2026-05-19T13:37:47.920" last_modified="2026-05-19T15:45:45" version="1779201944880">
+      <Q id="6428662719" qualifier_id="15"/>
+      <Q id="6428662693" qualifier_id="56" value="Back"/>
+      <Q id="6428662695" qualifier_id="140" value="27.6"/>
+      <Q id="6428662697" qualifier_id="141" value="46.3"/>
+      <Q id="6428662699" qualifier_id="212" value="18.9"/>
+      <Q id="6428662701" qualifier_id="213" value="6.16"/>
+    </Event>
+    <Event id="2939840675" event_id="498" type_id="1" period_id="2" min="59" sec="48" player_id="218339" team_id="417" outcome="1" x="74.9" y="46.6" keypass="1" timestamp="2026-05-19T14:37:49.537" timestamp_utc="2026-05-19T13:37:49.537" last_modified="2026-05-19T14:38:11" version="1779197891524">
+      <Q id="6428662787" qualifier_id="56" value="Center"/>
+      <Q id="6428662789" qualifier_id="140" value="76.4"/>
+      <Q id="6428662791" qualifier_id="141" value="56.9"/>
+      <Q id="6428663521" qualifier_id="154"/>
+      <Q id="6428663519" qualifier_id="210" value="15"/>
+      <Q id="6428662793" qualifier_id="212" value="7.2"/>
+      <Q id="6428662795" qualifier_id="213" value="1.35"/>
+    </Event>
+    <Event id="2939840711" event_id="499" type_id="15" period_id="2" min="59" sec="51" player_id="61778" team_id="417" outcome="1" x="78.4" y="63.4" timestamp="2026-05-19T14:37:52.012" timestamp_utc="2026-05-19T13:37:52.012" last_modified="2026-05-19T15:59:54" version="1779202793849">
+      <Q id="6428662975" qualifier_id="18"/>
+      <Q id="6428663445" qualifier_id="20"/>
+      <Q id="6428663443" qualifier_id="25"/>
+      <Q id="6428663527" qualifier_id="29"/>
+      <Q id="6428663531" qualifier_id="55" value="498"/>
+      <Q id="6428662977" qualifier_id="56" value="Center"/>
+      <Q id="6428663525" qualifier_id="78"/>
+      <Q id="6428663449" qualifier_id="82"/>
+      <Q id="6428663535" qualifier_id="102" value="49.9"/>
+      <Q id="6428663537" qualifier_id="103" value="19.0"/>
+      <Q id="6428663539" qualifier_id="146" value="81.4"/>
+      <Q id="6428663541" qualifier_id="147" value="61.6"/>
+      <Q id="6428663529" qualifier_id="154"/>
+      <Q id="6428663543" qualifier_id="230" value="98.1"/>
+      <Q id="6428663545" qualifier_id="231" value="52.0"/>
+      <Q id="6428663547" qualifier_id="233" value="625"/>
+    </Event>
+    <Event id="2939840707" event_id="625" type_id="10" period_id="2" min="59" sec="51" player_id="232091" team_id="244" outcome="1" x="18.6" y="38.4" timestamp="2026-05-19T14:37:52.112" timestamp_utc="2026-05-19T13:37:52.112" last_modified="2026-05-19T14:51:59" version="1779198719221">
+      <Q id="6428662953" qualifier_id="56" value="Back"/>
+      <Q id="6428662951" qualifier_id="94"/>
+      <Q id="6428663563" qualifier_id="233" value="499"/>
+    </Event>
+    <Event id="2939840727" event_id="500" type_id="44" period_id="2" min="59" sec="54" player_id="164593" team_id="417" outcome="1" x="81.8" y="35.8" timestamp="2026-05-19T14:37:55.423" timestamp_utc="2026-05-19T13:37:55.423" last_modified="2026-05-19T15:26:49" version="1779200797897">
+      <Q id="6428663083" qualifier_id="56" value="Center"/>
+      <Q id="6428663179" qualifier_id="233" value="626"/>
+      <Q id="6428663085" qualifier_id="286"/>
+    </Event>
+    <Event id="2939840743" event_id="626" type_id="44" period_id="2" min="59" sec="54" player_id="648131" team_id="244" outcome="0" x="18.2" y="64.2" timestamp="2026-05-19T14:37:55.424" timestamp_utc="2026-05-19T13:37:55.424" last_modified="2026-05-19T15:26:50" version="1779200797910">
+      <Q id="6428663159" qualifier_id="56" value="Back"/>
+      <Q id="6428663171" qualifier_id="233" value="500"/>
+      <Q id="6428663161" qualifier_id="285"/>
+    </Event>
+    <Event id="2939840731" event_id="501" type_id="61" period_id="2" min="59" sec="55" player_id="164593" team_id="417" outcome="1" x="79.5" y="31.6" timestamp="2026-05-19T14:37:56.104" timestamp_utc="2026-05-19T13:37:56.104" last_modified="2026-05-19T15:26:04" version="1779200764088">
+      <Q id="6428663103" qualifier_id="56" value="Center"/>
+    </Event>
+    <Event id="2939840745" event_id="627" type_id="61" period_id="2" min="59" sec="57" player_id="648131" team_id="244" outcome="1" x="14.3" y="57.2" timestamp="2026-05-19T14:37:57.723" timestamp_utc="2026-05-19T13:37:57.723" last_modified="2026-05-19T14:44:39" version="1779198279580">
+      <Q id="6428663163" qualifier_id="56" value="Back"/>
+    </Event>
+    <Event id="2939840753" event_id="502" type_id="13" period_id="2" min="59" sec="59" player_id="685390" team_id="417" outcome="1" x="86.2" y="29.1" timestamp="2026-05-19T14:37:59.760" timestamp_utc="2026-05-19T13:37:59.760" last_modified="2026-05-19T16:01:02" version="1779202862760">
+      <Q id="6428663579" qualifier_id="20"/>
+      <Q id="6428663673" qualifier_id="25"/>
+      <Q id="6428663235" qualifier_id="56" value="Center"/>
+      <Q id="6428663233" qualifier_id="63"/>
+      <Q id="6428663675" qualifier_id="77"/>
+      <Q id="6428663677" qualifier_id="102" value="61.2"/>
+      <Q id="6428663679" qualifier_id="103" value="93.1"/>
+      <Q id="6428663683" qualifier_id="230" value="98.4"/>
+      <Q id="6428663685" qualifier_id="231" value="48.7"/>
+      <Q id="6428663681" qualifier_id="458"/>
+    </Event>
+    <Event id="2939840761" event_id="628" type_id="5" period_id="2" min="60" sec="0" player_id="648131" team_id="244" outcome="1" x="-0.8" y="38.2" timestamp="2026-05-19T14:38:00.593" timestamp_utc="2026-05-19T13:38:00.593" last_modified="2026-05-19T14:46:12" version="1779198372684">
+      <Q id="6428663269" qualifier_id="56" value="Back"/>
+      <Q id="6428663441" qualifier_id="233" value="503"/>
+      <Q id="6428663271" qualifier_id="346"/>
+    </Event>
+    <Event id="2939840783" event_id="503" type_id="5" period_id="2" min="60" sec="0" player_id="685390" team_id="417" outcome="0" x="100.8" y="61.7" timestamp="2026-05-19T14:38:00.593" timestamp_utc="2026-05-19T13:38:00.593" last_modified="2026-05-19T15:26:33" version="1779200790166">
+      <Q id="6428663435" qualifier_id="56" value="Center"/>
+      <Q id="6428663455" qualifier_id="233" value="628"/>
+      <Q id="6428663437" qualifier_id="346"/>
+    </Event>
+    <Event id="2939840773" event_id="629" type_id="1" period_id="2" min="60" sec="2" player_id="578592" team_id="244" outcome="1" x="1.9" y="41.2" timestamp="2026-05-19T14:38:02.776" timestamp_utc="2026-05-19T13:38:02.776" last_modified="2026-05-19T14:38:03" version="1779197883090">
+      <Q id="6428663375" qualifier_id="56" value="Back"/>
+      <Q id="6428663373" qualifier_id="124"/>
+      <Q id="6428663377" qualifier_id="140" value="8.7"/>
+      <Q id="6428663379" qualifier_id="141" value="13.1"/>
+      <Q id="6428663381" qualifier_id="212" value="20.4"/>
+      <Q id="6428663383" qualifier_id="213" value="5.07"/>
+      <Q id="6428663387" qualifier_id="237"/>
+    </Event>
+    <Event id="2939840789" event_id="630" type_id="1" period_id="2" min="60" sec="2" player_id="240166" team_id="244" outcome="1" x="8.7" y="13.1" timestamp="2026-05-19T14:38:03.528" timestamp_utc="2026-05-19T13:38:03.528" last_modified="2026-05-19T14:38:10" version="1779197883780">
+      <Q id="6428663477" qualifier_id="56" value="Back"/>
+      <Q id="6428663479" qualifier_id="140" value="23.9"/>
+      <Q id="6428663481" qualifier_id="141" value="13.1"/>
+      <Q id="6428663483" qualifier_id="212" value="16.0"/>
+      <Q id="6428663485" qualifier_id="213" value="0.00"/>
+    </Event>
+    <Event id="2939840791" event_id="631" type_id="1" period_id="2" min="60" sec="7" player_id="625775" team_id="244" outcome="1" x="26.1" y="11.9" timestamp="2026-05-19T14:38:08.025" timestamp_utc="2026-05-19T13:38:08.025" last_modified="2026-05-19T14:38:10" version="1779197888514">
+      <Q id="6428663493" qualifier_id="56" value="Back"/>
+      <Q id="6428663495" qualifier_id="140" value="15.8"/>
+      <Q id="6428663497" qualifier_id="141" value="10.9"/>
+      <Q id="6428663499" qualifier_id="212" value="10.8"/>
+      <Q id="6428663501" qualifier_id="213" value="3.20"/>
+    </Event>
+    <Event id="2939840795" event_id="632" type_id="1" period_id="2" min="60" sec="9" player_id="240166" team_id="244" outcome="1" x="16.5" y="11.6" timestamp="2026-05-19T14:38:09.770" timestamp_utc="2026-05-19T13:38:09.770" last_modified="2026-05-19T14:38:12" version="1779197890081">
+      <Q id="6428663551" qualifier_id="56" value="Back"/>
+      <Q id="6428663553" qualifier_id="140" value="13.3"/>
+      <Q id="6428663555" qualifier_id="141" value="27.0"/>
+      <Q id="6428663557" qualifier_id="212" value="11.0"/>
+      <Q id="6428663559" qualifier_id="213" value="1.88"/>
+    </Event>
+    <Event id="2939840815" event_id="633" type_id="1" period_id="2" min="60" sec="11" player_id="627127" team_id="244" outcome="1" x="14.1" y="29.7" timestamp="2026-05-19T14:38:12.152" timestamp_utc="2026-05-19T13:38:12.152" last_modified="2026-05-19T14:38:18" version="1779197892730">
+      <Q id="6428663727" qualifier_id="56" value="Back"/>
+      <Q id="6428663729" qualifier_id="140" value="14.6"/>
+      <Q id="6428663731" qualifier_id="141" value="52.7"/>
+      <Q id="6428663733" qualifier_id="212" value="15.6"/>
+      <Q id="6428663735" qualifier_id="213" value="1.54"/>
+    </Event>
+    <Event id="2939840827" event_id="634" type_id="1" period_id="2" min="60" sec="18" player_id="578592" team_id="244" outcome="1" x="21.2" y="59.3" timestamp="2026-05-19T14:38:18.760" timestamp_utc="2026-05-19T13:38:18.760" last_modified="2026-05-19T14:38:22" version="1779197900146">
+      <Q id="6428663791" qualifier_id="56" value="Back"/>
+      <Q id="6428663793" qualifier_id="140" value="25.5"/>
+      <Q id="6428663795" qualifier_id="141" value="89.9"/>
+      <Q id="6428663797" qualifier_id="212" value="21.3"/>
+      <Q id="6428663799" qualifier_id="213" value="1.36"/>
+    </Event>
+    <Event id="2939840845" event_id="635" type_id="1" period_id="2" min="60" sec="22" player_id="575855" team_id="244" outcome="1" x="26.0" y="89.4" timestamp="2026-05-19T14:38:22.720" timestamp_utc="2026-05-19T13:38:22.720" last_modified="2026-05-19T14:38:30" version="1779197903811">
+      <Q id="6428663911" qualifier_id="56" value="Back"/>
+      <Q id="6428663913" qualifier_id="140" value="9.5"/>
+      <Q id="6428663915" qualifier_id="141" value="59.9"/>
+      <Q id="6428663917" qualifier_id="212" value="26.5"/>
+      <Q id="6428663919" qualifier_id="213" value="4.00"/>
+    </Event>
+    <Event id="2939840857" event_id="636" type_id="1" period_id="2" min="60" sec="30" player_id="578592" team_id="244" outcome="0" x="18.2" y="56.0" timestamp="2026-05-19T14:38:30.769" timestamp_utc="2026-05-19T13:38:30.769" last_modified="2026-05-19T14:38:34" version="1779197913706">
+      <Q id="6428664009" qualifier_id="1"/>
+      <Q id="6428663999" qualifier_id="56" value="Center"/>
+      <Q id="6428664001" qualifier_id="140" value="67.3"/>
+      <Q id="6428664003" qualifier_id="141" value="65.4"/>
+      <Q id="6428663997" qualifier_id="157"/>
+      <Q id="6428664005" qualifier_id="212" value="51.9"/>
+      <Q id="6428664007" qualifier_id="213" value="0.12"/>
+    </Event>
+    <Event id="2939840861" event_id="504" type_id="44" period_id="2" min="60" sec="32" player_id="531784" team_id="417" outcome="1" x="32.7" y="34.6" timestamp="2026-05-19T14:38:33.439" timestamp_utc="2026-05-19T13:38:33.439" last_modified="2026-05-19T15:45:45" version="1779201945149">
+      <Q id="6428664017" qualifier_id="56" value="Back"/>
+      <Q id="6428664047" qualifier_id="233" value="637"/>
+      <Q id="6428664019" qualifier_id="285"/>
+    </Event>
+    <Event id="2939840859" event_id="637" type_id="44" period_id="2" min="60" sec="32" player_id="232091" team_id="244" outcome="0" x="67.3" y="65.4" timestamp="2026-05-19T14:38:33.440" timestamp_utc="2026-05-19T13:38:33.440" last_modified="2026-05-19T15:45:45" version="1779201945415">
+      <Q id="6428664013" qualifier_id="56" value="Center"/>
+      <Q id="6428664063" qualifier_id="233" value="504"/>
+      <Q id="6428664015" qualifier_id="286"/>
+    </Event>
+    <Event id="2939840881" event_id="505" type_id="1" period_id="2" min="60" sec="33" player_id="531784" team_id="417" outcome="1" x="32.7" y="34.6" timestamp="2026-05-19T14:38:34.272" timestamp_utc="2026-05-19T13:38:34.272" last_modified="2026-05-19T15:45:45" version="1779201945683">
+      <Q id="6428664149" qualifier_id="3"/>
+      <Q id="6428664151" qualifier_id="56" value="Back"/>
+      <Q id="6428664153" qualifier_id="140" value="37.1"/>
+      <Q id="6428664155" qualifier_id="141" value="42.8"/>
+      <Q id="6428664157" qualifier_id="212" value="7.2"/>
+      <Q id="6428664159" qualifier_id="213" value="0.88"/>
+    </Event>
+    <Event id="2939840887" event_id="506" type_id="49" period_id="2" min="60" sec="35" player_id="218339" team_id="417" outcome="1" x="37.1" y="42.8" timestamp="2026-05-19T14:38:35.960" timestamp_utc="2026-05-19T13:38:35.960" last_modified="2026-05-19T14:38:36" version="1779197915961"/>
+    <Event id="2939840895" event_id="507" type_id="1" period_id="2" min="60" sec="35" player_id="218339" team_id="417" outcome="1" x="37.1" y="42.8" timestamp="2026-05-19T14:38:36.177" timestamp_utc="2026-05-19T13:38:36.177" last_modified="2026-05-19T14:38:37" version="1779197916362">
+      <Q id="6428664223" qualifier_id="56" value="Center"/>
+      <Q id="6428664225" qualifier_id="140" value="61.1"/>
+      <Q id="6428664227" qualifier_id="141" value="38.0"/>
+      <Q id="6428664229" qualifier_id="212" value="25.4"/>
+      <Q id="6428664231" qualifier_id="213" value="6.15"/>
+    </Event>
+    <Event id="2939840899" event_id="508" type_id="1" period_id="2" min="60" sec="36" player_id="445539" team_id="417" outcome="1" x="59.0" y="37.7" timestamp="2026-05-19T14:38:37.177" timestamp_utc="2026-05-19T13:38:37.177" last_modified="2026-05-19T14:38:38" version="1779197917754">
+      <Q id="6428664237" qualifier_id="56" value="Center"/>
+      <Q id="6428664239" qualifier_id="140" value="55.7"/>
+      <Q id="6428664241" qualifier_id="141" value="29.1"/>
+      <Q id="6428664249" qualifier_id="156"/>
+      <Q id="6428664243" qualifier_id="212" value="6.8"/>
+      <Q id="6428664245" qualifier_id="213" value="4.18"/>
+    </Event>
+    <Event id="2939840913" event_id="509" type_id="1" period_id="2" min="60" sec="38" player_id="685390" team_id="417" outcome="0" x="55.7" y="28.5" timestamp="2026-05-19T14:38:39.496" timestamp_utc="2026-05-19T13:38:39.496" last_modified="2026-05-19T14:38:40" version="1779197920216">
+      <Q id="6428664357" qualifier_id="56" value="Center"/>
+      <Q id="6428664359" qualifier_id="140" value="66.4"/>
+      <Q id="6428664361" qualifier_id="141" value="30.7"/>
+      <Q id="6428664353" qualifier_id="155"/>
+      <Q id="6428664363" qualifier_id="212" value="11.3"/>
+      <Q id="6428664365" qualifier_id="213" value="0.13"/>
+    </Event>
+    <Event id="2939840921" event_id="638" type_id="49" period_id="2" min="60" sec="41" player_id="578592" team_id="244" outcome="1" x="9.7" y="61.8" timestamp="2026-05-19T14:38:42.016" timestamp_utc="2026-05-19T13:38:42.016" last_modified="2026-05-19T14:38:42" version="1779197922017"/>
+    <Event id="2939840943" event_id="639" type_id="1" period_id="2" min="60" sec="45" player_id="578592" team_id="244" outcome="1" x="10.7" y="61.7" timestamp="2026-05-19T14:38:46.360" timestamp_utc="2026-05-19T13:38:46.360" last_modified="2026-05-19T14:38:47" version="1779197926800">
+      <Q id="6428664523" qualifier_id="56" value="Back"/>
+      <Q id="6428664525" qualifier_id="140" value="25.3"/>
+      <Q id="6428664527" qualifier_id="141" value="75.9"/>
+      <Q id="6428664529" qualifier_id="212" value="18.1"/>
+      <Q id="6428664531" qualifier_id="213" value="0.56"/>
+    </Event>
+    <Event id="2939840955" event_id="640" type_id="1" period_id="2" min="60" sec="46" player_id="575855" team_id="244" outcome="1" x="25.3" y="75.9" timestamp="2026-05-19T14:38:47.312" timestamp_utc="2026-05-19T13:38:47.312" last_modified="2026-05-19T14:38:50" version="1779197927874">
+      <Q id="6428664605" qualifier_id="56" value="Back"/>
+      <Q id="6428664607" qualifier_id="140" value="13.1"/>
+      <Q id="6428664609" qualifier_id="141" value="52.8"/>
+      <Q id="6428664611" qualifier_id="212" value="20.3"/>
+      <Q id="6428664613" qualifier_id="213" value="4.03"/>
+    </Event>
+    <Event id="2939840967" event_id="641" type_id="1" period_id="2" min="60" sec="49" player_id="627127" team_id="244" outcome="1" x="12.1" y="54.5" timestamp="2026-05-19T14:38:50.488" timestamp_utc="2026-05-19T13:38:50.488" last_modified="2026-05-19T14:38:52" version="1779197931553">
+      <Q id="6428664663" qualifier_id="56" value="Back"/>
+      <Q id="6428664665" qualifier_id="140" value="2.8"/>
+      <Q id="6428664667" qualifier_id="141" value="63.9"/>
+      <Q id="6428664669" qualifier_id="212" value="11.7"/>
+      <Q id="6428664671" qualifier_id="213" value="2.56"/>
+    </Event>
+    <Event id="2939840993" event_id="642" type_id="1" period_id="2" min="60" sec="51" player_id="578592" team_id="244" outcome="1" x="2.9" y="63.9" timestamp="2026-05-19T14:38:52.544" timestamp_utc="2026-05-19T13:38:52.544" last_modified="2026-05-19T14:38:58" version="1779197937265">
+      <Q id="6428664813" qualifier_id="1"/>
+      <Q id="6428664803" qualifier_id="56" value="Center"/>
+      <Q id="6428664805" qualifier_id="140" value="59.2"/>
+      <Q id="6428664807" qualifier_id="141" value="74.8"/>
+      <Q id="6428664801" qualifier_id="157"/>
+      <Q id="6428664809" qualifier_id="212" value="59.6"/>
+      <Q id="6428664811" qualifier_id="213" value="0.12"/>
+    </Event>
+    <Event id="2939840999" event_id="643" type_id="1" period_id="2" min="60" sec="58" player_id="648131" team_id="244" outcome="0" x="58.9" y="75.0" timestamp="2026-05-19T14:38:58.832" timestamp_utc="2026-05-19T13:38:58.832" last_modified="2026-05-19T14:39:54" version="1779197994398">
+      <Q id="6428664877" qualifier_id="1"/>
+      <Q id="6428664867" qualifier_id="56" value="Center"/>
+      <Q id="6428664869" qualifier_id="140" value="81.2"/>
+      <Q id="6428664871" qualifier_id="141" value="42.2"/>
+      <Q id="6428664865" qualifier_id="155"/>
+      <Q id="6428664873" qualifier_id="212" value="32.3"/>
+      <Q id="6428664875" qualifier_id="213" value="5.52"/>
+    </Event>
+    <Event id="2939840995" event_id="511" type_id="43" period_id="2" min="60" sec="58" player_id="531784" team_id="417" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T14:38:58.888" timestamp_utc="2026-05-19T13:38:58.888" last_modified="2026-05-19T14:54:51" version="1779197941292">
+      <Q id="6428692535" qualifier_id="144" value="83"/>
+    </Event>
+    <Event id="2939841005" event_id="512" type_id="49" period_id="2" min="61" sec="2" player_id="624620" team_id="417" outcome="1" x="5.9" y="57.5" timestamp="2026-05-19T14:39:02.720" timestamp_utc="2026-05-19T13:39:02.720" last_modified="2026-05-19T14:39:02" version="1779197942721"/>
+    <Event id="2939841013" event_id="513" type_id="1" period_id="2" min="61" sec="2" player_id="624620" team_id="417" outcome="1" x="19.8" y="72.7" timestamp="2026-05-19T14:39:02.945" timestamp_utc="2026-05-19T13:39:02.945" last_modified="2026-05-19T14:39:05" version="1779197943113">
+      <Q id="6428664969" qualifier_id="56" value="Back"/>
+      <Q id="6428664971" qualifier_id="140" value="8.2"/>
+      <Q id="6428664973" qualifier_id="141" value="50.9"/>
+      <Q id="6428664975" qualifier_id="212" value="19.2"/>
+      <Q id="6428664977" qualifier_id="213" value="4.02"/>
+    </Event>
+    <Event id="2939841029" event_id="514" type_id="1" period_id="2" min="61" sec="4" player_id="565487" team_id="417" outcome="0" x="8.7" y="50.3" timestamp="2026-05-19T14:39:05.432" timestamp_utc="2026-05-19T13:39:05.432" last_modified="2026-05-19T14:39:06" version="1779197946849">
+      <Q id="6428665061" qualifier_id="1"/>
+      <Q id="6428665051" qualifier_id="56" value="Center"/>
+      <Q id="6428665053" qualifier_id="140" value="50.1"/>
+      <Q id="6428665055" qualifier_id="141" value="42.5"/>
+      <Q id="6428665049" qualifier_id="157"/>
+      <Q id="6428665057" qualifier_id="212" value="43.8"/>
+      <Q id="6428665059" qualifier_id="213" value="6.16"/>
+    </Event>
+    <Event id="2939841039" event_id="644" type_id="1" period_id="2" min="61" sec="7" player_id="180662" team_id="244" outcome="0" x="36.5" y="57.6" timestamp="2026-05-19T14:39:08.009" timestamp_utc="2026-05-19T13:39:08.009" last_modified="2026-05-19T14:39:08" version="1779197948545">
+      <Q id="6428665125" qualifier_id="3"/>
+      <Q id="6428665127" qualifier_id="56" value="Center"/>
+      <Q id="6428665129" qualifier_id="140" value="58.4"/>
+      <Q id="6428665131" qualifier_id="141" value="65.8"/>
+      <Q id="6428665133" qualifier_id="212" value="23.7"/>
+      <Q id="6428665135" qualifier_id="213" value="0.24"/>
+    </Event>
+    <Event id="2939841049" event_id="515" type_id="1" period_id="2" min="61" sec="9" player_id="531784" team_id="417" outcome="1" x="34.0" y="22.5" timestamp="2026-05-19T14:39:09.777" timestamp_utc="2026-05-19T13:39:09.777" last_modified="2026-05-19T14:39:25" version="1779197965135">
+      <Q id="6428665177" qualifier_id="3"/>
+      <Q id="6428665179" qualifier_id="56" value="Center"/>
+      <Q id="6428665181" qualifier_id="140" value="60.9"/>
+      <Q id="6428665183" qualifier_id="141" value="27.7"/>
+      <Q id="6428665185" qualifier_id="212" value="28.5"/>
+      <Q id="6428665187" qualifier_id="213" value="0.12"/>
+    </Event>
+    <Event id="2939841063" event_id="516" type_id="61" period_id="2" min="61" sec="13" player_id="445539" team_id="417" outcome="0" x="61.5" y="28.2" timestamp="2026-05-19T14:39:14.000" timestamp_utc="2026-05-19T13:39:14.000" last_modified="2026-05-19T14:39:14" version="1779197954001">
+      <Q id="6428665271" qualifier_id="56" value="Center"/>
+    </Event>
+    <Event id="2939841075" event_id="645" type_id="3" period_id="2" min="61" sec="16" player_id="575855" team_id="244" outcome="0" x="37.2" y="75.6" timestamp="2026-05-19T14:39:16.744" timestamp_utc="2026-05-19T13:39:16.744" last_modified="2026-05-19T14:40:34" version="1779198034510">
+      <Q id="6428665349" qualifier_id="56" value="Back"/>
+      <Q id="6428665425" qualifier_id="233" value="517"/>
+      <Q id="6428665351" qualifier_id="286"/>
+    </Event>
+    <Event id="2939841083" event_id="517" type_id="7" period_id="2" min="61" sec="16" player_id="157851" team_id="417" outcome="0" x="62.7" y="24.4" timestamp="2026-05-19T14:39:16.745" timestamp_utc="2026-05-19T13:39:16.745" last_modified="2026-05-19T15:25:22" version="1779200722673">
+      <Q id="6428665393" qualifier_id="56" value="Center"/>
+      <Q id="6428665397" qualifier_id="178"/>
+      <Q id="6428665403" qualifier_id="233" value="645"/>
+      <Q id="6428665395" qualifier_id="285"/>
+    </Event>
+    <Event id="2939841101" event_id="646" type_id="4" period_id="2" min="61" sec="18" player_id="575855" team_id="244" outcome="1" x="37.2" y="78.6" timestamp="2026-05-19T14:39:19.304" timestamp_utc="2026-05-19T13:39:19.304" last_modified="2026-05-19T14:39:23" version="1779197961782">
+      <Q id="6428665517" qualifier_id="13"/>
+      <Q id="6428665519" qualifier_id="56" value="Back"/>
+      <Q id="6428665521" qualifier_id="152"/>
+      <Q id="6428665619" qualifier_id="233" value="518"/>
+      <Q id="6428665523" qualifier_id="265"/>
+      <Q id="6428665525" qualifier_id="286"/>
+    </Event>
+    <Event id="2939841109" event_id="518" type_id="4" period_id="2" min="61" sec="18" player_id="157851" team_id="417" outcome="0" x="62.8" y="21.4" timestamp="2026-05-19T14:39:19.305" timestamp_utc="2026-05-19T13:39:19.305" last_modified="2026-05-19T14:39:24" version="1779197961788">
+      <Q id="6428665585" qualifier_id="13"/>
+      <Q id="6428665587" qualifier_id="56" value="Center"/>
+      <Q id="6428665589" qualifier_id="152"/>
+      <Q id="6428665625" qualifier_id="233" value="646"/>
+      <Q id="6428665591" qualifier_id="265"/>
+      <Q id="6428665593" qualifier_id="285"/>
+    </Event>
+    <Event id="2939841343" event_id="647" type_id="1" period_id="2" min="62" sec="2" player_id="180662" team_id="244" outcome="1" x="35.3" y="70.3" timestamp="2026-05-19T14:40:03.416" timestamp_utc="2026-05-19T13:40:03.416" last_modified="2026-05-19T14:40:06" version="1779198003955">
+      <Q id="6428666849" qualifier_id="5"/>
+      <Q id="6428666853" qualifier_id="56" value="Back"/>
+      <Q id="6428666855" qualifier_id="140" value="33.9"/>
+      <Q id="6428666857" qualifier_id="141" value="55.1"/>
+      <Q id="6428666851" qualifier_id="152"/>
+      <Q id="6428666861" qualifier_id="212" value="10.4"/>
+      <Q id="6428666863" qualifier_id="213" value="4.57"/>
+    </Event>
+    <Event id="2939841347" event_id="648" type_id="1" period_id="2" min="62" sec="5" player_id="627127" team_id="244" outcome="1" x="33.5" y="57.9" timestamp="2026-05-19T14:40:06.007" timestamp_utc="2026-05-19T13:40:06.007" last_modified="2026-05-19T14:40:07" version="1779198006585">
+      <Q id="6428666895" qualifier_id="56" value="Back"/>
+      <Q id="6428666897" qualifier_id="140" value="38.2"/>
+      <Q id="6428666899" qualifier_id="141" value="74.4"/>
+      <Q id="6428666901" qualifier_id="212" value="12.3"/>
+      <Q id="6428666903" qualifier_id="213" value="1.16"/>
+    </Event>
+    <Event id="2939841355" event_id="649" type_id="1" period_id="2" min="62" sec="6" player_id="180662" team_id="244" outcome="1" x="38.2" y="74.4" timestamp="2026-05-19T14:40:06.959" timestamp_utc="2026-05-19T13:40:06.959" last_modified="2026-05-19T14:40:08" version="1779198007345">
+      <Q id="6428666931" qualifier_id="56" value="Back"/>
+      <Q id="6428666933" qualifier_id="140" value="41.1"/>
+      <Q id="6428666935" qualifier_id="141" value="90.2"/>
+      <Q id="6428666937" qualifier_id="212" value="11.2"/>
+      <Q id="6428666939" qualifier_id="213" value="1.29"/>
+    </Event>
+    <Event id="2939841367" event_id="650" type_id="1" period_id="2" min="62" sec="7" player_id="575855" team_id="244" outcome="1" x="41.1" y="90.2" timestamp="2026-05-19T14:40:08.376" timestamp_utc="2026-05-19T13:40:08.376" last_modified="2026-05-19T14:40:10" version="1779198008824">
+      <Q id="6428667033" qualifier_id="56" value="Left"/>
+      <Q id="6428667035" qualifier_id="140" value="57.0"/>
+      <Q id="6428667039" qualifier_id="141" value="88.7"/>
+      <Q id="6428667043" qualifier_id="212" value="16.7"/>
+      <Q id="6428667045" qualifier_id="213" value="6.22"/>
+    </Event>
+    <Event id="2939841379" event_id="651" type_id="1" period_id="2" min="62" sec="9" player_id="207884" team_id="244" outcome="0" x="57.9" y="88.6" timestamp="2026-05-19T14:40:10.264" timestamp_utc="2026-05-19T13:40:10.264" last_modified="2026-05-19T14:40:14" version="1779198014661">
+      <Q id="6428667115" qualifier_id="56" value="Center"/>
+      <Q id="6428667117" qualifier_id="140" value="84.1"/>
+      <Q id="6428667119" qualifier_id="141" value="67.5"/>
+      <Q id="6428667121" qualifier_id="212" value="31.0"/>
+      <Q id="6428667123" qualifier_id="213" value="5.80"/>
+    </Event>
+    <Event id="2939841391" event_id="521" type_id="43" period_id="2" min="62" sec="13" player_id="61812" team_id="417" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T14:40:14.270" timestamp_utc="2026-05-19T13:40:14.270" last_modified="2026-05-19T14:40:20" version="1779198014271">
+      <Q id="6428667169" qualifier_id="56" value="Back"/>
+      <Q id="6428667357" qualifier_id="144" value="61"/>
+    </Event>
+    <Event id="2939841401" event_id="522" type_id="52" period_id="2" min="62" sec="16" player_id="565487" team_id="417" outcome="1" x="12.5" y="34.6" timestamp="2026-05-19T14:40:16.695" timestamp_utc="2026-05-19T13:40:16.695" last_modified="2026-05-19T14:40:16" version="1779198016696"/>
+    <Event id="2939841419" event_id="523" type_id="1" period_id="2" min="62" sec="17" player_id="565487" team_id="417" outcome="1" x="12.5" y="34.6" timestamp="2026-05-19T14:40:17.679" timestamp_utc="2026-05-19T13:40:17.679" last_modified="2026-05-19T14:40:21" version="1779198018032">
+      <Q id="6428667369" qualifier_id="56" value="Back"/>
+      <Q id="6428667367" qualifier_id="123"/>
+      <Q id="6428667371" qualifier_id="140" value="30.8"/>
+      <Q id="6428667373" qualifier_id="141" value="26.8"/>
+      <Q id="6428667375" qualifier_id="212" value="19.9"/>
+      <Q id="6428667377" qualifier_id="213" value="6.01"/>
+    </Event>
+    <Event id="2939841451" event_id="524" type_id="1" period_id="2" min="62" sec="20" player_id="531784" team_id="417" outcome="1" x="33.5" y="12.0" timestamp="2026-05-19T14:40:21.552" timestamp_utc="2026-05-19T13:40:21.552" last_modified="2026-05-19T14:40:27" version="1779198021720">
+      <Q id="6428667517" qualifier_id="56" value="Back"/>
+      <Q id="6428667519" qualifier_id="140" value="36.2"/>
+      <Q id="6428667521" qualifier_id="141" value="24.4"/>
+      <Q id="6428667523" qualifier_id="212" value="8.9"/>
+      <Q id="6428667525" qualifier_id="213" value="1.25"/>
+    </Event>
+    <Event id="2939841421" event_id="652" type_id="83" period_id="2" min="62" sec="22" player_id="180662" team_id="244" outcome="0" x="59.5" y="78.7" timestamp="2026-05-19T14:40:22.615" timestamp_utc="2026-05-19T13:40:22.615" last_modified="2026-05-19T14:40:32" version="1779198032653">
+      <Q id="6428667685" qualifier_id="399" value="685390"/>
+    </Event>
+    <Event id="2939841437" event_id="653" type_id="43" period_id="2" min="62" sec="24" player_id="232091" team_id="244" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T14:40:24.688" timestamp_utc="2026-05-19T13:40:24.688" last_modified="2026-05-19T14:40:30" version="1779198024976">
+      <Q id="6428667459" qualifier_id="56" value="Center"/>
+      <Q id="6428667633" qualifier_id="144" value="7"/>
+      <Q id="6428667463" qualifier_id="178" value="0"/>
+      <Q id="6428667461" qualifier_id="285" value="0"/>
+    </Event>
+    <Event id="2939841455" event_id="525" type_id="4" period_id="2" min="62" sec="26" player_id="685390" team_id="417" outcome="1" x="40.2" y="29.6" timestamp="2026-05-19T14:40:26.806" timestamp_utc="2026-05-19T13:40:26.806" last_modified="2026-05-19T14:40:31" version="1779198030628">
+      <Q id="6428667569" qualifier_id="13"/>
+      <Q id="6428667571" qualifier_id="56" value="Back"/>
+      <Q id="6428667573" qualifier_id="152"/>
+      <Q id="6428667581" qualifier_id="233" value="654"/>
+      <Q id="6428667575" qualifier_id="265"/>
+      <Q id="6428667577" qualifier_id="286"/>
+    </Event>
+    <Event id="2939841447" event_id="654" type_id="4" period_id="2" min="62" sec="26" player_id="232091" team_id="244" outcome="0" x="59.8" y="70.4" timestamp="2026-05-19T14:40:26.807" timestamp_utc="2026-05-19T13:40:26.807" last_modified="2026-05-19T14:40:30" version="1779198028337">
+      <Q id="6428667545" qualifier_id="13"/>
+      <Q id="6428667547" qualifier_id="56" value="Center"/>
+      <Q id="6428667549" qualifier_id="152"/>
+      <Q id="6428667595" qualifier_id="233" value="525"/>
+      <Q id="6428667551" qualifier_id="265"/>
+      <Q id="6428667553" qualifier_id="285"/>
+    </Event>
+    <Event id="2939841559" event_id="526" type_id="1" period_id="2" min="62" sec="49" player_id="218339" team_id="417" outcome="1" x="44.4" y="31.0" timestamp="2026-05-19T14:40:50.312" timestamp_utc="2026-05-19T13:40:50.312" last_modified="2026-05-19T15:25:09" version="1779200709052">
+      <Q id="6428668193" qualifier_id="5"/>
+      <Q id="6428668197" qualifier_id="56" value="Back"/>
+      <Q id="6428668199" qualifier_id="140" value="38.5"/>
+      <Q id="6428668201" qualifier_id="141" value="24.7"/>
+      <Q id="6428668195" qualifier_id="152"/>
+      <Q id="6428668373" qualifier_id="189"/>
+      <Q id="6428668203" qualifier_id="212" value="7.5"/>
+      <Q id="6428668205" qualifier_id="213" value="3.75"/>
+    </Event>
+    <Event id="2939841561" event_id="527" type_id="1" period_id="2" min="62" sec="50" player_id="531784" team_id="417" outcome="1" x="38.6" y="24.3" timestamp="2026-05-19T14:40:50.914" timestamp_utc="2026-05-19T13:40:50.914" last_modified="2026-05-19T14:57:34" version="1779199054831">
+      <Q id="6428668223" qualifier_id="56" value="Back"/>
+      <Q id="6428668225" qualifier_id="140" value="39.1"/>
+      <Q id="6428668227" qualifier_id="141" value="43.6"/>
+      <Q id="6428668229" qualifier_id="212" value="13.1"/>
+      <Q id="6428668231" qualifier_id="213" value="1.53"/>
+    </Event>
+    <Event id="2939841579" event_id="528" type_id="1" period_id="2" min="62" sec="51" player_id="61812" team_id="417" outcome="0" x="39.1" y="40.1" timestamp="2026-05-19T14:40:52.008" timestamp_utc="2026-05-19T13:40:52.008" last_modified="2026-05-19T14:40:55" version="1779198055463">
+      <Q id="6428668291" qualifier_id="1"/>
+      <Q id="6428668281" qualifier_id="56" value="Left"/>
+      <Q id="6428668283" qualifier_id="140" value="59.9"/>
+      <Q id="6428668285" qualifier_id="141" value="100.0"/>
+      <Q id="6428668277" qualifier_id="155"/>
+      <Q id="6428668279" qualifier_id="196"/>
+      <Q id="6428668287" qualifier_id="212" value="46.5"/>
+      <Q id="6428668289" qualifier_id="213" value="1.08"/>
+    </Event>
+    <Event id="2939841583" event_id="529" type_id="5" period_id="2" min="62" sec="54" player_id="61812" team_id="417" outcome="0" x="61.3" y="100.6" timestamp="2026-05-19T14:40:55.468" timestamp_utc="2026-05-19T13:40:55.468" last_modified="2026-05-19T15:26:34" version="1779200790181">
+      <Q id="6428668305" qualifier_id="56" value="Left"/>
+      <Q id="6428668669" qualifier_id="233" value="655"/>
+      <Q id="6428668307" qualifier_id="347"/>
+    </Event>
+    <Event id="2939841645" event_id="655" type_id="5" period_id="2" min="62" sec="54" player_id="232091" team_id="244" outcome="1" x="38.7" y="-0.6" timestamp="2026-05-19T14:40:55.468" timestamp_utc="2026-05-19T13:40:55.468" last_modified="2026-05-19T15:26:34" version="1779200790174">
+      <Q id="6428668645" qualifier_id="56" value="Back"/>
+      <Q id="6428668661" qualifier_id="233" value="529"/>
+      <Q id="6428668647" qualifier_id="347"/>
+    </Event>
+    <Event id="2939841663" event_id="656" type_id="1" period_id="2" min="63" sec="11" player_id="240166" team_id="244" outcome="1" x="35.8" y="0.0" timestamp="2026-05-19T14:41:12.312" timestamp_utc="2026-05-19T13:41:12.312" last_modified="2026-05-19T14:41:15" version="1779198074202">
+      <Q id="6428668777" qualifier_id="56" value="Back"/>
+      <Q id="6428668775" qualifier_id="107"/>
+      <Q id="6428668779" qualifier_id="140" value="32.6"/>
+      <Q id="6428668781" qualifier_id="141" value="15.5"/>
+      <Q id="6428668783" qualifier_id="212" value="11.9"/>
+      <Q id="6428668785" qualifier_id="213" value="1.86"/>
+    </Event>
+    <Event id="2939841679" event_id="657" type_id="1" period_id="2" min="63" sec="14" player_id="515742" team_id="244" outcome="1" x="32.6" y="15.5" timestamp="2026-05-19T14:41:15.529" timestamp_utc="2026-05-19T13:41:15.529" last_modified="2026-05-19T14:41:17" version="1779198076825">
+      <Q id="6428668891" qualifier_id="1"/>
+      <Q id="6428668881" qualifier_id="56" value="Right"/>
+      <Q id="6428668883" qualifier_id="140" value="59.4"/>
+      <Q id="6428668885" qualifier_id="141" value="12.2"/>
+      <Q id="6428668879" qualifier_id="157"/>
+      <Q id="6428668887" qualifier_id="212" value="28.2"/>
+      <Q id="6428668889" qualifier_id="213" value="6.20"/>
+    </Event>
+    <Event id="2939841681" event_id="658" type_id="61" period_id="2" min="63" sec="17" player_id="479433" team_id="244" outcome="0" x="59.4" y="12.2" timestamp="2026-05-19T14:41:17.688" timestamp_utc="2026-05-19T13:41:17.688" last_modified="2026-05-19T14:41:18" version="1779198077689">
+      <Q id="6428668895" qualifier_id="56" value="Right"/>
+    </Event>
+    <Event id="2939841691" event_id="659" type_id="5" period_id="2" min="63" sec="18" player_id="479433" team_id="244" outcome="0" x="51.5" y="-2.0" timestamp="2026-05-19T14:41:18.575" timestamp_utc="2026-05-19T13:41:18.575" last_modified="2026-05-19T15:26:34" version="1779200790196">
+      <Q id="6428668919" qualifier_id="56" value="Right"/>
+      <Q id="6428668993" qualifier_id="233" value="530"/>
+      <Q id="6428668921" qualifier_id="347"/>
+    </Event>
+    <Event id="2939841705" event_id="530" type_id="5" period_id="2" min="63" sec="18" player_id="61812" team_id="417" outcome="1" x="48.5" y="102.0" timestamp="2026-05-19T14:41:18.575" timestamp_utc="2026-05-19T13:41:18.575" last_modified="2026-05-19T15:26:34" version="1779200790187">
+      <Q id="6428668973" qualifier_id="56" value="Back"/>
+      <Q id="6428668989" qualifier_id="233" value="659"/>
+      <Q id="6428668975" qualifier_id="347"/>
+    </Event>
+    <Event id="2939841725" event_id="531" type_id="1" period_id="2" min="63" sec="20" player_id="164593" team_id="417" outcome="1" x="45.9" y="100.0" timestamp="2026-05-19T14:41:21.366" timestamp_utc="2026-05-19T13:41:21.366" last_modified="2026-05-19T14:41:24" version="1779198082719">
+      <Q id="6428669111" qualifier_id="1"/>
+      <Q id="6428669101" qualifier_id="56" value="Back"/>
+      <Q id="6428669099" qualifier_id="107"/>
+      <Q id="6428669103" qualifier_id="140" value="27.6"/>
+      <Q id="6428669105" qualifier_id="141" value="87.4"/>
+      <Q id="6428669107" qualifier_id="212" value="21.4"/>
+      <Q id="6428669109" qualifier_id="213" value="3.60"/>
+    </Event>
+    <Event id="2939841763" event_id="532" type_id="1" period_id="2" min="63" sec="23" player_id="624620" team_id="417" outcome="1" x="28.5" y="79.3" timestamp="2026-05-19T14:41:24.302" timestamp_utc="2026-05-19T13:41:24.302" last_modified="2026-05-19T14:41:30" version="1779198086047">
+      <Q id="6428669313" qualifier_id="56" value="Back"/>
+      <Q id="6428669315" qualifier_id="140" value="30.9"/>
+      <Q id="6428669317" qualifier_id="141" value="32.5"/>
+      <Q id="6428669319" qualifier_id="212" value="31.9"/>
+      <Q id="6428669321" qualifier_id="213" value="4.79"/>
+    </Event>
+    <Event id="2939841785" event_id="533" type_id="1" period_id="2" min="63" sec="29" player_id="531784" team_id="417" outcome="1" x="31.6" y="28.9" timestamp="2026-05-19T14:41:29.950" timestamp_utc="2026-05-19T13:41:29.950" last_modified="2026-05-19T14:41:34" version="1779198092914">
+      <Q id="6428669453" qualifier_id="1"/>
+      <Q id="6428669443" qualifier_id="56" value="Right"/>
+      <Q id="6428669445" qualifier_id="140" value="76.3"/>
+      <Q id="6428669447" qualifier_id="141" value="11.1"/>
+      <Q id="6428669441" qualifier_id="155"/>
+      <Q id="6428669449" qualifier_id="212" value="48.5"/>
+      <Q id="6428669451" qualifier_id="213" value="6.03"/>
+    </Event>
+    <Event id="2939841787" event_id="534" type_id="61" period_id="2" min="63" sec="33" player_id="685390" team_id="417" outcome="0" x="75.4" y="12.2" timestamp="2026-05-19T14:41:34.112" timestamp_utc="2026-05-19T13:41:34.112" last_modified="2026-05-19T14:41:34" version="1779198094113">
+      <Q id="6428669457" qualifier_id="56" value="Right"/>
+    </Event>
+    <Event id="2939841797" event_id="660" type_id="1" period_id="2" min="63" sec="34" player_id="180662" team_id="244" outcome="1" x="17.0" y="79.9" timestamp="2026-05-19T14:41:34.800" timestamp_utc="2026-05-19T13:41:34.800" last_modified="2026-05-19T14:41:37" version="1779198095153">
+      <Q id="6428669509" qualifier_id="56" value="Back"/>
+      <Q id="6428669511" qualifier_id="140" value="24.7"/>
+      <Q id="6428669513" qualifier_id="141" value="91.4"/>
+      <Q id="6428669515" qualifier_id="212" value="11.2"/>
+      <Q id="6428669517" qualifier_id="213" value="0.77"/>
+    </Event>
+    <Event id="2939841801" event_id="661" type_id="49" period_id="2" min="63" sec="36" player_id="575855" team_id="244" outcome="1" x="24.8" y="91.4" timestamp="2026-05-19T14:41:36.904" timestamp_utc="2026-05-19T13:41:36.904" last_modified="2026-05-19T14:41:37" version="1779198096905"/>
+    <Event id="2939841807" event_id="662" type_id="1" period_id="2" min="63" sec="37" player_id="575855" team_id="244" outcome="1" x="24.8" y="91.4" timestamp="2026-05-19T14:41:38.184" timestamp_utc="2026-05-19T13:41:38.184" last_modified="2026-05-19T14:41:39" version="1779198098506">
+      <Q id="6428669567" qualifier_id="56" value="Back"/>
+      <Q id="6428669569" qualifier_id="140" value="15.6"/>
+      <Q id="6428669571" qualifier_id="141" value="81.4"/>
+      <Q id="6428669573" qualifier_id="212" value="11.8"/>
+      <Q id="6428669575" qualifier_id="213" value="3.75"/>
+    </Event>
+    <Event id="2939841813" event_id="663" type_id="1" period_id="2" min="63" sec="39" player_id="180662" team_id="244" outcome="1" x="15.6" y="81.4" timestamp="2026-05-19T14:41:39.680" timestamp_utc="2026-05-19T13:41:39.680" last_modified="2026-05-19T14:41:43" version="1779198102523">
+      <Q id="6428669623" qualifier_id="1"/>
+      <Q id="6428669613" qualifier_id="56" value="Back"/>
+      <Q id="6428669615" qualifier_id="140" value="43.4"/>
+      <Q id="6428669617" qualifier_id="141" value="67.9"/>
+      <Q id="6428669611" qualifier_id="157"/>
+      <Q id="6428669619" qualifier_id="212" value="30.6"/>
+      <Q id="6428669621" qualifier_id="213" value="5.98"/>
+    </Event>
+    <Event id="2939841817" event_id="664" type_id="1" period_id="2" min="63" sec="42" player_id="232091" team_id="244" outcome="0" x="43.4" y="67.9" timestamp="2026-05-19T14:41:42.879" timestamp_utc="2026-05-19T13:41:42.879" last_modified="2026-05-19T15:23:58" version="1779200638652">
+      <Q id="6428669639" qualifier_id="3"/>
+      <Q id="6428669641" qualifier_id="56" value="Back"/>
+      <Q id="6428669643" qualifier_id="140" value="46.3"/>
+      <Q id="6428669645" qualifier_id="141" value="63.3"/>
+      <Q id="6428669647" qualifier_id="212" value="4.4"/>
+      <Q id="6428669649" qualifier_id="213" value="5.48"/>
+    </Event>
+    <Event id="2939841821" event_id="535" type_id="61" period_id="2" min="63" sec="44" player_id="720682" team_id="417" outcome="1" x="61.6" y="18.6" timestamp="2026-05-19T14:41:44.664" timestamp_utc="2026-05-19T13:41:44.664" last_modified="2026-05-19T14:41:44" version="1779198104665">
+      <Q id="6428669655" qualifier_id="56" value="Right"/>
+    </Event>
+    <Event id="2939841827" event_id="536" type_id="1" period_id="2" min="63" sec="45" player_id="218339" team_id="417" outcome="1" x="60.0" y="10.1" timestamp="2026-05-19T14:41:45.902" timestamp_utc="2026-05-19T13:41:45.902" last_modified="2026-05-19T14:41:47" version="1779198106056">
+      <Q id="6428669701" qualifier_id="1"/>
+      <Q id="6428669691" qualifier_id="56" value="Center"/>
+      <Q id="6428669693" qualifier_id="140" value="72.9"/>
+      <Q id="6428669695" qualifier_id="141" value="26.7"/>
+      <Q id="6428669689" qualifier_id="157"/>
+      <Q id="6428669697" qualifier_id="212" value="17.6"/>
+      <Q id="6428669699" qualifier_id="213" value="0.69"/>
+    </Event>
+    <Event id="2939841829" event_id="537" type_id="1" period_id="2" min="63" sec="47" player_id="61778" team_id="417" outcome="0" x="70.5" y="27.0" timestamp="2026-05-19T14:41:47.607" timestamp_utc="2026-05-19T13:41:47.607" last_modified="2026-05-19T14:44:09" version="1779198249666">
+      <Q id="6428669705" qualifier_id="56" value="Center"/>
+      <Q id="6428669707" qualifier_id="140" value="69.5"/>
+      <Q id="6428669709" qualifier_id="141" value="26.1"/>
+      <Q id="6428669711" qualifier_id="212" value="1.2"/>
+      <Q id="6428669713" qualifier_id="213" value="3.67"/>
+      <Q id="6428669719" qualifier_id="233" value="665"/>
+      <Q id="6428669717" qualifier_id="236"/>
+      <Q id="6428669723" qualifier_id="286"/>
+    </Event>
+    <Event id="2939841825" event_id="665" type_id="74" period_id="2" min="63" sec="47" player_id="207884" team_id="244" outcome="1" x="30.5" y="73.9" timestamp="2026-05-19T14:41:47.608" timestamp_utc="2026-05-19T13:41:47.608" last_modified="2026-05-19T15:46:51" version="1779202011768">
+      <Q id="6428669685" qualifier_id="56" value="Back"/>
+      <Q id="6428669737" qualifier_id="233" value="537"/>
+      <Q id="6428669687" qualifier_id="285"/>
+    </Event>
+    <Event id="2939841833" event_id="666" type_id="1" period_id="2" min="63" sec="47" player_id="207884" team_id="244" outcome="0" x="44.0" y="53.3" timestamp="2026-05-19T14:41:48.071" timestamp_utc="2026-05-19T13:41:48.071" last_modified="2026-05-19T14:44:12" version="1779198251869">
+      <Q id="6428669725" qualifier_id="56" value="Back"/>
+      <Q id="6428669727" qualifier_id="140" value="47.2"/>
+      <Q id="6428669729" qualifier_id="141" value="51.3"/>
+      <Q id="6428669731" qualifier_id="212" value="3.6"/>
+      <Q id="6428669733" qualifier_id="213" value="5.90"/>
+      <Q id="6428673081" qualifier_id="233" value="538"/>
+      <Q id="6428673079" qualifier_id="236"/>
+      <Q id="6428673085" qualifier_id="286"/>
+    </Event>
+    <Event id="2939841845" event_id="538" type_id="74" period_id="2" min="63" sec="47" player_id="720682" team_id="417" outcome="1" x="52.8" y="48.7" timestamp="2026-05-19T14:41:48.072" timestamp_utc="2026-05-19T13:41:48.072" last_modified="2026-05-19T15:45:53" version="1779201953221">
+      <Q id="6428669793" qualifier_id="56" value="Center"/>
+      <Q id="6428673097" qualifier_id="233" value="666"/>
+      <Q id="6428669795" qualifier_id="285"/>
+    </Event>
+    <Event id="2939841855" event_id="539" type_id="49" period_id="2" min="63" sec="54" player_id="720682" team_id="417" outcome="1" x="61.9" y="45.5" timestamp="2026-05-19T14:41:55.078" timestamp_utc="2026-05-19T13:41:55.078" last_modified="2026-05-19T14:41:55" version="1779198115079"/>
+    <Event id="2939841875" event_id="540" type_id="1" period_id="2" min="63" sec="54" player_id="720682" team_id="417" outcome="1" x="62.9" y="43.4" keypass="1" timestamp="2026-05-19T14:41:55.294" timestamp_utc="2026-05-19T13:41:55.294" last_modified="2026-05-19T14:42:12" version="1779198132532">
+      <Q id="6428669989" qualifier_id="56" value="Right"/>
+      <Q id="6428669991" qualifier_id="140" value="70.9"/>
+      <Q id="6428669993" qualifier_id="141" value="18.0"/>
+      <Q id="6428670211" qualifier_id="154"/>
+      <Q id="6428670209" qualifier_id="210" value="13"/>
+      <Q id="6428669995" qualifier_id="212" value="19.2"/>
+      <Q id="6428669997" qualifier_id="213" value="5.17"/>
+    </Event>
+    <Event id="2939841877" event_id="541" type_id="13" period_id="2" min="64" sec="1" player_id="685390" team_id="417" outcome="1" x="76.8" y="29.3" timestamp="2026-05-19T14:42:01.566" timestamp_utc="2026-05-19T13:42:01.566" last_modified="2026-05-19T15:51:24" version="1779202284021">
+      <Q id="6428670007" qualifier_id="18"/>
+      <Q id="6428670155" qualifier_id="20"/>
+      <Q id="6428670005" qualifier_id="22"/>
+      <Q id="6428670215" qualifier_id="29"/>
+      <Q id="6428670219" qualifier_id="55" value="540"/>
+      <Q id="6428670009" qualifier_id="56" value="Center"/>
+      <Q id="6428670213" qualifier_id="83"/>
+      <Q id="6428670223" qualifier_id="102" value="58.3"/>
+      <Q id="6428670225" qualifier_id="103" value="19.4"/>
+      <Q id="6428670217" qualifier_id="154"/>
+      <Q id="6428670227" qualifier_id="230" value="97.8"/>
+      <Q id="6428670229" qualifier_id="231" value="47.3"/>
+    </Event>
+    <Event id="2939841897" event_id="542" type_id="5" period_id="2" min="64" sec="1" player_id="685390" team_id="417" outcome="0" x="101.4" y="60.2" timestamp="2026-05-19T14:42:02.280" timestamp_utc="2026-05-19T13:42:02.280" last_modified="2026-05-19T15:26:35" version="1779200790202">
+      <Q id="6428670151" qualifier_id="56" value="Center"/>
+      <Q id="6428685529" qualifier_id="233" value="667"/>
+      <Q id="6428670153" qualifier_id="346"/>
+    </Event>
+    <Event id="2939841941" event_id="667" type_id="5" period_id="2" min="64" sec="1" player_id="207884" team_id="244" outcome="1" x="-1.4" y="39.8" timestamp="2026-05-19T14:42:02.280" timestamp_utc="2026-05-19T13:42:02.280" last_modified="2026-05-19T14:51:10" version="1779198670121">
+      <Q id="6428670503" qualifier_id="56" value="Back"/>
+      <Q id="6428685513" qualifier_id="233" value="542"/>
+      <Q id="6428670505" qualifier_id="346"/>
+    </Event>
+    <Event id="2939841971" event_id="668" type_id="1" period_id="2" min="64" sec="20" player_id="627127" team_id="244" outcome="1" x="5.0" y="39.4" timestamp="2026-05-19T14:42:21.344" timestamp_utc="2026-05-19T13:42:21.344" last_modified="2026-05-19T14:42:27" version="1779198141691">
+      <Q id="6428670639" qualifier_id="56" value="Back"/>
+      <Q id="6428670637" qualifier_id="124"/>
+      <Q id="6428670641" qualifier_id="140" value="7.1"/>
+      <Q id="6428670643" qualifier_id="141" value="51.9"/>
+      <Q id="6428670645" qualifier_id="212" value="8.8"/>
+      <Q id="6428670647" qualifier_id="213" value="1.32"/>
+      <Q id="6428670651" qualifier_id="237"/>
+    </Event>
+    <Event id="2939841985" event_id="669" type_id="1" period_id="2" min="64" sec="26" player_id="578592" team_id="244" outcome="0" x="20.2" y="54.0" timestamp="2026-05-19T14:42:27.448" timestamp_utc="2026-05-19T13:42:27.448" last_modified="2026-05-19T14:42:30" version="1779198150073">
+      <Q id="6428670727" qualifier_id="1"/>
+      <Q id="6428670717" qualifier_id="56" value="Center"/>
+      <Q id="6428670719" qualifier_id="140" value="74.5"/>
+      <Q id="6428670721" qualifier_id="141" value="53.4"/>
+      <Q id="6428670715" qualifier_id="157"/>
+      <Q id="6428670723" qualifier_id="212" value="57.0"/>
+      <Q id="6428670725" qualifier_id="213" value="6.28"/>
+    </Event>
+    <Event id="2939841995" event_id="543" type_id="1" period_id="2" min="64" sec="30" player_id="531784" team_id="417" outcome="1" x="32.1" y="35.5" timestamp="2026-05-19T14:42:31.047" timestamp_utc="2026-05-19T13:42:31.047" last_modified="2026-05-19T14:42:33" version="1779198151229">
+      <Q id="6428670771" qualifier_id="3"/>
+      <Q id="6428670775" qualifier_id="56" value="Back"/>
+      <Q id="6428670779" qualifier_id="140" value="35.7"/>
+      <Q id="6428670787" qualifier_id="141" value="56.0"/>
+      <Q id="6428670789" qualifier_id="212" value="14.4"/>
+      <Q id="6428670791" qualifier_id="213" value="1.31"/>
+    </Event>
+    <Event id="2939842009" event_id="544" type_id="1" period_id="2" min="64" sec="32" player_id="720682" team_id="417" outcome="0" x="30.9" y="60.9" timestamp="2026-05-19T14:42:33.262" timestamp_utc="2026-05-19T13:42:33.262" last_modified="2026-05-19T14:42:34" version="1779198154703">
+      <Q id="6428670863" qualifier_id="1"/>
+      <Q id="6428670853" qualifier_id="56" value="Left"/>
+      <Q id="6428670855" qualifier_id="140" value="58.0"/>
+      <Q id="6428670857" qualifier_id="141" value="85.4"/>
+      <Q id="6428670851" qualifier_id="157"/>
+      <Q id="6428670859" qualifier_id="212" value="33.0"/>
+      <Q id="6428670861" qualifier_id="213" value="0.53"/>
+    </Event>
+    <Event id="2939842061" event_id="670" type_id="1" period_id="2" min="64" sec="38" player_id="627127" team_id="244" outcome="1" x="41.8" y="13.1" timestamp="2026-05-19T14:42:38.687" timestamp_utc="2026-05-19T13:42:38.687" last_modified="2026-05-19T14:42:48" version="1779198160835">
+      <Q id="6428671153" qualifier_id="56" value="Back"/>
+      <Q id="6428671155" qualifier_id="140" value="20.0"/>
+      <Q id="6428671157" qualifier_id="141" value="35.5"/>
+      <Q id="6428671159" qualifier_id="212" value="27.5"/>
+      <Q id="6428671161" qualifier_id="213" value="2.55"/>
+    </Event>
+    <Event id="2939842065" event_id="671" type_id="1" period_id="2" min="64" sec="48" player_id="578592" team_id="244" outcome="0" x="25.7" y="52.1" timestamp="2026-05-19T14:42:48.656" timestamp_utc="2026-05-19T13:42:48.656" last_modified="2026-05-19T14:42:51" version="1779198171225">
+      <Q id="6428671197" qualifier_id="1"/>
+      <Q id="6428671187" qualifier_id="56" value="Center"/>
+      <Q id="6428671189" qualifier_id="140" value="67.8"/>
+      <Q id="6428671191" qualifier_id="141" value="59.9"/>
+      <Q id="6428671185" qualifier_id="157"/>
+      <Q id="6428671193" qualifier_id="212" value="44.5"/>
+      <Q id="6428671195" qualifier_id="213" value="0.12"/>
+    </Event>
+    <Event id="2939842069" event_id="545" type_id="44" period_id="2" min="64" sec="50" player_id="531784" team_id="417" outcome="1" x="32.2" y="40.1" timestamp="2026-05-19T14:42:50.885" timestamp_utc="2026-05-19T13:42:50.885" last_modified="2026-05-19T15:45:46" version="1779201945965">
+      <Q id="6428671221" qualifier_id="56" value="Back"/>
+      <Q id="6428671231" qualifier_id="233" value="672"/>
+      <Q id="6428671223" qualifier_id="285"/>
+    </Event>
+    <Event id="2939842071" event_id="672" type_id="44" period_id="2" min="64" sec="50" player_id="232091" team_id="244" outcome="0" x="67.8" y="59.9" timestamp="2026-05-19T14:42:50.886" timestamp_utc="2026-05-19T13:42:50.886" last_modified="2026-05-19T15:45:46" version="1779201946247">
+      <Q id="6428671225" qualifier_id="56" value="Center"/>
+      <Q id="6428671233" qualifier_id="233" value="545"/>
+      <Q id="6428671227" qualifier_id="286"/>
+    </Event>
+    <Event id="2939842093" event_id="546" type_id="1" period_id="2" min="64" sec="50" player_id="531784" team_id="417" outcome="1" x="32.2" y="40.1" timestamp="2026-05-19T14:42:51.168" timestamp_utc="2026-05-19T13:42:51.168" last_modified="2026-05-19T15:45:46" version="1779201946529">
+      <Q id="6428671339" qualifier_id="3"/>
+      <Q id="6428671341" qualifier_id="56" value="Back"/>
+      <Q id="6428671343" qualifier_id="140" value="33.4"/>
+      <Q id="6428671345" qualifier_id="141" value="47.9"/>
+      <Q id="6428671347" qualifier_id="212" value="5.5"/>
+      <Q id="6428671349" qualifier_id="213" value="1.34"/>
+    </Event>
+    <Event id="2939842095" event_id="547" type_id="49" period_id="2" min="64" sec="52" player_id="720682" team_id="417" outcome="1" x="33.4" y="47.9" timestamp="2026-05-19T14:42:53.214" timestamp_utc="2026-05-19T13:42:53.214" last_modified="2026-05-19T14:42:55" version="1779198173215"/>
+    <Event id="2939842107" event_id="548" type_id="1" period_id="2" min="64" sec="53" player_id="720682" team_id="417" outcome="1" x="32.1" y="54.3" timestamp="2026-05-19T14:42:53.654" timestamp_utc="2026-05-19T13:42:53.654" last_modified="2026-05-19T14:42:58" version="1779198175123">
+      <Q id="6428671411" qualifier_id="56" value="Back"/>
+      <Q id="6428671413" qualifier_id="140" value="35.7"/>
+      <Q id="6428671415" qualifier_id="141" value="80.8"/>
+      <Q id="6428671409" qualifier_id="155"/>
+      <Q id="6428671417" qualifier_id="212" value="18.4"/>
+      <Q id="6428671419" qualifier_id="213" value="1.36"/>
+    </Event>
+    <Event id="2939842115" event_id="549" type_id="1" period_id="2" min="64" sec="57" player_id="164593" team_id="417" outcome="1" x="30.9" y="81.8" timestamp="2026-05-19T14:42:58.157" timestamp_utc="2026-05-19T13:42:58.157" last_modified="2026-05-19T14:43:00" version="1779198178333">
+      <Q id="6428671469" qualifier_id="56" value="Back"/>
+      <Q id="6428671471" qualifier_id="140" value="30.1"/>
+      <Q id="6428671473" qualifier_id="141" value="65.5"/>
+      <Q id="6428671475" qualifier_id="212" value="11.1"/>
+      <Q id="6428671477" qualifier_id="213" value="4.64"/>
+    </Event>
+    <Event id="2939842121" event_id="550" type_id="1" period_id="2" min="64" sec="59" player_id="720682" team_id="417" outcome="1" x="30.4" y="69.7" timestamp="2026-05-19T14:43:00.007" timestamp_utc="2026-05-19T13:43:00.007" last_modified="2026-05-19T14:43:02" version="1779198180184">
+      <Q id="6428671513" qualifier_id="56" value="Back"/>
+      <Q id="6428671515" qualifier_id="140" value="33.7"/>
+      <Q id="6428671517" qualifier_id="141" value="54.6"/>
+      <Q id="6428671519" qualifier_id="212" value="10.8"/>
+      <Q id="6428671521" qualifier_id="213" value="5.04"/>
+    </Event>
+    <Event id="2939842123" event_id="551" type_id="1" period_id="2" min="65" sec="1" player_id="218339" team_id="417" outcome="1" x="33.4" y="54.6" timestamp="2026-05-19T14:43:02.045" timestamp_utc="2026-05-19T13:43:02.045" last_modified="2026-05-19T14:43:02" version="1779198182214">
+      <Q id="6428671533" qualifier_id="56" value="Back"/>
+      <Q id="6428671535" qualifier_id="140" value="25.6"/>
+      <Q id="6428671537" qualifier_id="141" value="70.8"/>
+      <Q id="6428671539" qualifier_id="212" value="13.7"/>
+      <Q id="6428671541" qualifier_id="213" value="2.21"/>
+    </Event>
+    <Event id="2939842127" event_id="552" type_id="1" period_id="2" min="65" sec="2" player_id="624620" team_id="417" outcome="1" x="24.3" y="69.9" timestamp="2026-05-19T14:43:02.797" timestamp_utc="2026-05-19T13:43:02.797" last_modified="2026-05-19T14:43:03" version="1779198182936">
+      <Q id="6428671563" qualifier_id="56" value="Back"/>
+      <Q id="6428671565" qualifier_id="140" value="26.7"/>
+      <Q id="6428671567" qualifier_id="141" value="74.4"/>
+      <Q id="6428671569" qualifier_id="212" value="4.0"/>
+      <Q id="6428671571" qualifier_id="213" value="0.88"/>
+    </Event>
+    <Event id="2939842133" event_id="553" type_id="1" period_id="2" min="65" sec="2" player_id="720682" team_id="417" outcome="1" x="27.0" y="74.7" timestamp="2026-05-19T14:43:03.390" timestamp_utc="2026-05-19T13:43:03.390" last_modified="2026-05-19T14:43:06" version="1779198183528">
+      <Q id="6428671601" qualifier_id="56" value="Back"/>
+      <Q id="6428671603" qualifier_id="140" value="26.9"/>
+      <Q id="6428671605" qualifier_id="141" value="56.0"/>
+      <Q id="6428671607" qualifier_id="212" value="12.7"/>
+      <Q id="6428671609" qualifier_id="213" value="4.70"/>
+    </Event>
+    <Event id="2939842135" event_id="554" type_id="1" period_id="2" min="65" sec="6" player_id="218339" team_id="417" outcome="1" x="26.4" y="59.4" timestamp="2026-05-19T14:43:06.798" timestamp_utc="2026-05-19T13:43:06.798" last_modified="2026-05-19T14:43:09" version="1779198186958">
+      <Q id="6428671633" qualifier_id="56" value="Back"/>
+      <Q id="6428671635" qualifier_id="140" value="24.0"/>
+      <Q id="6428671637" qualifier_id="141" value="31.8"/>
+      <Q id="6428671639" qualifier_id="212" value="18.9"/>
+      <Q id="6428671641" qualifier_id="213" value="4.58"/>
+    </Event>
+    <Event id="2939842141" event_id="555" type_id="1" period_id="2" min="65" sec="8" player_id="61812" team_id="417" outcome="1" x="26.4" y="30.0" timestamp="2026-05-19T14:43:09.237" timestamp_utc="2026-05-19T13:43:09.237" last_modified="2026-05-19T14:43:12" version="1779198189398">
+      <Q id="6428671713" qualifier_id="56" value="Back"/>
+      <Q id="6428671715" qualifier_id="140" value="28.4"/>
+      <Q id="6428671717" qualifier_id="141" value="17.0"/>
+      <Q id="6428671719" qualifier_id="212" value="9.1"/>
+      <Q id="6428671721" qualifier_id="213" value="4.95"/>
+    </Event>
+    <Event id="2939842143" event_id="556" type_id="1" period_id="2" min="65" sec="12" player_id="531784" team_id="417" outcome="0" x="32.5" y="14.9" timestamp="2026-05-19T14:43:12.777" timestamp_utc="2026-05-19T13:43:12.777" last_modified="2026-05-19T14:43:13" version="1779198193230">
+      <Q id="6428671725" qualifier_id="56" value="Back"/>
+      <Q id="6428671727" qualifier_id="140" value="44.6"/>
+      <Q id="6428671729" qualifier_id="141" value="29.2"/>
+      <Q id="6428671731" qualifier_id="212" value="16.0"/>
+      <Q id="6428671733" qualifier_id="213" value="0.65"/>
+    </Event>
+    <Event id="2939842159" event_id="673" type_id="1" period_id="2" min="65" sec="14" player_id="180662" team_id="244" outcome="1" x="39.8" y="64.2" timestamp="2026-05-19T14:43:14.952" timestamp_utc="2026-05-19T13:43:14.952" last_modified="2026-05-19T14:43:17" version="1779198196139">
+      <Q id="6428671837" qualifier_id="1"/>
+      <Q id="6428671827" qualifier_id="56" value="Back"/>
+      <Q id="6428671829" qualifier_id="140" value="49.3"/>
+      <Q id="6428671831" qualifier_id="141" value="46.3"/>
+      <Q id="6428671825" qualifier_id="157"/>
+      <Q id="6428671833" qualifier_id="212" value="15.7"/>
+      <Q id="6428671835" qualifier_id="213" value="5.40"/>
+    </Event>
+    <Event id="2939842167" event_id="674" type_id="61" period_id="2" min="65" sec="16" player_id="625775" team_id="244" outcome="1" x="54.2" y="45.1" timestamp="2026-05-19T14:43:17.424" timestamp_utc="2026-05-19T13:43:17.424" last_modified="2026-05-19T14:43:31" version="1779198211265">
+      <Q id="6428671869" qualifier_id="56" value="Center"/>
+    </Event>
+    <Event id="2939842169" event_id="675" type_id="43" period_id="2" min="65" sec="18" player_id="625775" team_id="244" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T14:43:18.968" timestamp_utc="2026-05-19T13:43:18.968" last_modified="2026-05-19T14:43:29" version="1779198198969">
+      <Q id="6428672117" qualifier_id="144" value="49"/>
+    </Event>
+    <Event id="2939842203" event_id="676" type_id="43" period_id="2" min="65" sec="19" player_id="625775" team_id="244" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T14:43:19.584" timestamp_utc="2026-05-19T13:43:19.584" last_modified="2026-05-19T14:43:27" version="1779198205857">
+      <Q id="6428672067" qualifier_id="56" value="Center"/>
+      <Q id="6428672069" qualifier_id="140" value="58.2"/>
+      <Q id="6428672071" qualifier_id="141" value="62.6"/>
+      <Q id="6428672091" qualifier_id="144" value="1"/>
+      <Q id="6428672065" qualifier_id="155" value="0"/>
+      <Q id="6428672073" qualifier_id="212" value="9.0"/>
+      <Q id="6428672075" qualifier_id="213" value="1.26"/>
+    </Event>
+    <Event id="2939842231" event_id="677" type_id="4" period_id="2" min="65" sec="25" player_id="625775" team_id="244" outcome="1" x="54.8" y="46.2" timestamp="2026-05-19T14:43:25.760" timestamp_utc="2026-05-19T13:43:25.760" last_modified="2026-05-19T15:26:41" version="1779200795445">
+      <Q id="6428705015" qualifier_id="13"/>
+      <Q id="6428672249" qualifier_id="56" value="Center"/>
+      <Q id="6428672251" qualifier_id="152"/>
+      <Q id="6428685351" qualifier_id="233" value="557"/>
+      <Q id="6428672253" qualifier_id="286"/>
+      <Q id="6428705017" qualifier_id="295"/>
+    </Event>
+    <Event id="2939842205" event_id="557" type_id="4" period_id="2" min="65" sec="25" player_id="218339" team_id="417" outcome="0" x="45.2" y="53.8" timestamp="2026-05-19T14:43:25.761" timestamp_utc="2026-05-19T13:43:25.761" last_modified="2026-05-19T16:02:08" version="1779202928750">
+      <Q id="6428705065" qualifier_id="13"/>
+      <Q id="6428672171" qualifier_id="56" value="Back"/>
+      <Q id="6428672173" qualifier_id="152"/>
+      <Q id="6428685371" qualifier_id="233" value="677"/>
+      <Q id="6428672175" qualifier_id="285"/>
+      <Q id="6428705067" qualifier_id="295"/>
+    </Event>
+    <Event id="2939842273" event_id="679" type_id="1" period_id="2" min="65" sec="39" player_id="515742" team_id="244" outcome="1" x="54.3" y="53.3" keypass="1" timestamp="2026-05-19T14:43:39.615" timestamp_utc="2026-05-19T13:43:39.615" last_modified="2026-05-19T14:44:19" version="1779198259539">
+      <Q id="6428672489" qualifier_id="5"/>
+      <Q id="6428672493" qualifier_id="56" value="Left"/>
+      <Q id="6428672495" qualifier_id="140" value="57.9"/>
+      <Q id="6428672497" qualifier_id="141" value="80.0"/>
+      <Q id="6428672491" qualifier_id="152"/>
+      <Q id="6428673221" qualifier_id="210" value="15"/>
+      <Q id="6428672499" qualifier_id="212" value="18.5"/>
+      <Q id="6428672501" qualifier_id="213" value="1.37"/>
+    </Event>
+    <Event id="2939842277" event_id="680" type_id="3" period_id="2" min="65" sec="44" player_id="575855" team_id="244" outcome="1" x="85.4" y="66.2" timestamp="2026-05-19T14:43:44.903" timestamp_utc="2026-05-19T13:43:44.903" last_modified="2026-05-19T14:43:48" version="1779198226975">
+      <Q id="6428672519" qualifier_id="56" value="Center"/>
+      <Q id="6428672555" qualifier_id="233" value="558"/>
+      <Q id="6428672521" qualifier_id="286"/>
+    </Event>
+    <Event id="2939842283" event_id="558" type_id="45" period_id="2" min="65" sec="44" player_id="218339" team_id="417" outcome="0" x="14.6" y="33.8" timestamp="2026-05-19T14:43:44.903" timestamp_utc="2026-05-19T13:43:44.903" last_modified="2026-05-19T14:43:48" version="1779198226981">
+      <Q id="6428672549" qualifier_id="56" value="Back"/>
+      <Q id="6428672557" qualifier_id="233" value="680"/>
+      <Q id="6428672551" qualifier_id="285"/>
+    </Event>
+    <Event id="2939842281" event_id="681" type_id="15" period_id="2" min="65" sec="45" player_id="575855" team_id="244" outcome="1" x="86.5" y="62.2" timestamp="2026-05-19T14:43:45.680" timestamp_utc="2026-05-19T13:43:45.680" last_modified="2026-05-19T15:56:06" version="1779202566646">
+      <Q id="6428672537" qualifier_id="17"/>
+      <Q id="6428729859" qualifier_id="20"/>
+      <Q id="6428672535" qualifier_id="22"/>
+      <Q id="6428673247" qualifier_id="29"/>
+      <Q id="6428673249" qualifier_id="55" value="679"/>
+      <Q id="6428672539" qualifier_id="56" value="Center"/>
+      <Q id="6428741391" qualifier_id="76"/>
+      <Q id="6428673125" qualifier_id="82"/>
+      <Q id="6428673253" qualifier_id="102" value="52.4"/>
+      <Q id="6428673255" qualifier_id="103" value="19.0"/>
+      <Q id="6428673259" qualifier_id="146" value="88.9"/>
+      <Q id="6428673261" qualifier_id="147" value="60.5"/>
+      <Q id="6428673257" qualifier_id="215"/>
+      <Q id="6428673263" qualifier_id="230" value="100.0"/>
+      <Q id="6428673265" qualifier_id="231" value="50.0"/>
+      <Q id="6428673271" qualifier_id="233" value="559"/>
+    </Event>
+    <Event id="2939842285" event_id="559" type_id="10" period_id="2" min="65" sec="45" player_id="720682" team_id="417" outcome="1" x="11.0" y="43.5" timestamp="2026-05-19T14:43:45.780" timestamp_utc="2026-05-19T13:43:45.780" last_modified="2026-05-19T14:51:35" version="1779198694977">
+      <Q id="6428672565" qualifier_id="56" value="Back"/>
+      <Q id="6428672563" qualifier_id="94"/>
+      <Q id="6428673285" qualifier_id="233" value="681"/>
+    </Event>
+    <Event id="2939842299" event_id="682" type_id="1" period_id="2" min="65" sec="48" player_id="207884" team_id="244" outcome="1" x="73.0" y="63.6" timestamp="2026-05-19T14:43:48.591" timestamp_utc="2026-05-19T13:43:48.591" last_modified="2026-05-19T15:23:22" version="1779200602130">
+      <Q id="6428672613" qualifier_id="56" value="Left"/>
+      <Q id="6428672615" qualifier_id="140" value="83.2"/>
+      <Q id="6428672617" qualifier_id="141" value="81.7"/>
+      <Q id="6428672619" qualifier_id="212" value="16.3"/>
+      <Q id="6428672621" qualifier_id="213" value="0.85"/>
+    </Event>
+    <Event id="2939842301" event_id="683" type_id="1" period_id="2" min="65" sec="51" player_id="648131" team_id="244" outcome="0" x="83.2" y="81.7" timestamp="2026-05-19T14:43:51.855" timestamp_utc="2026-05-19T13:43:51.855" last_modified="2026-05-19T14:43:52" version="1779198232817">
+      <Q id="6428672643" qualifier_id="2"/>
+      <Q id="6428672647" qualifier_id="56" value="Center"/>
+      <Q id="6428672649" qualifier_id="140" value="93.2"/>
+      <Q id="6428672651" qualifier_id="141" value="41.3"/>
+      <Q id="6428672645" qualifier_id="155"/>
+      <Q id="6428672653" qualifier_id="212" value="29.4"/>
+      <Q id="6428672655" qualifier_id="213" value="5.08"/>
+    </Event>
+    <Event id="2939842309" event_id="560" type_id="12" period_id="2" min="65" sec="53" player_id="164593" team_id="417" outcome="1" x="10.1" y="61.4" timestamp="2026-05-19T14:43:53.789" timestamp_utc="2026-05-19T13:43:53.789" last_modified="2026-05-19T14:43:54" version="1779198234117">
+      <Q id="6428672711" qualifier_id="15"/>
+      <Q id="6428672697" qualifier_id="56" value="Back"/>
+      <Q id="6428672699" qualifier_id="140" value="10.9"/>
+      <Q id="6428672701" qualifier_id="141" value="64.2"/>
+      <Q id="6428672703" qualifier_id="212" value="2.1"/>
+      <Q id="6428672705" qualifier_id="213" value="1.16"/>
+    </Event>
+    <Event id="2939842321" event_id="684" type_id="3" period_id="2" min="65" sec="56" player_id="625775" team_id="244" outcome="0" x="91.4" y="27.8" timestamp="2026-05-19T14:43:56.888" timestamp_utc="2026-05-19T13:43:56.888" last_modified="2026-05-19T14:44:00" version="1779198240180">
+      <Q id="6428672775" qualifier_id="56" value="Center"/>
+      <Q id="6428672801" qualifier_id="233" value="561"/>
+      <Q id="6428672777" qualifier_id="286"/>
+    </Event>
+    <Event id="2939842323" event_id="561" type_id="7" period_id="2" min="65" sec="56" player_id="164593" team_id="417" outcome="0" x="8.6" y="72.2" timestamp="2026-05-19T14:43:56.889" timestamp_utc="2026-05-19T13:43:56.889" last_modified="2026-05-19T14:52:14" version="1779198734366">
+      <Q id="6428672789" qualifier_id="56" value="Back"/>
+      <Q id="6428672793" qualifier_id="178"/>
+      <Q id="6428672795" qualifier_id="233" value="684"/>
+      <Q id="6428672791" qualifier_id="285"/>
+    </Event>
+    <Event id="2939842333" event_id="685" type_id="1" period_id="2" min="65" sec="57" player_id="240166" team_id="244" outcome="1" x="74.4" y="23.5" keypass="1" timestamp="2026-05-19T14:43:58.456" timestamp_utc="2026-05-19T13:43:58.456" last_modified="2026-05-19T16:31:40" version="1779204699988">
+      <Q id="6428672881" qualifier_id="2"/>
+      <Q id="6428672885" qualifier_id="56" value="Center"/>
+      <Q id="6428672887" qualifier_id="140" value="88.6"/>
+      <Q id="6428672889" qualifier_id="141" value="47.7"/>
+      <Q id="6428673053" qualifier_id="154"/>
+      <Q id="6428672883" qualifier_id="155"/>
+      <Q id="6428673051" qualifier_id="210" value="13"/>
+      <Q id="6428672891" qualifier_id="212" value="22.2"/>
+      <Q id="6428672893" qualifier_id="213" value="0.83"/>
+    </Event>
+    <Event id="2939842335" event_id="686" type_id="13" period_id="2" min="65" sec="59" player_id="232091" team_id="244" outcome="1" x="88.6" y="47.7" timestamp="2026-05-19T14:44:00.199" timestamp_utc="2026-05-19T13:44:00.199" last_modified="2026-05-19T15:57:20" version="1779202640363">
+      <Q id="6428673055" qualifier_id="15"/>
+      <Q id="6428672899" qualifier_id="17"/>
+      <Q id="6428672897" qualifier_id="22"/>
+      <Q id="6428673059" qualifier_id="29"/>
+      <Q id="6428673063" qualifier_id="55" value="685"/>
+      <Q id="6428672901" qualifier_id="56" value="Center"/>
+      <Q id="6428673057" qualifier_id="73"/>
+      <Q id="6428673067" qualifier_id="102" value="60.0"/>
+      <Q id="6428673069" qualifier_id="103" value="11.1"/>
+      <Q id="6428673061" qualifier_id="154"/>
+      <Q id="6428673073" qualifier_id="230" value="99.1"/>
+      <Q id="6428673075" qualifier_id="231" value="48.9"/>
+      <Q id="6428673071" qualifier_id="328"/>
+    </Event>
+    <Event id="2939842337" event_id="562" type_id="5" period_id="2" min="66" sec="0" player_id="61778" team_id="417" outcome="1" x="-1.0" y="38.6" timestamp="2026-05-19T14:44:01.077" timestamp_utc="2026-05-19T13:44:01.077" last_modified="2026-05-19T14:50:59" version="1779198659201">
+      <Q id="6428672909" qualifier_id="56" value="Back"/>
+      <Q id="6428672965" qualifier_id="233" value="687"/>
+      <Q id="6428672911" qualifier_id="346"/>
+    </Event>
+    <Event id="2939842349" event_id="687" type_id="5" period_id="2" min="66" sec="0" player_id="232091" team_id="244" outcome="0" x="101.0" y="61.4" timestamp="2026-05-19T14:44:01.077" timestamp_utc="2026-05-19T13:44:01.077" last_modified="2026-05-19T15:26:35" version="1779200790210">
+      <Q id="6428672959" qualifier_id="56" value="Center"/>
+      <Q id="6428672987" qualifier_id="233" value="562"/>
+      <Q id="6428672961" qualifier_id="346"/>
+    </Event>
+    <Event id="2939842395" event_id="563" type_id="1" period_id="2" min="66" sec="20" player_id="565487" team_id="417" outcome="0" x="5.0" y="50.4" timestamp="2026-05-19T14:44:21.310" timestamp_utc="2026-05-19T13:44:21.310" last_modified="2026-05-19T14:44:23" version="1779198263045">
+      <Q id="6428673331" qualifier_id="1"/>
+      <Q id="6428673321" qualifier_id="56" value="Back"/>
+      <Q id="6428673333" qualifier_id="74"/>
+      <Q id="6428673319" qualifier_id="124"/>
+      <Q id="6428673323" qualifier_id="140" value="44.4"/>
+      <Q id="6428673325" qualifier_id="141" value="56.4"/>
+      <Q id="6428673327" qualifier_id="212" value="41.6"/>
+      <Q id="6428673329" qualifier_id="213" value="0.10"/>
+    </Event>
+    <Event id="2939842411" event_id="688" type_id="1" period_id="2" min="66" sec="25" player_id="515742" team_id="244" outcome="0" x="51.3" y="50.0" timestamp="2026-05-19T14:44:25.584" timestamp_utc="2026-05-19T13:44:25.584" last_modified="2026-05-19T14:52:18" version="1779198738277">
+      <Q id="6428673401" qualifier_id="1"/>
+      <Q id="6428673391" qualifier_id="56" value="Center"/>
+      <Q id="6428673393" qualifier_id="140" value="74.1"/>
+      <Q id="6428673395" qualifier_id="141" value="55.5"/>
+      <Q id="6428673389" qualifier_id="157"/>
+      <Q id="6428673397" qualifier_id="212" value="24.2"/>
+      <Q id="6428673399" qualifier_id="213" value="0.15"/>
+    </Event>
+    <Event id="2939842435" event_id="565" type_id="1" period_id="2" min="66" sec="25" player_id="531784" team_id="417" outcome="1" x="20.9" y="42.8" timestamp="2026-05-19T14:44:26.404" timestamp_utc="2026-05-19T13:44:26.404" last_modified="2026-05-19T14:44:29" version="1779198268126">
+      <Q id="6428673507" qualifier_id="3"/>
+      <Q id="6428673509" qualifier_id="56" value="Back"/>
+      <Q id="6428673511" qualifier_id="140" value="36.9"/>
+      <Q id="6428673513" qualifier_id="141" value="76.6"/>
+      <Q id="6428673515" qualifier_id="212" value="28.5"/>
+      <Q id="6428673517" qualifier_id="213" value="0.94"/>
+    </Event>
+    <Event id="2939842461" event_id="566" type_id="1" period_id="2" min="66" sec="28" player_id="61778" team_id="417" outcome="1" x="36.9" y="76.6" timestamp="2026-05-19T14:44:29.396" timestamp_utc="2026-05-19T13:44:29.396" last_modified="2026-05-19T14:44:33" version="1779198269511">
+      <Q id="6428673679" qualifier_id="3"/>
+      <Q id="6428673681" qualifier_id="56" value="Back"/>
+      <Q id="6428673683" qualifier_id="140" value="30.9"/>
+      <Q id="6428673685" qualifier_id="141" value="71.5"/>
+      <Q id="6428673687" qualifier_id="212" value="7.2"/>
+      <Q id="6428673689" qualifier_id="213" value="3.64"/>
+    </Event>
+    <Event id="2939842477" event_id="567" type_id="1" period_id="2" min="66" sec="32" player_id="720682" team_id="417" outcome="1" x="24.2" y="65.5" timestamp="2026-05-19T14:44:33.444" timestamp_utc="2026-05-19T13:44:33.444" last_modified="2026-05-19T14:44:35" version="1779198274014">
+      <Q id="6428673737" qualifier_id="56" value="Back"/>
+      <Q id="6428673739" qualifier_id="140" value="39.1"/>
+      <Q id="6428673741" qualifier_id="141" value="56.7"/>
+      <Q id="6428673743" qualifier_id="212" value="16.8"/>
+      <Q id="6428673745" qualifier_id="213" value="5.92"/>
+    </Event>
+    <Event id="2939842481" event_id="568" type_id="1" period_id="2" min="66" sec="34" player_id="445539" team_id="417" outcome="0" x="43.6" y="65.8" timestamp="2026-05-19T14:44:35.534" timestamp_utc="2026-05-19T13:44:35.534" last_modified="2026-05-19T14:44:36" version="1779198276663">
+      <Q id="6428673757" qualifier_id="56" value="Back"/>
+      <Q id="6428673759" qualifier_id="140" value="44.9"/>
+      <Q id="6428673761" qualifier_id="141" value="100.0"/>
+      <Q id="6428673763" qualifier_id="212" value="24.5"/>
+      <Q id="6428673765" qualifier_id="213" value="1.51"/>
+    </Event>
+    <Event id="2939842483" event_id="569" type_id="5" period_id="2" min="66" sec="36" player_id="445539" team_id="417" outcome="0" x="45.1" y="101.8" timestamp="2026-05-19T14:44:36.669" timestamp_utc="2026-05-19T13:44:36.669" last_modified="2026-05-19T15:26:35" version="1779200790226">
+      <Q id="6428673767" qualifier_id="56" value="Back"/>
+      <Q id="6428685245" qualifier_id="233" value="689"/>
+      <Q id="6428673769" qualifier_id="347"/>
+    </Event>
+    <Event id="2939842585" event_id="689" type_id="5" period_id="2" min="66" sec="36" player_id="625775" team_id="244" outcome="1" x="54.9" y="-1.8" timestamp="2026-05-19T14:44:36.669" timestamp_utc="2026-05-19T13:44:36.669" last_modified="2026-05-19T15:26:35" version="1779200790219">
+      <Q id="6428674293" qualifier_id="56" value="Right"/>
+      <Q id="6428685239" qualifier_id="233" value="569"/>
+      <Q id="6428674295" qualifier_id="347"/>
+    </Event>
+    <Event id="2939842589" event_id="690" type_id="1" period_id="2" min="66" sec="56" player_id="240166" team_id="244" outcome="1" x="51.9" y="0.0" timestamp="2026-05-19T14:44:56.864" timestamp_utc="2026-05-19T13:44:56.864" last_modified="2026-05-19T14:44:58" version="1779198297801">
+      <Q id="6428674319" qualifier_id="56" value="Center"/>
+      <Q id="6428674317" qualifier_id="107"/>
+      <Q id="6428674321" qualifier_id="140" value="58.9"/>
+      <Q id="6428674323" qualifier_id="141" value="28.3"/>
+      <Q id="6428674325" qualifier_id="212" value="21.0"/>
+      <Q id="6428674327" qualifier_id="213" value="1.21"/>
+    </Event>
+    <Event id="2939842593" event_id="691" type_id="1" period_id="2" min="66" sec="58" player_id="207884" team_id="244" outcome="0" x="58.5" y="27.9" timestamp="2026-05-19T14:44:58.792" timestamp_utc="2026-05-19T13:44:58.792" last_modified="2026-05-19T14:44:59" version="1779198299800">
+      <Q id="6428674345" qualifier_id="1"/>
+      <Q id="6428674335" qualifier_id="56" value="Center"/>
+      <Q id="6428674337" qualifier_id="140" value="76.8"/>
+      <Q id="6428674339" qualifier_id="141" value="29.7"/>
+      <Q id="6428674333" qualifier_id="157"/>
+      <Q id="6428674341" qualifier_id="212" value="19.3"/>
+      <Q id="6428674343" qualifier_id="213" value="0.06"/>
+    </Event>
+    <Event id="2939842603" event_id="570" type_id="8" period_id="2" min="67" sec="1" player_id="61812" team_id="417" outcome="1" x="23.2" y="70.3" timestamp="2026-05-19T14:45:02.004" timestamp_utc="2026-05-19T13:45:02.004" last_modified="2026-05-19T15:45:57" version="1779201957143">
+      <Q id="6428674399" qualifier_id="56" value="Back"/>
+    </Event>
+    <Event id="2939842617" event_id="571" type_id="49" period_id="2" min="67" sec="3" player_id="531784" team_id="417" outcome="1" x="23.1" y="56.0" timestamp="2026-05-19T14:45:04.148" timestamp_utc="2026-05-19T13:45:04.148" last_modified="2026-05-19T14:45:04" version="1779198304149"/>
+    <Event id="2939842639" event_id="572" type_id="1" period_id="2" min="67" sec="3" player_id="531784" team_id="417" outcome="0" x="23.1" y="56.0" timestamp="2026-05-19T14:45:04.524" timestamp_utc="2026-05-19T13:45:04.524" last_modified="2026-05-19T14:45:09" version="1779198308884">
+      <Q id="6428674583" qualifier_id="1"/>
+      <Q id="6428674573" qualifier_id="56" value="Right"/>
+      <Q id="6428674575" qualifier_id="140" value="79.7"/>
+      <Q id="6428674577" qualifier_id="141" value="16.8"/>
+      <Q id="6428674571" qualifier_id="155"/>
+      <Q id="6428674579" qualifier_id="212" value="65.1"/>
+      <Q id="6428674581" qualifier_id="213" value="5.86"/>
+    </Event>
+    <Event id="2939842677" event_id="692" type_id="12" period_id="2" min="67" sec="11" player_id="180662" team_id="244" outcome="1" x="21.8" y="81.2" timestamp="2026-05-19T14:45:12.272" timestamp_utc="2026-05-19T13:45:12.272" last_modified="2026-05-19T14:45:16" version="1779198312561">
+      <Q id="6428674733" qualifier_id="56" value="Back"/>
+      <Q id="6428674735" qualifier_id="140" value="38.4"/>
+      <Q id="6428674737" qualifier_id="141" value="85.1"/>
+      <Q id="6428674739" qualifier_id="212" value="17.6"/>
+      <Q id="6428674741" qualifier_id="213" value="0.15"/>
+    </Event>
+    <Event id="2939842671" event_id="573" type_id="1" period_id="2" min="67" sec="12" player_id="157851" team_id="417" outcome="1" x="68.8" y="16.4" timestamp="2026-05-19T14:45:13.204" timestamp_utc="2026-05-19T13:45:13.204" last_modified="2026-05-19T14:45:40" version="1779198340331">
+      <Q id="6428674709" qualifier_id="56" value="Center"/>
+      <Q id="6428674711" qualifier_id="140" value="74.4"/>
+      <Q id="6428674713" qualifier_id="141" value="31.8"/>
+      <Q id="6428674715" qualifier_id="212" value="12.0"/>
+      <Q id="6428674717" qualifier_id="213" value="1.06"/>
+    </Event>
+    <Event id="2939842673" event_id="574" type_id="1" period_id="2" min="67" sec="14" player_id="445539" team_id="417" outcome="0" x="75.1" y="33.1" timestamp="2026-05-19T14:45:14.973" timestamp_utc="2026-05-19T13:45:14.973" last_modified="2026-05-19T14:45:15" version="1779198315333">
+      <Q id="6428674721" qualifier_id="56" value="Center"/>
+      <Q id="6428674723" qualifier_id="140" value="75.4"/>
+      <Q id="6428674725" qualifier_id="141" value="47.0"/>
+      <Q id="6428674727" qualifier_id="212" value="9.5"/>
+      <Q id="6428674729" qualifier_id="213" value="1.54"/>
+    </Event>
+    <Event id="2939842681" event_id="693" type_id="1" period_id="2" min="67" sec="16" player_id="240166" team_id="244" outcome="0" x="26.6" y="55.7" timestamp="2026-05-19T14:45:16.823" timestamp_utc="2026-05-19T13:45:16.823" last_modified="2026-05-19T14:52:35" version="1779198755829">
+      <Q id="6428674779" qualifier_id="1"/>
+      <Q id="6428674769" qualifier_id="56" value="Back"/>
+      <Q id="6428674771" qualifier_id="140" value="48.4"/>
+      <Q id="6428674773" qualifier_id="141" value="72.4"/>
+      <Q id="6428674767" qualifier_id="157"/>
+      <Q id="6428674775" qualifier_id="212" value="25.6"/>
+      <Q id="6428674777" qualifier_id="213" value="0.46"/>
+    </Event>
+    <Event id="2939842741" event_id="575" type_id="1" period_id="2" min="67" sec="22" player_id="531784" team_id="417" outcome="1" x="51.9" y="20.4" timestamp="2026-05-19T14:45:23.524" timestamp_utc="2026-05-19T13:45:23.524" last_modified="2026-05-19T14:45:26" version="1779198323716">
+      <Q id="6428675125" qualifier_id="56" value="Center"/>
+      <Q id="6428675127" qualifier_id="140" value="53.1"/>
+      <Q id="6428675129" qualifier_id="141" value="41.5"/>
+      <Q id="6428675131" qualifier_id="212" value="14.4"/>
+      <Q id="6428675133" qualifier_id="213" value="1.48"/>
+    </Event>
+    <Event id="2939842753" event_id="576" type_id="1" period_id="2" min="67" sec="26" player_id="218339" team_id="417" outcome="1" x="42.1" y="44.0" timestamp="2026-05-19T14:45:26.732" timestamp_utc="2026-05-19T13:45:26.732" last_modified="2026-05-19T14:45:28" version="1779198326885">
+      <Q id="6428675195" qualifier_id="56" value="Back"/>
+      <Q id="6428675197" qualifier_id="140" value="31.5"/>
+      <Q id="6428675199" qualifier_id="141" value="44.0"/>
+      <Q id="6428675201" qualifier_id="212" value="11.1"/>
+      <Q id="6428675203" qualifier_id="213" value="3.14"/>
+    </Event>
+    <Event id="2939842769" event_id="577" type_id="1" period_id="2" min="67" sec="27" player_id="61812" team_id="417" outcome="1" x="31.2" y="42.8" timestamp="2026-05-19T14:45:28.380" timestamp_utc="2026-05-19T13:45:28.380" last_modified="2026-05-19T14:45:32" version="1779198328514">
+      <Q id="6428675305" qualifier_id="56" value="Back"/>
+      <Q id="6428675307" qualifier_id="140" value="28.7"/>
+      <Q id="6428675309" qualifier_id="141" value="26.1"/>
+      <Q id="6428675311" qualifier_id="212" value="11.7"/>
+      <Q id="6428675313" qualifier_id="213" value="4.49"/>
+    </Event>
+    <Event id="2939842787" event_id="578" type_id="1" period_id="2" min="67" sec="31" player_id="531784" team_id="417" outcome="1" x="36.0" y="25.2" timestamp="2026-05-19T14:45:31.932" timestamp_utc="2026-05-19T13:45:31.932" last_modified="2026-05-19T14:45:34" version="1779198332182">
+      <Q id="6428675417" qualifier_id="56" value="Back"/>
+      <Q id="6428675419" qualifier_id="140" value="48.7"/>
+      <Q id="6428675421" qualifier_id="141" value="23.6"/>
+      <Q id="6428675423" qualifier_id="212" value="13.4"/>
+      <Q id="6428675425" qualifier_id="213" value="6.20"/>
+    </Event>
+    <Event id="2939842793" event_id="579" type_id="1" period_id="2" min="67" sec="33" player_id="157851" team_id="417" outcome="0" x="55.3" y="19.8" timestamp="2026-05-19T14:45:34.046" timestamp_utc="2026-05-19T13:45:34.046" last_modified="2026-05-19T14:45:34" version="1779198334628">
+      <Q id="6428675445" qualifier_id="56" value="Back"/>
+      <Q id="6428675447" qualifier_id="140" value="49.4"/>
+      <Q id="6428675449" qualifier_id="141" value="20.9"/>
+      <Q id="6428675451" qualifier_id="212" value="6.2"/>
+      <Q id="6428675453" qualifier_id="213" value="3.02"/>
+    </Event>
+    <Event id="2939842813" event_id="694" type_id="49" period_id="2" min="67" sec="35" player_id="515742" team_id="244" outcome="1" x="30.6" y="79.6" timestamp="2026-05-19T14:45:36.392" timestamp_utc="2026-05-19T13:45:36.392" last_modified="2026-05-19T14:45:36" version="1779198336393"/>
+    <Event id="2939842815" event_id="695" type_id="1" period_id="2" min="67" sec="36" player_id="515742" team_id="244" outcome="1" x="30.9" y="79.7" timestamp="2026-05-19T14:45:36.671" timestamp_utc="2026-05-19T13:45:36.671" last_modified="2026-05-19T14:45:37" version="1779198337353">
+      <Q id="6428675549" qualifier_id="56" value="Back"/>
+      <Q id="6428675551" qualifier_id="140" value="25.0"/>
+      <Q id="6428675553" qualifier_id="141" value="87.5"/>
+      <Q id="6428675555" qualifier_id="212" value="8.2"/>
+      <Q id="6428675557" qualifier_id="213" value="2.43"/>
+    </Event>
+    <Event id="2939842823" event_id="696" type_id="1" period_id="2" min="67" sec="37" player_id="180662" team_id="244" outcome="1" x="25.0" y="87.5" timestamp="2026-05-19T14:45:37.759" timestamp_utc="2026-05-19T13:45:37.759" last_modified="2026-05-19T14:52:50" version="1779198770695">
+      <Q id="6428675587" qualifier_id="56" value="Back"/>
+      <Q id="6428675589" qualifier_id="140" value="9.0"/>
+      <Q id="6428675591" qualifier_id="141" value="73.2"/>
+      <Q id="6428675593" qualifier_id="212" value="19.4"/>
+      <Q id="6428675595" qualifier_id="213" value="3.67"/>
+    </Event>
+    <Event id="2939842855" event_id="697" type_id="1" period_id="2" min="67" sec="40" player_id="578592" team_id="244" outcome="1" x="9.0" y="73.2" timestamp="2026-05-19T14:45:40.992" timestamp_utc="2026-05-19T13:45:40.992" last_modified="2026-05-19T14:45:45" version="1779198344344">
+      <Q id="6428675807" qualifier_id="1"/>
+      <Q id="6428675797" qualifier_id="56" value="Back"/>
+      <Q id="6428675799" qualifier_id="140" value="41.8"/>
+      <Q id="6428675801" qualifier_id="141" value="85.9"/>
+      <Q id="6428675795" qualifier_id="157"/>
+      <Q id="6428675803" qualifier_id="212" value="35.5"/>
+      <Q id="6428675805" qualifier_id="213" value="0.25"/>
+    </Event>
+    <Event id="2939842857" event_id="698" type_id="61" period_id="2" min="67" sec="44" player_id="648131" team_id="244" outcome="1" x="41.8" y="85.9" timestamp="2026-05-19T14:45:45.359" timestamp_utc="2026-05-19T13:45:45.359" last_modified="2026-05-19T14:45:45" version="1779198345360">
+      <Q id="6428675811" qualifier_id="56" value="Back"/>
+    </Event>
+    <Event id="2939842865" event_id="699" type_id="1" period_id="2" min="67" sec="45" player_id="515742" team_id="244" outcome="0" x="35.9" y="78.7" timestamp="2026-05-19T14:45:46.543" timestamp_utc="2026-05-19T13:45:46.543" last_modified="2026-05-19T14:45:47" version="1779198347240">
+      <Q id="6428675853" qualifier_id="56" value="Back"/>
+      <Q id="6428675855" qualifier_id="140" value="36.5"/>
+      <Q id="6428675857" qualifier_id="141" value="88.7"/>
+      <Q id="6428675859" qualifier_id="212" value="6.8"/>
+      <Q id="6428675861" qualifier_id="213" value="1.48"/>
+    </Event>
+    <Event id="2939842893" event_id="580" type_id="1" period_id="2" min="67" sec="48" player_id="157851" team_id="417" outcome="1" x="57.4" y="15.6" timestamp="2026-05-19T14:45:48.988" timestamp_utc="2026-05-19T13:45:48.988" last_modified="2026-05-19T14:45:56" version="1779198356115">
+      <Q id="6428676025" qualifier_id="1"/>
+      <Q id="6428676015" qualifier_id="56" value="Center"/>
+      <Q id="6428676017" qualifier_id="140" value="91.6"/>
+      <Q id="6428676019" qualifier_id="141" value="25.3"/>
+      <Q id="6428676013" qualifier_id="155"/>
+      <Q id="6428676021" qualifier_id="212" value="36.5"/>
+      <Q id="6428676023" qualifier_id="213" value="0.18"/>
+    </Event>
+    <Event id="2939842901" event_id="581" type_id="50" period_id="2" min="67" sec="53" player_id="445539" team_id="417" outcome="1" x="90.6" y="27.5" timestamp="2026-05-19T14:45:53.798" timestamp_utc="2026-05-19T13:45:53.798" last_modified="2026-05-19T15:26:45" version="1779200796915">
+      <Q id="6428676055" qualifier_id="56" value="Center"/>
+      <Q id="6428676125" qualifier_id="233" value="700"/>
+      <Q id="6428676057" qualifier_id="286"/>
+    </Event>
+    <Event id="2939842903" event_id="700" type_id="7" period_id="2" min="67" sec="53" player_id="627127" team_id="244" outcome="1" x="9.4" y="72.5" timestamp="2026-05-19T14:45:53.799" timestamp_utc="2026-05-19T13:45:53.799" last_modified="2026-05-19T15:26:45" version="1779200796909">
+      <Q id="6428676085" qualifier_id="56" value="Back"/>
+      <Q id="6428676089" qualifier_id="178"/>
+      <Q id="6428676109" qualifier_id="233" value="581"/>
+      <Q id="6428676087" qualifier_id="285"/>
+    </Event>
+    <Event id="2939842907" event_id="701" type_id="43" period_id="2" min="67" sec="54" player_id="627127" team_id="244" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T14:45:54.752" timestamp_utc="2026-05-19T13:45:54.752" last_modified="2026-05-19T15:21:13" version="1779198354753">
+      <Q id="6428728317" qualifier_id="144" value="49"/>
+    </Event>
+    <Event id="2939842919" event_id="702" type_id="1" period_id="2" min="67" sec="55" player_id="627127" team_id="244" outcome="0" x="9.8" y="84.5" timestamp="2026-05-19T14:45:55.560" timestamp_utc="2026-05-19T13:45:55.560" last_modified="2026-05-19T15:21:12" version="1779200472331">
+      <Q id="6428676193" qualifier_id="1"/>
+      <Q id="6428676183" qualifier_id="56" value="Back"/>
+      <Q id="6428676185" qualifier_id="140" value="42.1"/>
+      <Q id="6428676187" qualifier_id="141" value="66.9"/>
+      <Q id="6428676181" qualifier_id="157"/>
+      <Q id="6428676189" qualifier_id="212" value="36.0"/>
+      <Q id="6428676191" qualifier_id="213" value="5.94"/>
+    </Event>
+    <Event id="2939842927" event_id="582" type_id="8" period_id="2" min="68" sec="0" player_id="531784" team_id="417" outcome="1" x="57.9" y="33.1" timestamp="2026-05-19T14:46:00.643" timestamp_utc="2026-05-19T13:46:00.643" last_modified="2026-05-19T15:45:57" version="1779201957412">
+      <Q id="6428676217" qualifier_id="56" value="Center"/>
+    </Event>
+    <Event id="2939848915" event_id="718" type_id="49" period_id="2" min="68" sec="1" player_id="218339" team_id="417" outcome="1" x="63.2" y="36.6" timestamp="2026-05-19T14:46:02.283" timestamp_utc="2026-05-19T13:46:02.283" last_modified="2026-05-19T15:06:26" version="1779199586344"/>
+    <Event id="2939842949" event_id="583" type_id="3" period_id="2" min="68" sec="2" player_id="218339" team_id="417" outcome="0" x="67.8" y="38.0" timestamp="2026-05-19T14:46:03.283" timestamp_utc="2026-05-19T13:46:03.283" last_modified="2026-05-19T14:46:08" version="1779198366057">
+      <Q id="6428676349" qualifier_id="56" value="Center"/>
+      <Q id="6428676499" qualifier_id="233" value="703"/>
+      <Q id="6428676351" qualifier_id="286"/>
+    </Event>
+    <Event id="2939842955" event_id="703" type_id="7" period_id="2" min="68" sec="2" player_id="479433" team_id="244" outcome="1" x="32.2" y="62.0" timestamp="2026-05-19T14:46:03.284" timestamp_utc="2026-05-19T13:46:03.284" last_modified="2026-05-19T14:53:22" version="1779198802143">
+      <Q id="6428676449" qualifier_id="56" value="Back"/>
+      <Q id="6428676453" qualifier_id="178"/>
+      <Q id="6428676481" qualifier_id="233" value="583"/>
+      <Q id="6428676451" qualifier_id="285"/>
+    </Event>
+    <Event id="2939847139" event_id="776" type_id="1" period_id="2" min="68" sec="3" player_id="180662" team_id="244" outcome="1" x="22.2" y="49.9" timestamp="2026-05-19T14:46:03.663" timestamp_utc="2026-05-19T13:46:03.663" last_modified="2026-05-19T14:59:13" version="1779199153530">
+      <Q id="6428701037" qualifier_id="1"/>
+      <Q id="6428701027" qualifier_id="56" value="Back"/>
+      <Q id="6428701029" qualifier_id="140" value="44.3"/>
+      <Q id="6428701031" qualifier_id="141" value="65.1"/>
+      <Q id="6428701025" qualifier_id="157"/>
+      <Q id="6428701033" qualifier_id="212" value="25.4"/>
+      <Q id="6428701035" qualifier_id="213" value="0.42"/>
+    </Event>
+    <Event id="2939849207" event_id="823" type_id="49" period_id="2" min="68" sec="6" player_id="648131" team_id="244" outcome="1" x="50.0" y="50.0" timestamp="2026-05-19T14:46:07.055" timestamp_utc="2026-05-19T13:46:07.055" last_modified="2026-05-19T15:07:52" version="1779199672441"/>
+    <Event id="2939849095" event_id="819" type_id="43" period_id="2" min="68" sec="7" player_id="180662" team_id="244" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T14:46:08.055" timestamp_utc="2026-05-19T13:46:08.055" last_modified="2026-05-19T15:08:06" version="1779199669655">
+      <Q id="6428714055" qualifier_id="144" value="83"/>
+    </Event>
+    <Event id="2939849383" event_id="723" type_id="83" period_id="2" min="68" sec="7" player_id="531784" team_id="417" outcome="0" x="58.1" y="30.1" timestamp="2026-05-19T14:46:08.055" timestamp_utc="2026-05-19T13:46:08.055" last_modified="2026-05-19T15:08:35" version="1779199715135">
+      <Q id="6428714549" qualifier_id="399" value="648131"/>
+    </Event>
+    <Event id="2939842975" event_id="705" type_id="3" period_id="2" min="68" sec="8" player_id="648131" team_id="244" outcome="0" x="37.8" y="64.0" timestamp="2026-05-19T14:46:09.055" timestamp_utc="2026-05-19T13:46:09.055" last_modified="2026-05-19T15:21:52" version="1779200511961">
+      <Q id="6428676567" qualifier_id="56" value="Back"/>
+      <Q id="6428676607" qualifier_id="233" value="584"/>
+      <Q id="6428676569" qualifier_id="286"/>
+    </Event>
+    <Event id="2939842977" event_id="584" type_id="7" period_id="2" min="68" sec="8" player_id="720682" team_id="417" outcome="0" x="62.2" y="36.0" timestamp="2026-05-19T14:46:09.056" timestamp_utc="2026-05-19T13:46:09.056" last_modified="2026-05-19T14:46:11" version="1779198369924">
+      <Q id="6428676589" qualifier_id="56" value="Center"/>
+      <Q id="6428676593" qualifier_id="178"/>
+      <Q id="6428676599" qualifier_id="233" value="705"/>
+      <Q id="6428676591" qualifier_id="285"/>
+    </Event>
+    <Event id="2939842979" event_id="706" type_id="61" period_id="2" min="68" sec="9" player_id="648131" team_id="244" outcome="1" x="35.6" y="62.3" timestamp="2026-05-19T14:46:10.200" timestamp_utc="2026-05-19T13:46:10.200" last_modified="2026-05-19T14:46:10" version="1779198370201">
+      <Q id="6428676603" qualifier_id="56" value="Back"/>
+    </Event>
+    <Event id="2939843001" event_id="707" type_id="1" period_id="2" min="68" sec="10" player_id="515742" team_id="244" outcome="1" x="33.8" y="52.7" timestamp="2026-05-19T14:46:11.191" timestamp_utc="2026-05-19T13:46:11.191" last_modified="2026-05-19T14:46:14" version="1779198374025">
+      <Q id="6428676733" qualifier_id="56" value="Back"/>
+      <Q id="6428676735" qualifier_id="140" value="46.0"/>
+      <Q id="6428676737" qualifier_id="141" value="46.1"/>
+      <Q id="6428676739" qualifier_id="212" value="13.6"/>
+      <Q id="6428676741" qualifier_id="213" value="5.95"/>
+    </Event>
+    <Event id="2939843013" event_id="708" type_id="1" period_id="2" min="68" sec="13" player_id="479433" team_id="244" outcome="1" x="46.0" y="46.1" timestamp="2026-05-19T14:46:14.471" timestamp_utc="2026-05-19T13:46:14.471" last_modified="2026-05-19T14:46:15" version="1779198375129">
+      <Q id="6428676791" qualifier_id="56" value="Back"/>
+      <Q id="6428676793" qualifier_id="140" value="42.4"/>
+      <Q id="6428676795" qualifier_id="141" value="29.1"/>
+      <Q id="6428676797" qualifier_id="212" value="12.2"/>
+      <Q id="6428676799" qualifier_id="213" value="4.40"/>
+    </Event>
+    <Event id="2939843017" event_id="709" type_id="1" period_id="2" min="68" sec="15" player_id="240166" team_id="244" outcome="1" x="42.4" y="29.1" timestamp="2026-05-19T14:46:15.567" timestamp_utc="2026-05-19T13:46:15.567" last_modified="2026-05-19T15:22:03" version="1779200523626">
+      <Q id="6428676819" qualifier_id="56" value="Right"/>
+      <Q id="6428676821" qualifier_id="140" value="58.2"/>
+      <Q id="6428676823" qualifier_id="141" value="17.6"/>
+      <Q id="6428676825" qualifier_id="212" value="18.3"/>
+      <Q id="6428676827" qualifier_id="213" value="5.84"/>
+    </Event>
+    <Event id="2939843027" event_id="585" type_id="83" period_id="2" min="68" sec="18" player_id="624620" team_id="417" outcome="0" x="33.8" y="78.2" timestamp="2026-05-19T14:46:18.819" timestamp_utc="2026-05-19T13:46:18.819" last_modified="2026-05-19T14:46:21" version="1779198381650">
+      <Q id="6428676935" qualifier_id="399" value="625775"/>
+    </Event>
+    <Event id="2939843037" event_id="710" type_id="61" period_id="2" min="68" sec="20" player_id="625775" team_id="244" outcome="0" x="65.1" y="18.2" timestamp="2026-05-19T14:46:20.752" timestamp_utc="2026-05-19T13:46:20.752" last_modified="2026-05-19T14:46:21" version="1779198380753">
+      <Q id="6428676917" qualifier_id="56" value="Right"/>
+    </Event>
+    <Event id="2939843047" event_id="586" type_id="49" period_id="2" min="68" sec="22" player_id="624620" team_id="417" outcome="1" x="43.0" y="85.4" timestamp="2026-05-19T14:46:22.563" timestamp_utc="2026-05-19T13:46:22.563" last_modified="2026-05-19T14:46:22" version="1779198382564"/>
+    <Event id="2939843059" event_id="587" type_id="4" period_id="2" min="68" sec="23" player_id="624620" team_id="417" outcome="1" x="53.4" y="89.0" timestamp="2026-05-19T14:46:23.766" timestamp_utc="2026-05-19T13:46:23.766" last_modified="2026-05-19T14:46:28" version="1779198388092">
+      <Q id="6428677027" qualifier_id="13"/>
+      <Q id="6428677029" qualifier_id="56" value="Left"/>
+      <Q id="6428677031" qualifier_id="152"/>
+      <Q id="6428677089" qualifier_id="233" value="711"/>
+      <Q id="6428677033" qualifier_id="265"/>
+      <Q id="6428677035" qualifier_id="286"/>
+    </Event>
+    <Event id="2939843053" event_id="711" type_id="4" period_id="2" min="68" sec="23" player_id="232091" team_id="244" outcome="0" x="46.6" y="11.0" timestamp="2026-05-19T14:46:23.767" timestamp_utc="2026-05-19T13:46:23.767" last_modified="2026-05-19T14:46:35" version="1779198395382">
+      <Q id="6428677065" qualifier_id="13"/>
+      <Q id="6428677371" qualifier_id="55" value="712"/>
+      <Q id="6428677067" qualifier_id="56" value="Back"/>
+      <Q id="6428677069" qualifier_id="152"/>
+      <Q id="6428677091" qualifier_id="233" value="587"/>
+      <Q id="6428677071" qualifier_id="265"/>
+      <Q id="6428677073" qualifier_id="285"/>
+    </Event>
+    <Event id="2939843069" event_id="712" type_id="17" period_id="2" min="68" sec="29" player_id="232091" team_id="244" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T14:46:29.784" timestamp_utc="2026-05-19T13:46:29.784" last_modified="2026-05-19T15:22:13" version="1779200533635">
+      <Q id="6428677363" qualifier_id="13" value="243"/>
+      <Q id="6428677359" qualifier_id="31"/>
+      <Q id="6428677365" qualifier_id="55" value="711"/>
+      <Q id="6428729093" qualifier_id="393"/>
+    </Event>
+    <Event id="2939843509" event_id="715" type_id="18" period_id="2" min="68" sec="54" player_id="648131" team_id="244" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T14:46:54.850" timestamp_utc="2026-05-19T13:46:54.850" last_modified="2026-05-19T14:48:47" version="1779198527171">
+      <Q id="6428679751" qualifier_id="42"/>
+      <Q id="6428679755" qualifier_id="44" value="Midfielder"/>
+      <Q id="6428679789" qualifier_id="55" value="716"/>
+      <Q id="6428679759" qualifier_id="59" value="26"/>
+    </Event>
+    <Event id="2939843513" event_id="716" type_id="19" period_id="2" min="68" sec="54" player_id="246081" team_id="244" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T14:46:54.851" timestamp_utc="2026-05-19T13:46:54.851" last_modified="2026-05-19T15:46:13" version="1779201973332">
+      <Q id="6428679769" qualifier_id="42"/>
+      <Q id="6428679777" qualifier_id="44" value="Midfielder"/>
+      <Q id="6428679779" qualifier_id="55" value="715"/>
+      <Q id="6428679775" qualifier_id="59" value="23"/>
+      <Q id="6428679773" qualifier_id="145" value="11"/>
+      <Q id="6428737827" qualifier_id="292" value="6"/>
+      <Q id="6428681005" qualifier_id="293" value="4"/>
+    </Event>
+    <Event id="2939843453" event_id="713" type_id="18" period_id="2" min="69" sec="10" player_id="625775" team_id="244" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T14:47:11.274" timestamp_utc="2026-05-19T13:47:11.274" last_modified="2026-05-19T14:50:47" version="1779198647714">
+      <Q id="6428679495" qualifier_id="42"/>
+      <Q id="6428679497" qualifier_id="44" value="Forward"/>
+      <Q id="6428679533" qualifier_id="55" value="714"/>
+      <Q id="6428679499" qualifier_id="59" value="7"/>
+      <Q id="6428684955" qualifier_id="189"/>
+    </Event>
+    <Event id="2939843457" event_id="714" type_id="19" period_id="2" min="69" sec="10" player_id="508143" team_id="244" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T14:47:11.275" timestamp_utc="2026-05-19T13:47:11.275" last_modified="2026-05-19T15:46:15" version="1779201975074">
+      <Q id="6428679505" qualifier_id="42"/>
+      <Q id="6428679513" qualifier_id="44" value="Midfielder"/>
+      <Q id="6428679515" qualifier_id="55" value="713"/>
+      <Q id="6428679511" qualifier_id="59" value="9"/>
+      <Q id="6428679509" qualifier_id="145" value="10"/>
+      <Q id="6428685089" qualifier_id="189"/>
+      <Q id="6428737853" qualifier_id="292" value="6"/>
+      <Q id="6428683101" qualifier_id="293" value="5"/>
+    </Event>
+    <Event id="2939843367" event_id="588" type_id="18" period_id="2" min="69" sec="12" player_id="164593" team_id="417" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T14:47:13.473" timestamp_utc="2026-05-19T13:47:13.473" last_modified="2026-05-19T14:50:40" version="1779198640138">
+      <Q id="6428678875" qualifier_id="42"/>
+      <Q id="6428678877" qualifier_id="44" value="Defender"/>
+      <Q id="6428678899" qualifier_id="55" value="589"/>
+      <Q id="6428678879" qualifier_id="59" value="19"/>
+      <Q id="6428684707" qualifier_id="189"/>
+    </Event>
+    <Event id="2939843369" event_id="589" type_id="19" period_id="2" min="69" sec="12" player_id="683488" team_id="417" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T14:47:13.474" timestamp_utc="2026-05-19T13:47:13.474" last_modified="2026-05-19T14:50:38" version="1779198638202">
+      <Q id="6428678881" qualifier_id="42"/>
+      <Q id="6428678893" qualifier_id="44" value="Defender"/>
+      <Q id="6428678895" qualifier_id="55" value="588"/>
+      <Q id="6428678887" qualifier_id="59" value="25"/>
+      <Q id="6428678885" qualifier_id="145" value="3"/>
+      <Q id="6428684675" qualifier_id="189"/>
+      <Q id="6428678889" qualifier_id="292" value="3"/>
+      <Q id="6428678891" qualifier_id="293" value="1"/>
+    </Event>
+    <Event id="2939843401" event_id="590" type_id="18" period_id="2" min="69" sec="15" player_id="218339" team_id="417" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T14:47:16.200" timestamp_utc="2026-05-19T13:47:16.200" last_modified="2026-05-19T14:50:33" version="1779198633179">
+      <Q id="6428679113" qualifier_id="42"/>
+      <Q id="6428679115" qualifier_id="44" value="Midfielder"/>
+      <Q id="6428679163" qualifier_id="55" value="591"/>
+      <Q id="6428679117" qualifier_id="59" value="23"/>
+      <Q id="6428684505" qualifier_id="189"/>
+    </Event>
+    <Event id="2939843407" event_id="591" type_id="19" period_id="2" min="69" sec="15" player_id="570078" team_id="417" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T14:47:16.201" timestamp_utc="2026-05-19T13:47:16.201" last_modified="2026-05-19T14:50:35" version="1779198635322">
+      <Q id="6428679143" qualifier_id="42"/>
+      <Q id="6428679155" qualifier_id="44" value="Midfielder"/>
+      <Q id="6428679157" qualifier_id="55" value="590"/>
+      <Q id="6428679149" qualifier_id="59" value="16"/>
+      <Q id="6428679147" qualifier_id="145" value="8"/>
+      <Q id="6428684575" qualifier_id="189"/>
+      <Q id="6428679151" qualifier_id="292" value="7"/>
+      <Q id="6428679153" qualifier_id="293" value="3"/>
+    </Event>
+    <Event id="2939843463" event_id="592" type_id="1" period_id="2" min="69" sec="43" player_id="685390" team_id="417" outcome="0" x="58.8" y="84.7" timestamp="2026-05-19T14:47:43.699" timestamp_utc="2026-05-19T13:47:43.699" last_modified="2026-05-19T14:47:46" version="1779198466827">
+      <Q id="6428679565" qualifier_id="1"/>
+      <Q id="6428679549" qualifier_id="5"/>
+      <Q id="6428679555" qualifier_id="56" value="Center"/>
+      <Q id="6428679557" qualifier_id="140" value="90.6"/>
+      <Q id="6428679559" qualifier_id="141" value="33.6"/>
+      <Q id="6428679553" qualifier_id="152"/>
+      <Q id="6428679551" qualifier_id="155"/>
+      <Q id="6428679561" qualifier_id="212" value="48.2"/>
+      <Q id="6428679563" qualifier_id="213" value="5.48"/>
+    </Event>
+    <Event id="2939843581" event_id="717" type_id="4" period_id="2" min="69" sec="46" player_id="575855" team_id="244" outcome="1" x="9.6" y="65.6" timestamp="2026-05-19T14:47:46.647" timestamp_utc="2026-05-19T13:47:46.647" last_modified="2026-05-19T16:22:20" version="1779204140348">
+      <Q id="6428680549" qualifier_id="13"/>
+      <Q id="6428680183" qualifier_id="56" value="Back"/>
+      <Q id="6428680553" qualifier_id="152"/>
+      <Q id="6428680757" qualifier_id="233" value="593"/>
+      <Q id="6428680185" qualifier_id="285"/>
+      <Q id="6428680733" qualifier_id="294"/>
+    </Event>
+    <Event id="2939843469" event_id="593" type_id="4" period_id="2" min="69" sec="46" player_id="61812" team_id="417" outcome="0" x="90.4" y="34.4" timestamp="2026-05-19T14:47:46.648" timestamp_utc="2026-05-19T13:47:46.648" last_modified="2026-05-19T15:26:42" version="1779200795467">
+      <Q id="6428680749" qualifier_id="13"/>
+      <Q id="6428679597" qualifier_id="56" value="Center"/>
+      <Q id="6428680753" qualifier_id="152"/>
+      <Q id="6428680763" qualifier_id="233" value="717"/>
+      <Q id="6428679599" qualifier_id="286"/>
+      <Q id="6428680751" qualifier_id="294"/>
+    </Event>
+    <Event id="2939843781" event_id="718" type_id="1" period_id="2" min="70" sec="50" player_id="578592" team_id="244" outcome="1" x="9.4" y="65.5" timestamp="2026-05-19T14:48:50.911" timestamp_utc="2026-05-19T13:48:50.911" last_modified="2026-05-19T14:48:56" version="1779198531698">
+      <Q id="6428681259" qualifier_id="5"/>
+      <Q id="6428681263" qualifier_id="56" value="Back"/>
+      <Q id="6428681265" qualifier_id="140" value="5.1"/>
+      <Q id="6428681267" qualifier_id="141" value="42.8"/>
+      <Q id="6428681261" qualifier_id="152"/>
+      <Q id="6428681269" qualifier_id="212" value="16.1"/>
+      <Q id="6428681271" qualifier_id="213" value="4.43"/>
+    </Event>
+    <Event id="2939843791" event_id="719" type_id="1" period_id="2" min="70" sec="55" player_id="627127" team_id="244" outcome="1" x="10.5" y="30.7" timestamp="2026-05-19T14:48:56.297" timestamp_utc="2026-05-19T13:48:56.297" last_modified="2026-05-19T14:48:58" version="1779198537186">
+      <Q id="6428681337" qualifier_id="1"/>
+      <Q id="6428681327" qualifier_id="56" value="Center"/>
+      <Q id="6428681329" qualifier_id="140" value="55.7"/>
+      <Q id="6428681331" qualifier_id="141" value="32.7"/>
+      <Q id="6428681325" qualifier_id="155"/>
+      <Q id="6428681333" qualifier_id="212" value="47.5"/>
+      <Q id="6428681335" qualifier_id="213" value="0.03"/>
+    </Event>
+    <Event id="2939843801" event_id="720" type_id="1" period_id="2" min="70" sec="57" player_id="232091" team_id="244" outcome="1" x="55.7" y="32.7" timestamp="2026-05-19T14:48:57.855" timestamp_utc="2026-05-19T13:48:57.855" last_modified="2026-05-19T14:48:59" version="1779198538458">
+      <Q id="6428681379" qualifier_id="3"/>
+      <Q id="6428681383" qualifier_id="56" value="Center"/>
+      <Q id="6428681385" qualifier_id="140" value="64.1"/>
+      <Q id="6428681387" qualifier_id="141" value="38.3"/>
+      <Q id="6428681381" qualifier_id="168"/>
+      <Q id="6428681389" qualifier_id="212" value="9.6"/>
+      <Q id="6428681391" qualifier_id="213" value="0.41"/>
+    </Event>
+    <Event id="2939843805" event_id="721" type_id="1" period_id="2" min="70" sec="58" player_id="508143" team_id="244" outcome="1" x="64.1" y="38.3" timestamp="2026-05-19T14:48:59.407" timestamp_utc="2026-05-19T13:48:59.407" last_modified="2026-05-19T14:50:06" version="1779198606344">
+      <Q id="6428681407" qualifier_id="56" value="Center"/>
+      <Q id="6428681409" qualifier_id="140" value="53.6"/>
+      <Q id="6428681411" qualifier_id="141" value="47.8"/>
+      <Q id="6428681431" qualifier_id="156"/>
+      <Q id="6428681413" qualifier_id="212" value="12.8"/>
+      <Q id="6428681415" qualifier_id="213" value="2.61"/>
+    </Event>
+    <Event id="2939843815" event_id="722" type_id="1" period_id="2" min="70" sec="59" player_id="246081" team_id="244" outcome="0" x="53.6" y="47.8" timestamp="2026-05-19T14:49:00.497" timestamp_utc="2026-05-19T13:49:00.497" last_modified="2026-05-19T14:51:43" version="1779198703477">
+      <Q id="6428681465" qualifier_id="56" value="Center"/>
+      <Q id="6428681467" qualifier_id="140" value="59.3"/>
+      <Q id="6428681469" qualifier_id="141" value="49.7"/>
+      <Q id="6428681471" qualifier_id="212" value="6.1"/>
+      <Q id="6428681473" qualifier_id="213" value="0.21"/>
+      <Q id="6428681493" qualifier_id="233" value="594"/>
+      <Q id="6428681491" qualifier_id="236"/>
+      <Q id="6428681497" qualifier_id="286"/>
+    </Event>
+    <Event id="2939843811" event_id="594" type_id="74" period_id="2" min="70" sec="59" player_id="61812" team_id="417" outcome="1" x="40.7" y="50.3" timestamp="2026-05-19T14:49:00.498" timestamp_utc="2026-05-19T13:49:00.498" last_modified="2026-05-19T15:45:53" version="1779201953503">
+      <Q id="6428681445" qualifier_id="56" value="Back"/>
+      <Q id="6428681501" qualifier_id="233" value="722"/>
+      <Q id="6428681447" qualifier_id="285"/>
+    </Event>
+    <Event id="2939843853" event_id="723" type_id="1" period_id="2" min="71" sec="5" player_id="180662" team_id="244" outcome="1" x="33.5" y="81.7" timestamp="2026-05-19T14:49:06.207" timestamp_utc="2026-05-19T13:49:06.207" last_modified="2026-05-19T14:51:17" version="1779198677353">
+      <Q id="6428681679" qualifier_id="56" value="Left"/>
+      <Q id="6428681681" qualifier_id="140" value="54.6"/>
+      <Q id="6428681683" qualifier_id="141" value="86.2"/>
+      <Q id="6428681685" qualifier_id="212" value="22.4"/>
+      <Q id="6428681687" qualifier_id="213" value="0.14"/>
+    </Event>
+    <Event id="2939843859" event_id="725" type_id="3" period_id="2" min="71" sec="6" player_id="207884" team_id="244" outcome="1" x="49.8" y="86.2" timestamp="2026-05-19T14:49:07.263" timestamp_utc="2026-05-19T13:49:07.263" last_modified="2026-05-19T14:51:36" version="1779198696147">
+      <Q id="6428681721" qualifier_id="56" value="Back"/>
+      <Q id="6428681749" qualifier_id="233" value="595"/>
+      <Q id="6428681723" qualifier_id="286"/>
+    </Event>
+    <Event id="2939843865" event_id="595" type_id="45" period_id="2" min="71" sec="6" player_id="157851" team_id="417" outcome="0" x="50.2" y="13.8" timestamp="2026-05-19T14:49:07.263" timestamp_utc="2026-05-19T13:49:07.263" last_modified="2026-05-19T15:26:47" version="1779200797347">
+      <Q id="6428681743" qualifier_id="56" value="Right"/>
+      <Q id="6428681763" qualifier_id="233" value="725"/>
+      <Q id="6428681745" qualifier_id="285"/>
+    </Event>
+    <Event id="2939843857" event_id="724" type_id="1" period_id="2" min="71" sec="6" player_id="207884" team_id="244" outcome="1" x="53.6" y="85.9" timestamp="2026-05-19T14:49:07.343" timestamp_utc="2026-05-19T13:49:07.343" last_modified="2026-05-19T14:49:08" version="1779198547866">
+      <Q id="6428681705" qualifier_id="56" value="Back"/>
+      <Q id="6428681707" qualifier_id="140" value="42.4"/>
+      <Q id="6428681709" qualifier_id="141" value="80.2"/>
+      <Q id="6428681711" qualifier_id="212" value="12.4"/>
+      <Q id="6428681713" qualifier_id="213" value="3.46"/>
+    </Event>
+    <Event id="2939843885" event_id="726" type_id="1" period_id="2" min="71" sec="10" player_id="515742" team_id="244" outcome="1" x="41.0" y="74.5" timestamp="2026-05-19T14:49:10.903" timestamp_utc="2026-05-19T13:49:10.903" last_modified="2026-05-19T14:49:14" version="1779198551593">
+      <Q id="6428681849" qualifier_id="56" value="Back"/>
+      <Q id="6428681851" qualifier_id="140" value="34.0"/>
+      <Q id="6428681853" qualifier_id="141" value="59.7"/>
+      <Q id="6428681855" qualifier_id="212" value="12.5"/>
+      <Q id="6428681857" qualifier_id="213" value="4.08"/>
+    </Event>
+    <Event id="2939843889" event_id="727" type_id="1" period_id="2" min="71" sec="12" player_id="627127" team_id="244" outcome="1" x="34.3" y="53.4" timestamp="2026-05-19T14:49:13.342" timestamp_utc="2026-05-19T13:49:13.342" last_modified="2026-05-19T14:49:15" version="1779198553765">
+      <Q id="6428681865" qualifier_id="56" value="Back"/>
+      <Q id="6428681867" qualifier_id="140" value="41.1"/>
+      <Q id="6428681869" qualifier_id="141" value="28.2"/>
+      <Q id="6428681871" qualifier_id="212" value="18.6"/>
+      <Q id="6428681873" qualifier_id="213" value="5.11"/>
+    </Event>
+    <Event id="2939843897" event_id="728" type_id="1" period_id="2" min="71" sec="15" player_id="240166" team_id="244" outcome="1" x="43.8" y="24.1" timestamp="2026-05-19T14:49:15.703" timestamp_utc="2026-05-19T13:49:15.703" last_modified="2026-05-19T14:49:17" version="1779198556319">
+      <Q id="6428681915" qualifier_id="56" value="Center"/>
+      <Q id="6428681917" qualifier_id="140" value="63.3"/>
+      <Q id="6428681919" qualifier_id="141" value="31.6"/>
+      <Q id="6428681921" qualifier_id="212" value="21.1"/>
+      <Q id="6428681923" qualifier_id="213" value="0.24"/>
+    </Event>
+    <Event id="2939843915" event_id="729" type_id="1" period_id="2" min="71" sec="16" player_id="232091" team_id="244" outcome="0" x="60.4" y="30.4" timestamp="2026-05-19T14:49:17.031" timestamp_utc="2026-05-19T13:49:17.031" last_modified="2026-05-19T14:49:18" version="1779198558587">
+      <Q id="6428682021" qualifier_id="56" value="Right"/>
+      <Q id="6428682023" qualifier_id="140" value="59.2"/>
+      <Q id="6428682025" qualifier_id="141" value="0.0"/>
+      <Q id="6428682027" qualifier_id="212" value="21.4"/>
+      <Q id="6428682029" qualifier_id="213" value="4.65"/>
+    </Event>
+    <Event id="2939843917" event_id="730" type_id="5" period_id="2" min="71" sec="18" player_id="232091" team_id="244" outcome="0" x="60.7" y="-1.0" timestamp="2026-05-19T14:49:18.607" timestamp_utc="2026-05-19T13:49:18.607" last_modified="2026-05-19T15:26:36" version="1779200790242">
+      <Q id="6428682031" qualifier_id="56" value="Right"/>
+      <Q id="6428682201" qualifier_id="233" value="596"/>
+      <Q id="6428682033" qualifier_id="347"/>
+    </Event>
+    <Event id="2939843941" event_id="596" type_id="5" period_id="2" min="71" sec="18" player_id="157851" team_id="417" outcome="1" x="39.3" y="101.0" timestamp="2026-05-19T14:49:18.607" timestamp_utc="2026-05-19T13:49:18.607" last_modified="2026-05-19T15:26:36" version="1779200790231">
+      <Q id="6428682191" qualifier_id="56" value="Back"/>
+      <Q id="6428682197" qualifier_id="233" value="730"/>
+      <Q id="6428682193" qualifier_id="347"/>
+    </Event>
+    <Event id="2939843963" event_id="597" type_id="1" period_id="2" min="71" sec="23" player_id="570078" team_id="417" outcome="1" x="36.9" y="100.0" timestamp="2026-05-19T14:49:23.625" timestamp_utc="2026-05-19T13:49:23.625" last_modified="2026-05-19T14:49:25" version="1779198563863">
+      <Q id="6428682311" qualifier_id="56" value="Back"/>
+      <Q id="6428682309" qualifier_id="107"/>
+      <Q id="6428682313" qualifier_id="140" value="30.4"/>
+      <Q id="6428682315" qualifier_id="141" value="85.4"/>
+      <Q id="6428682317" qualifier_id="212" value="12.7"/>
+      <Q id="6428682319" qualifier_id="213" value="4.14"/>
+    </Event>
+    <Event id="2939843985" event_id="598" type_id="1" period_id="2" min="71" sec="25" player_id="624620" team_id="417" outcome="0" x="30.2" y="87.1" timestamp="2026-05-19T14:49:25.745" timestamp_utc="2026-05-19T13:49:25.745" last_modified="2026-05-19T14:49:27" version="1779198567834">
+      <Q id="6428682415" qualifier_id="56" value="Left"/>
+      <Q id="6428682417" qualifier_id="140" value="50.4"/>
+      <Q id="6428682419" qualifier_id="141" value="86.2"/>
+      <Q id="6428682413" qualifier_id="155"/>
+      <Q id="6428682421" qualifier_id="212" value="21.2"/>
+      <Q id="6428682423" qualifier_id="213" value="6.25"/>
+    </Event>
+    <Event id="2939843983" event_id="731" type_id="8" period_id="2" min="71" sec="27" player_id="240166" team_id="244" outcome="1" x="49.6" y="13.8" timestamp="2026-05-19T14:49:27.719" timestamp_utc="2026-05-19T13:49:27.719" last_modified="2026-05-19T15:45:57" version="1779201957678">
+      <Q id="6428682449" qualifier_id="15"/>
+      <Q id="6428682409" qualifier_id="56" value="Back"/>
+    </Event>
+    <Event id="2939843999" event_id="732" type_id="1" period_id="2" min="71" sec="28" player_id="232091" team_id="244" outcome="1" x="56.5" y="19.4" timestamp="2026-05-19T14:49:28.935" timestamp_utc="2026-05-19T13:49:28.935" last_modified="2026-05-19T14:49:30" version="1779198569883">
+      <Q id="6428682493" qualifier_id="56" value="Back"/>
+      <Q id="6428682495" qualifier_id="140" value="41.6"/>
+      <Q id="6428682497" qualifier_id="141" value="24.1"/>
+      <Q id="6428682505" qualifier_id="156"/>
+      <Q id="6428682499" qualifier_id="212" value="16.0"/>
+      <Q id="6428682501" qualifier_id="213" value="2.94"/>
+    </Event>
+    <Event id="2939844011" event_id="733" type_id="49" period_id="2" min="71" sec="29" player_id="515742" team_id="244" outcome="1" x="36.7" y="28.2" timestamp="2026-05-19T14:49:30.465" timestamp_utc="2026-05-19T13:49:30.465" last_modified="2026-05-19T14:49:30" version="1779198570466"/>
+    <Event id="2939844069" event_id="734" type_id="1" period_id="2" min="71" sec="36" player_id="515742" team_id="244" outcome="1" x="69.1" y="28.6" timestamp="2026-05-19T14:49:37.199" timestamp_utc="2026-05-19T13:49:37.199" last_modified="2026-05-19T14:49:41" version="1779198577514">
+      <Q id="6428682907" qualifier_id="56" value="Right"/>
+      <Q id="6428682909" qualifier_id="140" value="79.2"/>
+      <Q id="6428682911" qualifier_id="141" value="15.3"/>
+      <Q id="6428682913" qualifier_id="212" value="13.9"/>
+      <Q id="6428682915" qualifier_id="213" value="5.58"/>
+    </Event>
+    <Event id="2939844071" event_id="735" type_id="1" period_id="2" min="71" sec="40" player_id="479433" team_id="244" outcome="0" x="89.3" y="13.1" timestamp="2026-05-19T14:49:41.479" timestamp_utc="2026-05-19T13:49:41.479" last_modified="2026-05-19T14:49:43" version="1779198582784">
+      <Q id="6428682921" qualifier_id="2"/>
+      <Q id="6428682925" qualifier_id="56" value="Center"/>
+      <Q id="6428682927" qualifier_id="140" value="90.1"/>
+      <Q id="6428682929" qualifier_id="141" value="40.6"/>
+      <Q id="6428682931" qualifier_id="212" value="18.7"/>
+      <Q id="6428682933" qualifier_id="213" value="1.53"/>
+    </Event>
+    <Event id="2939844085" event_id="599" type_id="12" period_id="2" min="71" sec="42" player_id="624620" team_id="417" outcome="1" x="9.5" y="69.4" timestamp="2026-05-19T14:49:43.473" timestamp_utc="2026-05-19T13:49:43.473" last_modified="2026-05-19T14:49:45" version="1779198584621">
+      <Q id="6428683001" qualifier_id="56" value="Back"/>
+      <Q id="6428683003" qualifier_id="140" value="0.0"/>
+      <Q id="6428683005" qualifier_id="141" value="85.7"/>
+      <Q id="6428683027" qualifier_id="167"/>
+      <Q id="6428683007" qualifier_id="212" value="15.6"/>
+      <Q id="6428683009" qualifier_id="213" value="2.35"/>
+    </Event>
+    <Event id="2939844079" event_id="736" type_id="6" period_id="2" min="71" sec="42" player_id="479433" team_id="244" outcome="1" x="96.6" y="24.8" timestamp="2026-05-19T14:49:43.551" timestamp_utc="2026-05-19T13:49:43.551" last_modified="2026-05-19T14:49:47" version="1779198585559">
+      <Q id="6428683023" qualifier_id="56" value="Center"/>
+      <Q id="6428683025" qualifier_id="75"/>
+      <Q id="6428683055" qualifier_id="233" value="600"/>
+    </Event>
+    <Event id="2939844089" event_id="600" type_id="6" period_id="2" min="71" sec="42" player_id="624620" team_id="417" outcome="0" x="3.4" y="75.2" timestamp="2026-05-19T14:49:43.551" timestamp_utc="2026-05-19T13:49:43.551" last_modified="2026-05-19T15:27:45" version="1779200864958">
+      <Q id="6428683045" qualifier_id="56" value="Back"/>
+      <Q id="6428683047" qualifier_id="73"/>
+      <Q id="6428683073" qualifier_id="233" value="736"/>
+    </Event>
+    <Event id="2939844245" event_id="737" type_id="1" period_id="2" min="72" sec="12" player_id="207884" team_id="244" outcome="1" x="99.5" y="0.5" keypass="1" timestamp="2026-05-19T14:50:13.551" timestamp_utc="2026-05-19T13:50:13.551" last_modified="2026-05-19T16:31:40" version="1779204700272">
+      <Q id="6428774593" qualifier_id="1"/>
+      <Q id="6428683961" qualifier_id="2"/>
+      <Q id="6428683963" qualifier_id="6"/>
+      <Q id="6428683969" qualifier_id="56" value="Center"/>
+      <Q id="6428683971" qualifier_id="140" value="91.8"/>
+      <Q id="6428683973" qualifier_id="141" value="46.2"/>
+      <Q id="6428684993" qualifier_id="154"/>
+      <Q id="6428683965" qualifier_id="155"/>
+      <Q id="6428684991" qualifier_id="210" value="15"/>
+      <Q id="6428683975" qualifier_id="212" value="32.1"/>
+      <Q id="6428683977" qualifier_id="213" value="1.83"/>
+      <Q id="6428683967" qualifier_id="224"/>
+    </Event>
+    <Event id="2939844249" event_id="738" type_id="15" period_id="2" min="72" sec="15" player_id="627127" team_id="244" outcome="1" x="91.8" y="46.2" timestamp="2026-05-19T14:50:16.311" timestamp_utc="2026-05-19T13:50:16.311" last_modified="2026-05-19T15:58:21" version="1779202701657">
+      <Q id="6428684831" qualifier_id="15"/>
+      <Q id="6428683997" qualifier_id="17"/>
+      <Q id="6428684829" qualifier_id="25"/>
+      <Q id="6428684999" qualifier_id="29"/>
+      <Q id="6428685003" qualifier_id="55" value="737"/>
+      <Q id="6428683999" qualifier_id="56" value="Center"/>
+      <Q id="6428684997" qualifier_id="76"/>
+      <Q id="6428684837" qualifier_id="82"/>
+      <Q id="6428685011" qualifier_id="100"/>
+      <Q id="6428730149" qualifier_id="101"/>
+      <Q id="6428685007" qualifier_id="102" value="54.6"/>
+      <Q id="6428685009" qualifier_id="103" value="19.0"/>
+      <Q id="6428685013" qualifier_id="146" value="98.9"/>
+      <Q id="6428685015" qualifier_id="147" value="53.4"/>
+      <Q id="6428685001" qualifier_id="154"/>
+      <Q id="6428685017" qualifier_id="230" value="98.9"/>
+      <Q id="6428685019" qualifier_id="231" value="48.0"/>
+      <Q id="6428719179" qualifier_id="233" value="601"/>
+      <Q id="6428684835" qualifier_id="328"/>
+    </Event>
+    <Event id="2939844271" event_id="601" type_id="10" period_id="2" min="72" sec="15" player_id="624620" team_id="417" outcome="1" x="1.1" y="47.0" timestamp="2026-05-19T14:50:16.411" timestamp_utc="2026-05-19T13:50:16.411" last_modified="2026-05-19T15:23:36" version="1779200616544">
+      <Q id="6428684227" qualifier_id="14"/>
+      <Q id="6428684141" qualifier_id="56" value="Back"/>
+      <Q id="6428684139" qualifier_id="94"/>
+      <Q id="6428719183" qualifier_id="233" value="738"/>
+    </Event>
+    <Event id="2939845737" event_id="747" type_id="44" period_id="2" min="72" sec="17" player_id="508143" team_id="244" outcome="1" x="97.7" y="56.4" timestamp="2026-05-19T14:50:17.807" timestamp_utc="2026-05-19T13:50:17.807" last_modified="2026-05-19T16:31:39" version="1779204699436">
+      <Q id="6428692551" qualifier_id="56" value="Center"/>
+      <Q id="6428719501" qualifier_id="233" value="758"/>
+      <Q id="6428692553" qualifier_id="286"/>
+    </Event>
+    <Event id="2939850233" event_id="758" type_id="44" period_id="2" min="72" sec="17" player_id="624620" team_id="417" outcome="0" x="2.3" y="43.6" timestamp="2026-05-19T14:50:17.808" timestamp_utc="2026-05-19T13:50:17.808" last_modified="2026-05-19T16:31:39" version="1779204699708">
+      <Q id="6428719493" qualifier_id="56" value="Back"/>
+      <Q id="6428719507" qualifier_id="233" value="747"/>
+      <Q id="6428719495" qualifier_id="285"/>
+    </Event>
+    <Event id="2939845755" event_id="748" type_id="13" period_id="2" min="72" sec="17" player_id="508143" team_id="244" outcome="1" x="97.7" y="56.4" timestamp="2026-05-19T14:50:18.455" timestamp_utc="2026-05-19T13:50:18.455" last_modified="2026-05-19T15:58:49" version="1779202729011">
+      <Q id="6428692797" qualifier_id="15"/>
+      <Q id="6428692795" qualifier_id="25"/>
+      <Q id="6428692673" qualifier_id="56" value="Center"/>
+      <Q id="6428692671" qualifier_id="61"/>
+      <Q id="6428692905" qualifier_id="77"/>
+      <Q id="6428692907" qualifier_id="102" value="61.0"/>
+      <Q id="6428692909" qualifier_id="103" value="47.2"/>
+      <Q id="6428692913" qualifier_id="230" value="99.4"/>
+      <Q id="6428692915" qualifier_id="231" value="52.2"/>
+      <Q id="6428692801" qualifier_id="328"/>
+      <Q id="6428692911" qualifier_id="458"/>
+    </Event>
+    <Event id="2939845161" event_id="608" type_id="5" period_id="2" min="73" sec="1" player_id="624620" team_id="417" outcome="1" x="-0.9" y="43.6" timestamp="2026-05-19T14:51:01.856" timestamp_utc="2026-05-19T13:51:01.856" last_modified="2026-05-19T15:26:36" version="1779200790252">
+      <Q id="6428689391" qualifier_id="56" value="Back"/>
+      <Q id="6428717503" qualifier_id="233" value="741"/>
+      <Q id="6428689393" qualifier_id="346"/>
+    </Event>
+    <Event id="2939845255" event_id="741" type_id="5" period_id="2" min="73" sec="1" player_id="508143" team_id="244" outcome="0" x="100.9" y="56.4" timestamp="2026-05-19T14:51:01.856" timestamp_utc="2026-05-19T13:51:01.856" last_modified="2026-05-19T16:28:30" version="1779204510255">
+      <Q id="6428689873" qualifier_id="56" value="Center"/>
+      <Q id="6428717515" qualifier_id="233" value="608"/>
+      <Q id="6428689875" qualifier_id="346"/>
+    </Event>
+    <Event id="2939844501" event_id="739" type_id="27" period_id="2" min="73" sec="4" team_id="244" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T14:51:05.296" timestamp_utc="2026-05-19T13:51:05.296" last_modified="2026-05-19T15:46:36" version="1779201995937">
+      <Q id="6428737981" qualifier_id="41" value="Injury"/>
+      <Q id="6428737983" qualifier_id="53" value="508143"/>
+      <Q id="6428732077" qualifier_id="233" value="602"/>
+    </Event>
+    <Event id="2939844839" event_id="602" type_id="27" period_id="2" min="73" sec="4" team_id="417" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T14:51:05.296" timestamp_utc="2026-05-19T13:51:05.296" last_modified="2026-05-19T15:27:40" version="1779200860184">
+      <Q id="6428731867" qualifier_id="233" value="739"/>
+    </Event>
+    <Event id="2939844505" event_id="740" type_id="28" period_id="2" min="73" sec="5" team_id="244" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T14:51:06.175" timestamp_utc="2026-05-19T13:51:06.175" last_modified="2026-05-19T15:27:41" version="1779200860938">
+      <Q id="6428685497" qualifier_id="55" value="739"/>
+      <Q id="6428732083" qualifier_id="233" value="603"/>
+    </Event>
+    <Event id="2939844847" event_id="603" type_id="28" period_id="2" min="73" sec="5" team_id="417" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T14:51:06.175" timestamp_utc="2026-05-19T13:51:06.175" last_modified="2026-05-19T15:27:40" version="1779200860194">
+      <Q id="6428687469" qualifier_id="55" value="602"/>
+      <Q id="6428731879" qualifier_id="233" value="740"/>
+    </Event>
+    <Event id="2939847815" event_id="790" type_id="27" period_id="2" min="74" sec="15" team_id="244" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T14:52:15.576" timestamp_utc="2026-05-19T13:52:15.576" last_modified="2026-05-19T15:27:41" version="1779200860221">
+      <Q id="6428705041" qualifier_id="41" value="Injury"/>
+      <Q id="6428705043" qualifier_id="53" value="578592"/>
+      <Q id="6428731873" qualifier_id="233" value="689"/>
+    </Event>
+    <Event id="2939847937" event_id="689" type_id="27" period_id="2" min="74" sec="15" team_id="417" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T14:52:15.576" timestamp_utc="2026-05-19T13:52:15.576" last_modified="2026-05-19T15:27:41" version="1779200860215">
+      <Q id="6428731887" qualifier_id="233" value="790"/>
+    </Event>
+    <Event id="2939847817" event_id="791" type_id="28" period_id="2" min="74" sec="16" team_id="244" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T14:52:16.760" timestamp_utc="2026-05-19T13:52:16.760" last_modified="2026-05-19T15:27:42" version="1779200860231">
+      <Q id="6428704989" qualifier_id="55" value="790"/>
+      <Q id="6428731883" qualifier_id="233" value="690"/>
+    </Event>
+    <Event id="2939847939" event_id="690" type_id="28" period_id="2" min="74" sec="16" team_id="417" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T14:52:16.760" timestamp_utc="2026-05-19T13:52:16.760" last_modified="2026-05-19T15:27:41" version="1779200860223">
+      <Q id="6428705753" qualifier_id="55" value="689"/>
+      <Q id="6428731897" qualifier_id="233" value="791"/>
+    </Event>
+    <Event id="2939845013" event_id="604" type_id="18" period_id="2" min="74" sec="30" player_id="720682" team_id="417" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T14:52:30.900" timestamp_utc="2026-05-19T13:52:30.900" last_modified="2026-05-19T14:53:21" version="1779198801046">
+      <Q id="6428688481" qualifier_id="42"/>
+      <Q id="6428688483" qualifier_id="44" value="Midfielder"/>
+      <Q id="6428688505" qualifier_id="55" value="605"/>
+      <Q id="6428688485" qualifier_id="59" value="8"/>
+      <Q id="6428689215" qualifier_id="189"/>
+    </Event>
+    <Event id="2939845015" event_id="605" type_id="19" period_id="2" min="74" sec="30" player_id="731191" team_id="417" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T14:52:30.901" timestamp_utc="2026-05-19T13:52:30.901" last_modified="2026-05-19T14:53:28" version="1779198807849">
+      <Q id="6428688487" qualifier_id="42"/>
+      <Q id="6428688499" qualifier_id="44" value="Midfielder"/>
+      <Q id="6428688501" qualifier_id="55" value="604"/>
+      <Q id="6428688493" qualifier_id="59" value="15"/>
+      <Q id="6428688491" qualifier_id="145" value="11"/>
+      <Q id="6428689647" qualifier_id="189"/>
+      <Q id="6428688495" qualifier_id="292" value="7"/>
+      <Q id="6428688497" qualifier_id="293" value="4"/>
+    </Event>
+    <Event id="2939845043" event_id="606" type_id="18" period_id="2" min="74" sec="30" player_id="685390" team_id="417" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T14:52:31.008" timestamp_utc="2026-05-19T13:52:31.008" last_modified="2026-05-19T14:53:29" version="1779198809577">
+      <Q id="6428688699" qualifier_id="42"/>
+      <Q id="6428688701" qualifier_id="44" value="Forward"/>
+      <Q id="6428688747" qualifier_id="55" value="607"/>
+      <Q id="6428688703" qualifier_id="59" value="17"/>
+      <Q id="6428689703" qualifier_id="189"/>
+    </Event>
+    <Event id="2939845045" event_id="607" type_id="19" period_id="2" min="74" sec="30" player_id="720789" team_id="417" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T14:52:31.009" timestamp_utc="2026-05-19T13:52:31.009" last_modified="2026-05-19T14:53:32" version="1779198811824">
+      <Q id="6428688705" qualifier_id="42"/>
+      <Q id="6428688717" qualifier_id="44" value="Midfielder"/>
+      <Q id="6428688719" qualifier_id="55" value="606"/>
+      <Q id="6428688711" qualifier_id="59" value="29"/>
+      <Q id="6428688709" qualifier_id="145" value="7"/>
+      <Q id="6428689751" qualifier_id="189"/>
+      <Q id="6428688713" qualifier_id="292" value="7"/>
+      <Q id="6428688715" qualifier_id="293" value="2"/>
+    </Event>
+    <Event id="2939845263" event_id="609" type_id="1" period_id="2" min="75" sec="28" player_id="565487" team_id="417" outcome="1" x="3.7" y="49.4" timestamp="2026-05-19T14:53:29.158" timestamp_utc="2026-05-19T13:53:29.158" last_modified="2026-05-19T15:23:11" version="1779200591222">
+      <Q id="6428689911" qualifier_id="56" value="Back"/>
+      <Q id="6428689909" qualifier_id="124"/>
+      <Q id="6428689913" qualifier_id="140" value="16.7"/>
+      <Q id="6428689915" qualifier_id="141" value="41.5"/>
+      <Q id="6428689917" qualifier_id="212" value="14.7"/>
+      <Q id="6428689919" qualifier_id="213" value="5.91"/>
+      <Q id="6428689925" qualifier_id="237"/>
+    </Event>
+    <Event id="2939845279" event_id="610" type_id="1" period_id="2" min="75" sec="36" player_id="531784" team_id="417" outcome="1" x="30.5" y="38.2" timestamp="2026-05-19T14:53:37.207" timestamp_utc="2026-05-19T13:53:37.207" last_modified="2026-05-19T14:53:40" version="1779198817487">
+      <Q id="6428690009" qualifier_id="56" value="Back"/>
+      <Q id="6428690011" qualifier_id="140" value="32.4"/>
+      <Q id="6428690013" qualifier_id="141" value="66.6"/>
+      <Q id="6428690015" qualifier_id="212" value="19.4"/>
+      <Q id="6428690017" qualifier_id="213" value="1.47"/>
+    </Event>
+    <Event id="2939845325" event_id="611" type_id="1" period_id="2" min="75" sec="43" player_id="61812" team_id="417" outcome="1" x="48.5" y="76.7" timestamp="2026-05-19T14:53:44.415" timestamp_utc="2026-05-19T13:53:44.415" last_modified="2026-05-19T14:53:46" version="1779198824599">
+      <Q id="6428690305" qualifier_id="56" value="Back"/>
+      <Q id="6428690307" qualifier_id="140" value="39.5"/>
+      <Q id="6428690309" qualifier_id="141" value="57.2"/>
+      <Q id="6428690311" qualifier_id="212" value="16.3"/>
+      <Q id="6428690313" qualifier_id="213" value="4.09"/>
+    </Event>
+    <Event id="2939845351" event_id="612" type_id="1" period_id="2" min="75" sec="45" player_id="531784" team_id="417" outcome="1" x="35.3" y="47.9" timestamp="2026-05-19T14:53:46.486" timestamp_utc="2026-05-19T13:53:46.486" last_modified="2026-05-19T14:53:51" version="1779198826688">
+      <Q id="6428690463" qualifier_id="56" value="Back"/>
+      <Q id="6428690465" qualifier_id="140" value="40.5"/>
+      <Q id="6428690467" qualifier_id="141" value="72.6"/>
+      <Q id="6428690469" qualifier_id="212" value="17.7"/>
+      <Q id="6428690471" qualifier_id="213" value="1.26"/>
+    </Event>
+    <Event id="2939845397" event_id="613" type_id="1" period_id="2" min="75" sec="50" player_id="61812" team_id="417" outcome="1" x="53.6" y="76.7" timestamp="2026-05-19T14:53:51.255" timestamp_utc="2026-05-19T13:53:51.255" last_modified="2026-05-19T14:53:56" version="1779198831479">
+      <Q id="6428690697" qualifier_id="56" value="Back"/>
+      <Q id="6428690699" qualifier_id="140" value="42.5"/>
+      <Q id="6428690701" qualifier_id="141" value="55.7"/>
+      <Q id="6428690703" qualifier_id="212" value="18.4"/>
+      <Q id="6428690705" qualifier_id="213" value="4.03"/>
+    </Event>
+    <Event id="2939845413" event_id="614" type_id="1" period_id="2" min="75" sec="56" player_id="531784" team_id="417" outcome="1" x="51.0" y="34.3" timestamp="2026-05-19T14:53:56.806" timestamp_utc="2026-05-19T13:53:56.806" last_modified="2026-05-19T14:53:59" version="1779198837073">
+      <Q id="6428690803" qualifier_id="56" value="Back"/>
+      <Q id="6428690805" qualifier_id="140" value="48.8"/>
+      <Q id="6428690807" qualifier_id="141" value="16.2"/>
+      <Q id="6428690809" qualifier_id="212" value="12.5"/>
+      <Q id="6428690811" qualifier_id="213" value="4.53"/>
+    </Event>
+    <Event id="2939845429" event_id="615" type_id="1" period_id="2" min="75" sec="58" player_id="157851" team_id="417" outcome="1" x="48.3" y="10.4" timestamp="2026-05-19T14:53:59.254" timestamp_utc="2026-05-19T13:53:59.254" last_modified="2026-05-19T14:54:02" version="1779198840962">
+      <Q id="6428690883" qualifier_id="56" value="Back"/>
+      <Q id="6428690885" qualifier_id="140" value="32.6"/>
+      <Q id="6428690887" qualifier_id="141" value="37.0"/>
+      <Q id="6428690889" qualifier_id="212" value="24.5"/>
+      <Q id="6428690891" qualifier_id="213" value="2.31"/>
+    </Event>
+    <Event id="2939845449" event_id="616" type_id="1" period_id="2" min="76" sec="1" player_id="565487" team_id="417" outcome="1" x="29.7" y="37.1" timestamp="2026-05-19T14:54:02.518" timestamp_utc="2026-05-19T13:54:02.518" last_modified="2026-05-19T14:54:05" version="1779198842745">
+      <Q id="6428690979" qualifier_id="56" value="Back"/>
+      <Q id="6428690981" qualifier_id="140" value="30.0"/>
+      <Q id="6428690983" qualifier_id="141" value="64.0"/>
+      <Q id="6428690985" qualifier_id="212" value="18.3"/>
+      <Q id="6428690987" qualifier_id="213" value="1.55"/>
+    </Event>
+    <Event id="2939845489" event_id="617" type_id="1" period_id="2" min="76" sec="4" player_id="61812" team_id="417" outcome="1" x="31.4" y="63.6" timestamp="2026-05-19T14:54:05.446" timestamp_utc="2026-05-19T13:54:05.446" last_modified="2026-05-19T14:54:09" version="1779198846408">
+      <Q id="6428691177" qualifier_id="56" value="Back"/>
+      <Q id="6428691179" qualifier_id="140" value="41.0"/>
+      <Q id="6428691181" qualifier_id="141" value="80.5"/>
+      <Q id="6428691183" qualifier_id="212" value="15.3"/>
+      <Q id="6428691185" qualifier_id="213" value="0.85"/>
+    </Event>
+    <Event id="2939845505" event_id="618" type_id="1" period_id="2" min="76" sec="8" player_id="624620" team_id="417" outcome="1" x="45.9" y="70.2" timestamp="2026-05-19T14:54:09.383" timestamp_utc="2026-05-19T13:54:09.383" last_modified="2026-05-19T14:54:12" version="1779198851209">
+      <Q id="6428691277" qualifier_id="56" value="Back"/>
+      <Q id="6428691279" qualifier_id="140" value="44.0"/>
+      <Q id="6428691281" qualifier_id="141" value="39.4"/>
+      <Q id="6428691283" qualifier_id="212" value="21.0"/>
+      <Q id="6428691285" qualifier_id="213" value="4.62"/>
+    </Event>
+    <Event id="2939845517" event_id="619" type_id="1" period_id="2" min="76" sec="12" player_id="531784" team_id="417" outcome="1" x="46.0" y="44.8" timestamp="2026-05-19T14:54:12.558" timestamp_utc="2026-05-19T13:54:12.558" last_modified="2026-05-19T14:54:17" version="1779198852817">
+      <Q id="6428691365" qualifier_id="56" value="Back"/>
+      <Q id="6428691367" qualifier_id="140" value="48.1"/>
+      <Q id="6428691369" qualifier_id="141" value="64.6"/>
+      <Q id="6428691371" qualifier_id="212" value="13.6"/>
+      <Q id="6428691373" qualifier_id="213" value="1.41"/>
+    </Event>
+    <Event id="2939845533" event_id="620" type_id="1" period_id="2" min="76" sec="16" player_id="624620" team_id="417" outcome="1" x="57.1" y="75.0" timestamp="2026-05-19T14:54:16.886" timestamp_utc="2026-05-19T13:54:16.886" last_modified="2026-05-19T14:54:21" version="1779198857111">
+      <Q id="6428691473" qualifier_id="56" value="Left"/>
+      <Q id="6428691475" qualifier_id="140" value="59.0"/>
+      <Q id="6428691477" qualifier_id="141" value="88.4"/>
+      <Q id="6428691479" qualifier_id="212" value="9.3"/>
+      <Q id="6428691481" qualifier_id="213" value="1.36"/>
+    </Event>
+    <Event id="2939845559" event_id="621" type_id="1" period_id="2" min="76" sec="20" player_id="61778" team_id="417" outcome="1" x="56.2" y="85.1" timestamp="2026-05-19T14:54:20.905" timestamp_utc="2026-05-19T13:54:20.905" last_modified="2026-05-19T14:54:25" version="1779198861288">
+      <Q id="6428691639" qualifier_id="1"/>
+      <Q id="6428691629" qualifier_id="56" value="Back"/>
+      <Q id="6428691631" qualifier_id="140" value="45.1"/>
+      <Q id="6428691633" qualifier_id="141" value="40.1"/>
+      <Q id="6428691635" qualifier_id="212" value="32.7"/>
+      <Q id="6428691637" qualifier_id="213" value="4.35"/>
+    </Event>
+    <Event id="2939845577" event_id="622" type_id="1" period_id="2" min="76" sec="24" player_id="531784" team_id="417" outcome="1" x="53.9" y="38.5" timestamp="2026-05-19T14:54:25.168" timestamp_utc="2026-05-19T13:54:25.168" last_modified="2026-05-19T14:54:27" version="1779198865887">
+      <Q id="6428691701" qualifier_id="56" value="Right"/>
+      <Q id="6428691703" qualifier_id="140" value="61.7"/>
+      <Q id="6428691705" qualifier_id="141" value="18.2"/>
+      <Q id="6428691707" qualifier_id="212" value="16.1"/>
+      <Q id="6428691709" qualifier_id="213" value="5.25"/>
+    </Event>
+    <Event id="2939845601" event_id="623" type_id="1" period_id="2" min="76" sec="26" player_id="157851" team_id="417" outcome="1" x="62.0" y="14.7" timestamp="2026-05-19T14:54:26.998" timestamp_utc="2026-05-19T13:54:26.998" last_modified="2026-05-19T14:54:32" version="1779198867161">
+      <Q id="6428691853" qualifier_id="56" value="Right"/>
+      <Q id="6428691855" qualifier_id="140" value="69.0"/>
+      <Q id="6428691857" qualifier_id="141" value="18.9"/>
+      <Q id="6428691859" qualifier_id="212" value="7.9"/>
+      <Q id="6428691861" qualifier_id="213" value="0.37"/>
+    </Event>
+    <Event id="2939845595" event_id="742" type_id="83" period_id="2" min="76" sec="30" player_id="207884" team_id="244" outcome="0" x="14.7" y="84.4" timestamp="2026-05-19T14:54:30.727" timestamp_utc="2026-05-19T13:54:30.727" last_modified="2026-05-19T14:54:34" version="1779198874535">
+      <Q id="6428691907" qualifier_id="399" value="720789"/>
+    </Event>
+    <Event id="2939845603" event_id="743" type_id="45" period_id="2" min="76" sec="32" player_id="575855" team_id="244" outcome="0" x="20.1" y="84.5" timestamp="2026-05-19T14:54:32.638" timestamp_utc="2026-05-19T13:54:32.638" last_modified="2026-05-19T14:54:34" version="1779198874192">
+      <Q id="6428691865" qualifier_id="56" value="Back"/>
+      <Q id="6428691891" qualifier_id="233" value="624"/>
+      <Q id="6428691867" qualifier_id="285"/>
+    </Event>
+    <Event id="2939845605" event_id="624" type_id="3" period_id="2" min="76" sec="32" player_id="720789" team_id="417" outcome="1" x="79.8" y="15.6" timestamp="2026-05-19T14:54:32.638" timestamp_utc="2026-05-19T13:54:32.638" last_modified="2026-05-19T14:54:34" version="1779198873165">
+      <Q id="6428691869" qualifier_id="56" value="Right"/>
+      <Q id="6428691875" qualifier_id="233" value="743"/>
+      <Q id="6428691871" qualifier_id="286"/>
+    </Event>
+    <Event id="2939845613" event_id="625" type_id="1" period_id="2" min="76" sec="32" player_id="720789" team_id="417" outcome="1" x="80.3" y="14.9" timestamp="2026-05-19T14:54:33.046" timestamp_utc="2026-05-19T13:54:33.046" last_modified="2026-05-19T14:54:34" version="1779198873197">
+      <Q id="6428691921" qualifier_id="56" value="Right"/>
+      <Q id="6428691923" qualifier_id="140" value="68.9"/>
+      <Q id="6428691925" qualifier_id="141" value="14.0"/>
+      <Q id="6428691927" qualifier_id="212" value="12.0"/>
+      <Q id="6428691929" qualifier_id="213" value="3.19"/>
+    </Event>
+    <Event id="2939845629" event_id="626" type_id="1" period_id="2" min="76" sec="33" player_id="683488" team_id="417" outcome="1" x="68.9" y="14.0" timestamp="2026-05-19T14:54:34.398" timestamp_utc="2026-05-19T13:54:34.398" last_modified="2026-05-19T14:54:37" version="1779198874487">
+      <Q id="6428692001" qualifier_id="56" value="Right"/>
+      <Q id="6428692003" qualifier_id="140" value="71.5"/>
+      <Q id="6428692005" qualifier_id="141" value="8.8"/>
+      <Q id="6428692007" qualifier_id="212" value="4.5"/>
+      <Q id="6428692009" qualifier_id="213" value="5.37"/>
+    </Event>
+    <Event id="2939845645" event_id="627" type_id="1" period_id="2" min="76" sec="36" player_id="157851" team_id="417" outcome="0" x="71.9" y="9.1" timestamp="2026-05-19T14:54:37.358" timestamp_utc="2026-05-19T13:54:37.358" last_modified="2026-05-19T14:54:39" version="1779198879539">
+      <Q id="6428692101" qualifier_id="1"/>
+      <Q id="6428692087" qualifier_id="2"/>
+      <Q id="6428692091" qualifier_id="56" value="Center"/>
+      <Q id="6428692093" qualifier_id="140" value="91.7"/>
+      <Q id="6428692095" qualifier_id="141" value="47.6"/>
+      <Q id="6428692097" qualifier_id="212" value="33.4"/>
+      <Q id="6428692099" qualifier_id="213" value="0.90"/>
+    </Event>
+    <Event id="2939845651" event_id="744" type_id="52" period_id="2" min="76" sec="39" player_id="578592" team_id="244" outcome="1" x="2.0" y="52.5" timestamp="2026-05-19T14:54:40.031" timestamp_utc="2026-05-19T13:54:40.031" last_modified="2026-05-19T14:54:40" version="1779198880032"/>
+    <Event id="2939845687" event_id="745" type_id="1" period_id="2" min="76" sec="42" player_id="578592" team_id="244" outcome="1" x="10.2" y="51.9" timestamp="2026-05-19T14:54:42.743" timestamp_utc="2026-05-19T13:54:42.743" last_modified="2026-05-19T14:54:44" version="1779198883639">
+      <Q id="6428692291" qualifier_id="56" value="Back"/>
+      <Q id="6428692289" qualifier_id="123"/>
+      <Q id="6428692293" qualifier_id="140" value="30.0"/>
+      <Q id="6428692295" qualifier_id="141" value="62.3"/>
+      <Q id="6428692297" qualifier_id="212" value="22.0"/>
+      <Q id="6428692299" qualifier_id="213" value="0.33"/>
+    </Event>
+    <Event id="2939845695" event_id="746" type_id="1" period_id="2" min="76" sec="44" player_id="515742" team_id="244" outcome="0" x="30.0" y="62.3" timestamp="2026-05-19T14:54:44.566" timestamp_utc="2026-05-19T13:54:44.566" last_modified="2026-05-19T14:54:45" version="1779198885863">
+      <Q id="6428692339" qualifier_id="56" value="Back"/>
+      <Q id="6428692341" qualifier_id="140" value="47.2"/>
+      <Q id="6428692343" qualifier_id="141" value="77.3"/>
+      <Q id="6428692345" qualifier_id="212" value="20.7"/>
+      <Q id="6428692347" qualifier_id="213" value="0.51"/>
+    </Event>
+    <Event id="2939845715" event_id="628" type_id="49" period_id="2" min="76" sec="47" player_id="157851" team_id="417" outcome="1" x="49.0" y="21.9" timestamp="2026-05-19T14:54:47.646" timestamp_utc="2026-05-19T13:54:47.646" last_modified="2026-05-19T14:54:47" version="1779198887647"/>
+    <Event id="2939845751" event_id="629" type_id="1" period_id="2" min="76" sec="52" player_id="157851" team_id="417" outcome="1" x="56.6" y="52.5" timestamp="2026-05-19T14:54:53.038" timestamp_utc="2026-05-19T13:54:53.038" last_modified="2026-05-19T14:54:54" version="1779198893238">
+      <Q id="6428692641" qualifier_id="56" value="Back"/>
+      <Q id="6428692643" qualifier_id="140" value="43.6"/>
+      <Q id="6428692645" qualifier_id="141" value="52.5"/>
+      <Q id="6428692647" qualifier_id="212" value="13.6"/>
+      <Q id="6428692649" qualifier_id="213" value="3.14"/>
+    </Event>
+    <Event id="2939845757" event_id="630" type_id="1" period_id="2" min="76" sec="53" player_id="61812" team_id="417" outcome="1" x="43.1" y="52.2" timestamp="2026-05-19T14:54:54.118" timestamp_utc="2026-05-19T13:54:54.118" last_modified="2026-05-19T14:54:56" version="1779198894246">
+      <Q id="6428692681" qualifier_id="56" value="Back"/>
+      <Q id="6428692683" qualifier_id="140" value="45.7"/>
+      <Q id="6428692685" qualifier_id="141" value="45.8"/>
+      <Q id="6428692687" qualifier_id="212" value="5.1"/>
+      <Q id="6428692689" qualifier_id="213" value="5.27"/>
+    </Event>
+    <Event id="2939845773" event_id="631" type_id="1" period_id="2" min="76" sec="55" player_id="61778" team_id="417" outcome="1" x="46.1" y="46.1" timestamp="2026-05-19T14:54:56.301" timestamp_utc="2026-05-19T13:54:56.301" last_modified="2026-05-19T14:54:59" version="1779198896534">
+      <Q id="6428692817" qualifier_id="56" value="Center"/>
+      <Q id="6428692819" qualifier_id="140" value="52.1"/>
+      <Q id="6428692821" qualifier_id="141" value="23.6"/>
+      <Q id="6428692823" qualifier_id="212" value="16.5"/>
+      <Q id="6428692825" qualifier_id="213" value="5.10"/>
+    </Event>
+    <Event id="2939845811" event_id="632" type_id="1" period_id="2" min="76" sec="59" player_id="683488" team_id="417" outcome="1" x="53.8" y="25.2" timestamp="2026-05-19T14:54:59.790" timestamp_utc="2026-05-19T13:54:59.790" last_modified="2026-05-19T14:55:06" version="1779198900296">
+      <Q id="6428693055" qualifier_id="56" value="Right"/>
+      <Q id="6428693057" qualifier_id="140" value="65.7"/>
+      <Q id="6428693059" qualifier_id="141" value="7.9"/>
+      <Q id="6428693061" qualifier_id="212" value="17.2"/>
+      <Q id="6428693063" qualifier_id="213" value="5.53"/>
+    </Event>
+    <Event id="2939845825" event_id="633" type_id="1" period_id="2" min="77" sec="5" player_id="720789" team_id="417" outcome="1" x="73.9" y="5.2" timestamp="2026-05-19T14:55:06.528" timestamp_utc="2026-05-19T13:55:06.528" last_modified="2026-05-19T14:55:07" version="1779198906703">
+      <Q id="6428693135" qualifier_id="56" value="Right"/>
+      <Q id="6428693137" qualifier_id="140" value="66.0"/>
+      <Q id="6428693139" qualifier_id="141" value="11.9"/>
+      <Q id="6428693141" qualifier_id="212" value="9.5"/>
+      <Q id="6428693143" qualifier_id="213" value="2.64"/>
+    </Event>
+    <Event id="2939845835" event_id="634" type_id="1" period_id="2" min="77" sec="7" player_id="531784" team_id="417" outcome="1" x="65.9" y="11.9" timestamp="2026-05-19T14:55:07.589" timestamp_utc="2026-05-19T13:55:07.589" last_modified="2026-05-19T14:55:10" version="1779198907744">
+      <Q id="6428693189" qualifier_id="56" value="Right"/>
+      <Q id="6428693191" qualifier_id="140" value="72.9"/>
+      <Q id="6428693193" qualifier_id="141" value="14.4"/>
+      <Q id="6428693195" qualifier_id="212" value="7.5"/>
+      <Q id="6428693197" qualifier_id="213" value="0.23"/>
+    </Event>
+    <Event id="2939845853" event_id="635" type_id="1" period_id="2" min="77" sec="9" player_id="720789" team_id="417" outcome="1" x="69.2" y="17.6" timestamp="2026-05-19T14:55:10.038" timestamp_utc="2026-05-19T13:55:10.038" last_modified="2026-05-19T14:55:13" version="1779198910222">
+      <Q id="6428693239" qualifier_id="56" value="Center"/>
+      <Q id="6428693241" qualifier_id="140" value="63.1"/>
+      <Q id="6428693243" qualifier_id="141" value="33.7"/>
+      <Q id="6428693245" qualifier_id="212" value="12.7"/>
+      <Q id="6428693247" qualifier_id="213" value="2.10"/>
+    </Event>
+    <Event id="2939845879" event_id="636" type_id="1" period_id="2" min="77" sec="13" player_id="61778" team_id="417" outcome="1" x="65.1" y="42.1" timestamp="2026-05-19T14:55:13.798" timestamp_utc="2026-05-19T13:55:13.798" last_modified="2026-05-19T14:55:16" version="1779198914670">
+      <Q id="6428693381" qualifier_id="1"/>
+      <Q id="6428693371" qualifier_id="56" value="Left"/>
+      <Q id="6428693373" qualifier_id="140" value="88.8"/>
+      <Q id="6428693375" qualifier_id="141" value="86.9"/>
+      <Q id="6428693369" qualifier_id="155"/>
+      <Q id="6428693377" qualifier_id="212" value="39.3"/>
+      <Q id="6428693379" qualifier_id="213" value="0.89"/>
+    </Event>
+    <Event id="2939845891" event_id="637" type_id="1" period_id="2" min="77" sec="15" player_id="570078" team_id="417" outcome="1" x="87.2" y="87.2" timestamp="2026-05-19T14:55:16.533" timestamp_utc="2026-05-19T13:55:16.533" last_modified="2026-05-19T14:55:19" version="1779198916743">
+      <Q id="6428693451" qualifier_id="56" value="Left"/>
+      <Q id="6428693453" qualifier_id="140" value="73.9"/>
+      <Q id="6428693455" qualifier_id="141" value="82.1"/>
+      <Q id="6428693457" qualifier_id="212" value="14.4"/>
+      <Q id="6428693459" qualifier_id="213" value="3.39"/>
+    </Event>
+    <Event id="2939845897" event_id="638" type_id="1" period_id="2" min="77" sec="18" player_id="624620" team_id="417" outcome="1" x="72.5" y="80.2" timestamp="2026-05-19T14:55:19.229" timestamp_utc="2026-05-19T13:55:19.229" last_modified="2026-05-19T14:55:21" version="1779198919422">
+      <Q id="6428693481" qualifier_id="56" value="Center"/>
+      <Q id="6428693483" qualifier_id="140" value="64.4"/>
+      <Q id="6428693485" qualifier_id="141" value="70.0"/>
+      <Q id="6428693487" qualifier_id="212" value="11.0"/>
+      <Q id="6428693489" qualifier_id="213" value="3.83"/>
+    </Event>
+    <Event id="2939845909" event_id="639" type_id="1" period_id="2" min="77" sec="20" player_id="61778" team_id="417" outcome="1" x="66.0" y="70.5" timestamp="2026-05-19T14:55:21.542" timestamp_utc="2026-05-19T13:55:21.542" last_modified="2026-05-19T14:55:24" version="1779198923104">
+      <Q id="6428693577" qualifier_id="56" value="Center"/>
+      <Q id="6428693579" qualifier_id="140" value="92.6"/>
+      <Q id="6428693581" qualifier_id="141" value="75.4"/>
+      <Q id="6428693583" qualifier_id="212" value="28.1"/>
+      <Q id="6428693585" qualifier_id="213" value="0.12"/>
+    </Event>
+    <Event id="2939845913" event_id="640" type_id="1" period_id="2" min="77" sec="23" player_id="570078" team_id="417" outcome="0" x="92.4" y="73.8" timestamp="2026-05-19T14:55:24.263" timestamp_utc="2026-05-19T13:55:24.263" last_modified="2026-05-19T14:55:25" version="1779198924943">
+      <Q id="6428693589" qualifier_id="2"/>
+      <Q id="6428693593" qualifier_id="56" value="Center"/>
+      <Q id="6428693595" qualifier_id="140" value="90.7"/>
+      <Q id="6428693597" qualifier_id="141" value="63.0"/>
+      <Q id="6428693599" qualifier_id="212" value="7.6"/>
+      <Q id="6428693601" qualifier_id="213" value="4.47"/>
+    </Event>
+    <Event id="2939846067" event_id="749" type_id="4" period_id="2" min="77" sec="25" player_id="575855" team_id="244" outcome="1" x="10.7" y="53.6" timestamp="2026-05-19T14:55:25.782" timestamp_utc="2026-05-19T13:55:25.782" last_modified="2026-05-19T15:03:26" version="1779199406740">
+      <Q id="6428694453" qualifier_id="13"/>
+      <Q id="6428694455" qualifier_id="56" value="Back"/>
+      <Q id="6428694459" qualifier_id="152"/>
+      <Q id="6428694543" qualifier_id="233" value="641"/>
+      <Q id="6428694461" qualifier_id="265"/>
+      <Q id="6428694465" qualifier_id="285"/>
+    </Event>
+    <Event id="2939846073" event_id="641" type_id="4" period_id="2" min="77" sec="25" player_id="731191" team_id="417" outcome="0" x="89.3" y="46.4" timestamp="2026-05-19T14:55:25.783" timestamp_utc="2026-05-19T13:55:25.783" last_modified="2026-05-19T14:55:56" version="1779198956782">
+      <Q id="6428694511" qualifier_id="13"/>
+      <Q id="6428694517" qualifier_id="56" value="Center"/>
+      <Q id="6428694519" qualifier_id="152"/>
+      <Q id="6428694559" qualifier_id="233" value="749"/>
+      <Q id="6428694521" qualifier_id="265"/>
+      <Q id="6428694523" qualifier_id="286"/>
+    </Event>
+    <Event id="2939846149" event_id="750" type_id="1" period_id="2" min="78" sec="3" player_id="578592" team_id="244" outcome="0" x="17.7" y="54.3" timestamp="2026-05-19T14:56:03.823" timestamp_utc="2026-05-19T13:56:03.823" last_modified="2026-05-19T14:56:07" version="1779198967721">
+      <Q id="6428694991" qualifier_id="1"/>
+      <Q id="6428694973" qualifier_id="5"/>
+      <Q id="6428694979" qualifier_id="56" value="Center"/>
+      <Q id="6428694981" qualifier_id="140" value="65.7"/>
+      <Q id="6428694983" qualifier_id="141" value="70.2"/>
+      <Q id="6428694977" qualifier_id="152"/>
+      <Q id="6428694975" qualifier_id="157"/>
+      <Q id="6428694985" qualifier_id="212" value="51.5"/>
+      <Q id="6428694987" qualifier_id="213" value="0.21"/>
+    </Event>
+    <Event id="2939846159" event_id="642" type_id="1" period_id="2" min="78" sec="7" player_id="531784" team_id="417" outcome="0" x="27.7" y="25.6" timestamp="2026-05-19T14:56:07.710" timestamp_utc="2026-05-19T13:56:07.710" last_modified="2026-05-19T14:56:08" version="1779198968286">
+      <Q id="6428695027" qualifier_id="3"/>
+      <Q id="6428695029" qualifier_id="56" value="Back"/>
+      <Q id="6428695031" qualifier_id="140" value="36.9"/>
+      <Q id="6428695033" qualifier_id="141" value="24.1"/>
+      <Q id="6428695035" qualifier_id="212" value="9.7"/>
+      <Q id="6428695037" qualifier_id="213" value="6.18"/>
+    </Event>
+    <Event id="2939846171" event_id="751" type_id="61" period_id="2" min="78" sec="10" player_id="207884" team_id="244" outcome="1" x="55.8" y="71.5" timestamp="2026-05-19T14:56:11.262" timestamp_utc="2026-05-19T13:56:11.262" last_modified="2026-05-19T14:56:11" version="1779198971264">
+      <Q id="6428695123" qualifier_id="56" value="Center"/>
+    </Event>
+    <Event id="2939846179" event_id="752" type_id="1" period_id="2" min="78" sec="11" player_id="232091" team_id="244" outcome="1" x="58.1" y="64.5" timestamp="2026-05-19T14:56:12.062" timestamp_utc="2026-05-19T13:56:12.062" last_modified="2026-05-19T14:56:13" version="1779198972808">
+      <Q id="6428695163" qualifier_id="56" value="Back"/>
+      <Q id="6428695165" qualifier_id="140" value="47.1"/>
+      <Q id="6428695167" qualifier_id="141" value="76.1"/>
+      <Q id="6428695169" qualifier_id="212" value="14.0"/>
+      <Q id="6428695171" qualifier_id="213" value="2.54"/>
+    </Event>
+    <Event id="2939846207" event_id="753" type_id="1" period_id="2" min="78" sec="12" player_id="180662" team_id="244" outcome="1" x="47.1" y="76.1" timestamp="2026-05-19T14:56:13.222" timestamp_utc="2026-05-19T13:56:13.222" last_modified="2026-05-19T14:56:17" version="1779198973538">
+      <Q id="6428695323" qualifier_id="56" value="Left"/>
+      <Q id="6428695325" qualifier_id="140" value="60.9"/>
+      <Q id="6428695327" qualifier_id="141" value="95.4"/>
+      <Q id="6428695329" qualifier_id="212" value="19.5"/>
+      <Q id="6428695331" qualifier_id="213" value="0.74"/>
+    </Event>
+    <Event id="2939846185" event_id="643" type_id="83" period_id="2" min="78" sec="13" player_id="731191" team_id="417" outcome="0" x="35.3" y="23.4" timestamp="2026-05-19T14:56:13.741" timestamp_utc="2026-05-19T13:56:13.741" last_modified="2026-05-19T14:56:17" version="1779198977837">
+      <Q id="6428695381" qualifier_id="399" value="575855"/>
+    </Event>
+    <Event id="2939846213" event_id="754" type_id="61" period_id="2" min="78" sec="16" player_id="575855" team_id="244" outcome="0" x="63.2" y="91.1" timestamp="2026-05-19T14:56:17.070" timestamp_utc="2026-05-19T13:56:17.070" last_modified="2026-05-19T14:56:17" version="1779198977072">
+      <Q id="6428695367" qualifier_id="56" value="Left"/>
+    </Event>
+    <Event id="2939846217" event_id="755" type_id="5" period_id="2" min="78" sec="17" player_id="575855" team_id="244" outcome="0" x="64.2" y="101.2" timestamp="2026-05-19T14:56:17.870" timestamp_utc="2026-05-19T13:56:17.870" last_modified="2026-05-19T15:26:37" version="1779200790293">
+      <Q id="6428695391" qualifier_id="56" value="Left"/>
+      <Q id="6428695461" qualifier_id="233" value="644"/>
+      <Q id="6428695393" qualifier_id="347"/>
+    </Event>
+    <Event id="2939846229" event_id="644" type_id="5" period_id="2" min="78" sec="17" player_id="731191" team_id="417" outcome="1" x="35.8" y="-1.2" timestamp="2026-05-19T14:56:17.870" timestamp_utc="2026-05-19T13:56:17.870" last_modified="2026-05-19T15:26:37" version="1779200790285">
+      <Q id="6428695433" qualifier_id="56" value="Back"/>
+      <Q id="6428695441" qualifier_id="233" value="755"/>
+      <Q id="6428695435" qualifier_id="347"/>
+    </Event>
+    <Event id="2939846253" event_id="645" type_id="1" period_id="2" min="78" sec="18" player_id="157851" team_id="417" outcome="1" x="32.5" y="0.0" timestamp="2026-05-19T14:56:19.413" timestamp_utc="2026-05-19T13:56:19.413" last_modified="2026-05-19T14:56:25" version="1779198980069">
+      <Q id="6428695633" qualifier_id="1"/>
+      <Q id="6428695623" qualifier_id="56" value="Right"/>
+      <Q id="6428695621" qualifier_id="107"/>
+      <Q id="6428695625" qualifier_id="140" value="55.8"/>
+      <Q id="6428695627" qualifier_id="141" value="18.9"/>
+      <Q id="6428695629" qualifier_id="212" value="28.3"/>
+      <Q id="6428695631" qualifier_id="213" value="0.52"/>
+    </Event>
+    <Event id="2939846255" event_id="646" type_id="4" period_id="2" min="78" sec="24" player_id="731191" team_id="417" outcome="1" x="63.0" y="17.2" timestamp="2026-05-19T14:56:25.077" timestamp_utc="2026-05-19T13:56:25.077" last_modified="2026-05-19T14:56:32" version="1779198990297">
+      <Q id="6428695805" qualifier_id="13"/>
+      <Q id="6428695809" qualifier_id="56" value="Right"/>
+      <Q id="6428695811" qualifier_id="152"/>
+      <Q id="6428695831" qualifier_id="233" value="756"/>
+      <Q id="6428695813" qualifier_id="286"/>
+      <Q id="6428695807" qualifier_id="295"/>
+    </Event>
+    <Event id="2939846251" event_id="756" type_id="4" period_id="2" min="78" sec="24" player_id="180662" team_id="244" outcome="0" x="37.0" y="82.8" timestamp="2026-05-19T14:56:25.078" timestamp_utc="2026-05-19T13:56:25.078" last_modified="2026-05-19T14:56:34" version="1779198994432">
+      <Q id="6428695759" qualifier_id="13"/>
+      <Q id="6428695979" qualifier_id="55" value="757"/>
+      <Q id="6428695763" qualifier_id="56" value="Back"/>
+      <Q id="6428695765" qualifier_id="152"/>
+      <Q id="6428695839" qualifier_id="233" value="646"/>
+      <Q id="6428695767" qualifier_id="285"/>
+      <Q id="6428695761" qualifier_id="295"/>
+    </Event>
+    <Event id="2939846279" event_id="757" type_id="17" period_id="2" min="78" sec="27" player_id="180662" team_id="244" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T14:56:27.935" timestamp_utc="2026-05-19T13:56:27.935" last_modified="2026-05-19T14:56:34" version="1779198994344">
+      <Q id="6428695935" qualifier_id="13" value="243"/>
+      <Q id="6428695931" qualifier_id="31"/>
+      <Q id="6428695937" qualifier_id="55" value="756"/>
+      <Q id="6428695933" qualifier_id="393"/>
+    </Event>
+    <Event id="2939846507" event_id="647" type_id="1" period_id="2" min="79" sec="5" player_id="61778" team_id="417" outcome="1" x="64.9" y="8.8" timestamp="2026-05-19T14:57:06.237" timestamp_utc="2026-05-19T13:57:06.237" last_modified="2026-05-19T14:57:09" version="1779199029128">
+      <Q id="6428697151" qualifier_id="1"/>
+      <Q id="6428697133" qualifier_id="2"/>
+      <Q id="6428697135" qualifier_id="5"/>
+      <Q id="6428697141" qualifier_id="56" value="Center"/>
+      <Q id="6428697143" qualifier_id="140" value="90.4"/>
+      <Q id="6428697145" qualifier_id="141" value="49.4"/>
+      <Q id="6428697139" qualifier_id="152"/>
+      <Q id="6428697137" qualifier_id="155"/>
+      <Q id="6428697147" qualifier_id="212" value="38.5"/>
+      <Q id="6428697149" qualifier_id="213" value="0.80"/>
+    </Event>
+    <Event id="2939846519" event_id="648" type_id="1" period_id="2" min="79" sec="9" player_id="731191" team_id="417" outcome="1" x="90.3" y="49.6" timestamp="2026-05-19T14:57:09.628" timestamp_utc="2026-05-19T13:57:09.628" last_modified="2026-05-19T14:57:11" version="1779199029734">
+      <Q id="6428697217" qualifier_id="3"/>
+      <Q id="6428697219" qualifier_id="56" value="Center"/>
+      <Q id="6428697221" qualifier_id="140" value="90.1"/>
+      <Q id="6428697223" qualifier_id="141" value="42.5"/>
+      <Q id="6428697225" qualifier_id="212" value="4.8"/>
+      <Q id="6428697227" qualifier_id="213" value="4.67"/>
+    </Event>
+    <Event id="2939846521" event_id="649" type_id="50" period_id="2" min="79" sec="10" player_id="531784" team_id="417" outcome="1" x="91.0" y="46.0" timestamp="2026-05-19T14:57:11.285" timestamp_utc="2026-05-19T13:57:11.285" last_modified="2026-05-19T15:22:32" version="1779200552060">
+      <Q id="6428697239" qualifier_id="56" value="Center"/>
+      <Q id="6428697303" qualifier_id="233" value="758"/>
+      <Q id="6428697241" qualifier_id="286"/>
+    </Event>
+    <Event id="2939846529" event_id="758" type_id="7" period_id="2" min="79" sec="10" player_id="508143" team_id="244" outcome="0" x="9.0" y="54.0" timestamp="2026-05-19T14:57:11.286" timestamp_utc="2026-05-19T13:57:11.286" last_modified="2026-05-19T14:57:16" version="1779199033190">
+      <Q id="6428697283" qualifier_id="56" value="Back"/>
+      <Q id="6428697287" qualifier_id="178"/>
+      <Q id="6428697289" qualifier_id="233" value="649"/>
+      <Q id="6428697285" qualifier_id="285"/>
+    </Event>
+    <Event id="2939850593" event_id="890" type_id="61" period_id="2" min="79" sec="11" player_id="627127" team_id="244" outcome="1" x="8.7" y="50.7" timestamp="2026-05-19T14:57:12.286" timestamp_utc="2026-05-19T13:57:12.286" last_modified="2026-05-19T15:14:44" version="1779200084580">
+      <Q id="6428722101" qualifier_id="56" value="Back"/>
+    </Event>
+    <Event id="2939846553" event_id="650" type_id="50" period_id="2" min="79" sec="14" player_id="445539" team_id="417" outcome="1" x="90.1" y="38.6" timestamp="2026-05-19T14:57:15.199" timestamp_utc="2026-05-19T13:57:15.199" last_modified="2026-05-19T15:22:31" version="1779200551066">
+      <Q id="6428697407" qualifier_id="56" value="Center"/>
+      <Q id="6428697497" qualifier_id="233" value="759"/>
+      <Q id="6428697409" qualifier_id="286"/>
+    </Event>
+    <Event id="2939846567" event_id="759" type_id="7" period_id="2" min="79" sec="14" player_id="575855" team_id="244" outcome="0" x="9.9" y="61.4" timestamp="2026-05-19T14:57:15.200" timestamp_utc="2026-05-19T13:57:15.200" last_modified="2026-05-19T15:02:27" version="1779199346956">
+      <Q id="6428697485" qualifier_id="56" value="Back"/>
+      <Q id="6428697489" qualifier_id="178"/>
+      <Q id="6428697491" qualifier_id="233" value="650"/>
+      <Q id="6428697487" qualifier_id="285"/>
+    </Event>
+    <Event id="2939846577" event_id="651" type_id="1" period_id="2" min="79" sec="17" player_id="720789" team_id="417" outcome="0" x="86.5" y="10.7" timestamp="2026-05-19T14:57:18.319" timestamp_utc="2026-05-19T13:57:18.319" last_modified="2026-05-19T14:57:19" version="1779199039373">
+      <Q id="6428697555" qualifier_id="2"/>
+      <Q id="6428697559" qualifier_id="56" value="Center"/>
+      <Q id="6428697561" qualifier_id="140" value="89.0"/>
+      <Q id="6428697563" qualifier_id="141" value="42.8"/>
+      <Q id="6428697557" qualifier_id="155"/>
+      <Q id="6428697565" qualifier_id="212" value="22.0"/>
+      <Q id="6428697567" qualifier_id="213" value="1.45"/>
+    </Event>
+    <Event id="2939846593" event_id="760" type_id="12" period_id="2" min="79" sec="19" player_id="627127" team_id="244" outcome="1" x="9.2" y="51.6" timestamp="2026-05-19T14:57:20.039" timestamp_utc="2026-05-19T13:57:20.039" last_modified="2026-05-19T14:57:43" version="1779199041439">
+      <Q id="6428697649" qualifier_id="15"/>
+      <Q id="6428697635" qualifier_id="56" value="Back"/>
+      <Q id="6428697637" qualifier_id="140" value="31.2"/>
+      <Q id="6428697639" qualifier_id="141" value="46.6"/>
+      <Q id="6428697641" qualifier_id="212" value="23.3"/>
+      <Q id="6428697643" qualifier_id="213" value="6.14"/>
+    </Event>
+    <Event id="2939846619" event_id="652" type_id="1" period_id="2" min="79" sec="22" player_id="570078" team_id="417" outcome="1" x="67.7" y="53.7" timestamp="2026-05-19T14:57:22.694" timestamp_utc="2026-05-19T13:57:22.694" last_modified="2026-05-19T14:57:26" version="1779199042886">
+      <Q id="6428697775" qualifier_id="56" value="Center"/>
+      <Q id="6428697777" qualifier_id="140" value="59.0"/>
+      <Q id="6428697779" qualifier_id="141" value="35.5"/>
+      <Q id="6428697781" qualifier_id="212" value="15.4"/>
+      <Q id="6428697783" qualifier_id="213" value="4.08"/>
+    </Event>
+    <Event id="2939846629" event_id="653" type_id="1" period_id="2" min="79" sec="25" player_id="683488" team_id="417" outcome="1" x="53.7" y="35.1" timestamp="2026-05-19T14:57:25.918" timestamp_utc="2026-05-19T13:57:25.918" last_modified="2026-05-19T14:57:28" version="1779199047330">
+      <Q id="6428697869" qualifier_id="56" value="Back"/>
+      <Q id="6428697871" qualifier_id="140" value="29.5"/>
+      <Q id="6428697873" qualifier_id="141" value="55.1"/>
+      <Q id="6428697875" qualifier_id="212" value="28.8"/>
+      <Q id="6428697877" qualifier_id="213" value="2.65"/>
+    </Event>
+    <Event id="2939846637" event_id="654" type_id="1" period_id="2" min="79" sec="27" player_id="565487" team_id="417" outcome="1" x="29.5" y="55.1" timestamp="2026-05-19T14:57:28.108" timestamp_utc="2026-05-19T13:57:28.108" last_modified="2026-05-19T14:57:30" version="1779199048302">
+      <Q id="6428697931" qualifier_id="56" value="Back"/>
+      <Q id="6428697933" qualifier_id="140" value="37.7"/>
+      <Q id="6428697935" qualifier_id="141" value="71.7"/>
+      <Q id="6428697937" qualifier_id="212" value="14.2"/>
+      <Q id="6428697939" qualifier_id="213" value="0.92"/>
+    </Event>
+    <Event id="2939846657" event_id="655" type_id="1" period_id="2" min="79" sec="32" player_id="570078" team_id="417" outcome="1" x="54.3" y="84.1" timestamp="2026-05-19T14:57:32.908" timestamp_utc="2026-05-19T13:57:32.908" last_modified="2026-05-19T14:57:35" version="1779199053205">
+      <Q id="6428698059" qualifier_id="56" value="Center"/>
+      <Q id="6428698061" qualifier_id="140" value="62.0"/>
+      <Q id="6428698063" qualifier_id="141" value="48.8"/>
+      <Q id="6428698065" qualifier_id="212" value="25.3"/>
+      <Q id="6428698067" qualifier_id="213" value="5.04"/>
+    </Event>
+    <Event id="2939846683" event_id="656" type_id="1" period_id="2" min="79" sec="34" player_id="157851" team_id="417" outcome="1" x="64.0" y="46.3" timestamp="2026-05-19T14:57:34.868" timestamp_utc="2026-05-19T13:57:34.868" last_modified="2026-05-19T14:57:39" version="1779199055064">
+      <Q id="6428698237" qualifier_id="3"/>
+      <Q id="6428698239" qualifier_id="56" value="Center"/>
+      <Q id="6428698241" qualifier_id="140" value="73.0"/>
+      <Q id="6428698243" qualifier_id="141" value="21.9"/>
+      <Q id="6428698245" qualifier_id="212" value="19.1"/>
+      <Q id="6428698247" qualifier_id="213" value="5.23"/>
+    </Event>
+    <Event id="2939846691" event_id="657" type_id="1" period_id="2" min="79" sec="39" player_id="720789" team_id="417" outcome="1" x="86.6" y="13.4" timestamp="2026-05-19T14:57:39.844" timestamp_utc="2026-05-19T13:57:39.844" last_modified="2026-05-19T14:57:41" version="1779199060054">
+      <Q id="6428698317" qualifier_id="56" value="Right"/>
+      <Q id="6428698319" qualifier_id="140" value="78.9"/>
+      <Q id="6428698321" qualifier_id="141" value="17.6"/>
+      <Q id="6428698323" qualifier_id="212" value="8.6"/>
+      <Q id="6428698325" qualifier_id="213" value="2.80"/>
+    </Event>
+    <Event id="2939846705" event_id="658" type_id="1" period_id="2" min="79" sec="41" player_id="157851" team_id="417" outcome="0" x="80.0" y="17.0" timestamp="2026-05-19T14:57:41.716" timestamp_utc="2026-05-19T13:57:41.716" last_modified="2026-05-19T14:57:46" version="1779199065549">
+      <Q id="6428698397" qualifier_id="2"/>
+      <Q id="6428698401" qualifier_id="56" value="Center"/>
+      <Q id="6428698403" qualifier_id="140" value="94.2"/>
+      <Q id="6428698405" qualifier_id="141" value="42.8"/>
+      <Q id="6428698399" qualifier_id="155"/>
+      <Q id="6428698407" qualifier_id="212" value="23.0"/>
+      <Q id="6428698409" qualifier_id="213" value="0.87"/>
+    </Event>
+    <Event id="2939846697" event_id="761" type_id="44" period_id="2" min="79" sec="42" player_id="627127" team_id="244" outcome="1" x="5.8" y="57.2" timestamp="2026-05-19T14:57:42.982" timestamp_utc="2026-05-19T13:57:42.982" last_modified="2026-05-19T15:45:46" version="1779201946811">
+      <Q id="6428698355" qualifier_id="56" value="Back"/>
+      <Q id="6428698457" qualifier_id="233" value="659"/>
+      <Q id="6428698357" qualifier_id="285"/>
+    </Event>
+    <Event id="2939846713" event_id="659" type_id="44" period_id="2" min="79" sec="42" player_id="61812" team_id="417" outcome="0" x="94.2" y="42.8" timestamp="2026-05-19T14:57:42.983" timestamp_utc="2026-05-19T13:57:42.983" last_modified="2026-05-19T15:45:47" version="1779201947093">
+      <Q id="6428698447" qualifier_id="56" value="Center"/>
+      <Q id="6428698489" qualifier_id="233" value="761"/>
+      <Q id="6428698449" qualifier_id="286"/>
+    </Event>
+    <Event id="2939846699" event_id="762" type_id="12" period_id="2" min="79" sec="42" player_id="627127" team_id="244" outcome="1" x="5.8" y="57.2" timestamp="2026-05-19T14:57:43.346" timestamp_utc="2026-05-19T13:57:43.346" last_modified="2026-05-19T15:45:47" version="1779201947372">
+      <Q id="6428698369" qualifier_id="15"/>
+      <Q id="6428698359" qualifier_id="56" value="Back"/>
+      <Q id="6428698361" qualifier_id="140" value="12.2"/>
+      <Q id="6428698363" qualifier_id="141" value="44.2"/>
+      <Q id="6428698365" qualifier_id="212" value="11.1"/>
+      <Q id="6428698367" qualifier_id="213" value="5.36"/>
+    </Event>
+    <Event id="2939846723" event_id="763" type_id="12" period_id="2" min="79" sec="44" player_id="246081" team_id="244" outcome="1" x="12.2" y="44.2" timestamp="2026-05-19T14:57:44.862" timestamp_utc="2026-05-19T13:57:44.862" last_modified="2026-05-19T14:57:49" version="1779199065743">
+      <Q id="6428698529" qualifier_id="56" value="Back"/>
+      <Q id="6428698531" qualifier_id="140" value="15.2"/>
+      <Q id="6428698533" qualifier_id="141" value="39.8"/>
+      <Q id="6428698535" qualifier_id="212" value="4.3"/>
+      <Q id="6428698537" qualifier_id="213" value="5.52"/>
+    </Event>
+    <Event id="2939846737" event_id="764" type_id="12" period_id="2" min="79" sec="46" player_id="479433" team_id="244" outcome="1" x="15.2" y="39.8" timestamp="2026-05-19T14:57:46.629" timestamp_utc="2026-05-19T13:57:46.629" last_modified="2026-05-19T15:02:08" version="1779199327940">
+      <Q id="6428698609" qualifier_id="56" value="Back"/>
+      <Q id="6428698611" qualifier_id="140" value="45.4"/>
+      <Q id="6428698613" qualifier_id="141" value="62.4"/>
+      <Q id="6428698615" qualifier_id="212" value="35.2"/>
+      <Q id="6428698617" qualifier_id="213" value="0.45"/>
+    </Event>
+    <Event id="2939846755" event_id="660" type_id="1" period_id="2" min="79" sec="51" player_id="683488" team_id="417" outcome="1" x="43.4" y="41.6" timestamp="2026-05-19T14:57:51.814" timestamp_utc="2026-05-19T13:57:51.814" last_modified="2026-05-19T14:57:55" version="1779199072084">
+      <Q id="6428698713" qualifier_id="56" value="Center"/>
+      <Q id="6428698715" qualifier_id="140" value="53.1"/>
+      <Q id="6428698717" qualifier_id="141" value="64.2"/>
+      <Q id="6428698719" qualifier_id="212" value="18.4"/>
+      <Q id="6428698721" qualifier_id="213" value="0.99"/>
+    </Event>
+    <Event id="2939846759" event_id="661" type_id="1" period_id="2" min="79" sec="54" player_id="61778" team_id="417" outcome="0" x="50.8" y="66.6" timestamp="2026-05-19T14:57:55.128" timestamp_utc="2026-05-19T13:57:55.128" last_modified="2026-05-19T14:57:57" version="1779199077589">
+      <Q id="6428698757" qualifier_id="1"/>
+      <Q id="6428698747" qualifier_id="56" value="Right"/>
+      <Q id="6428698749" qualifier_id="140" value="70.3"/>
+      <Q id="6428698751" qualifier_id="141" value="20.1"/>
+      <Q id="6428698745" qualifier_id="155"/>
+      <Q id="6428698753" qualifier_id="212" value="37.7"/>
+      <Q id="6428698755" qualifier_id="213" value="5.29"/>
+    </Event>
+    <Event id="2939846777" event_id="765" type_id="12" period_id="2" min="79" sec="59" player_id="575855" team_id="244" outcome="1" x="24.9" y="88.1" timestamp="2026-05-19T14:57:59.975" timestamp_utc="2026-05-19T13:57:59.975" last_modified="2026-05-19T14:58:08" version="1779199088586">
+      <Q id="6428698989" qualifier_id="15"/>
+      <Q id="6428698863" qualifier_id="56" value="Back"/>
+      <Q id="6428698865" qualifier_id="140" value="29.5"/>
+      <Q id="6428698867" qualifier_id="141" value="100.0"/>
+      <Q id="6428699059" qualifier_id="167"/>
+      <Q id="6428698869" qualifier_id="212" value="9.9"/>
+      <Q id="6428698871" qualifier_id="213" value="1.06"/>
+    </Event>
+    <Event id="2939846787" event_id="766" type_id="5" period_id="2" min="80" sec="1" player_id="575855" team_id="244" outcome="0" x="31.9" y="101.4" timestamp="2026-05-19T14:58:02.382" timestamp_utc="2026-05-19T13:58:02.382" last_modified="2026-05-19T14:58:27" version="1779199106785">
+      <Q id="6428698941" qualifier_id="56" value="Back"/>
+      <Q id="6428699579" qualifier_id="233" value="662"/>
+      <Q id="6428698943" qualifier_id="347"/>
+    </Event>
+    <Event id="2939846885" event_id="662" type_id="5" period_id="2" min="80" sec="1" player_id="157851" team_id="417" outcome="1" x="68.2" y="-1.4" timestamp="2026-05-19T14:58:02.382" timestamp_utc="2026-05-19T13:58:02.382" last_modified="2026-05-19T15:26:37" version="1779200790298">
+      <Q id="6428699515" qualifier_id="56" value="Right"/>
+      <Q id="6428699549" qualifier_id="233" value="766"/>
+      <Q id="6428699517" qualifier_id="347"/>
+    </Event>
+    <Event id="2939846905" event_id="663" type_id="1" period_id="2" min="80" sec="25" player_id="624620" team_id="417" outcome="0" x="72.1" y="0.0" timestamp="2026-05-19T14:58:26.515" timestamp_utc="2026-05-19T13:58:26.515" last_modified="2026-05-19T14:58:29" version="1779199109220">
+      <Q id="6428699655" qualifier_id="1"/>
+      <Q id="6428699645" qualifier_id="56" value="Center"/>
+      <Q id="6428699643" qualifier_id="107"/>
+      <Q id="6428699647" qualifier_id="140" value="87.3"/>
+      <Q id="6428699649" qualifier_id="141" value="46.7"/>
+      <Q id="6428699651" qualifier_id="212" value="36.7"/>
+      <Q id="6428699653" qualifier_id="213" value="1.12"/>
+    </Event>
+    <Event id="2939846913" event_id="767" type_id="12" period_id="2" min="80" sec="31" player_id="246081" team_id="244" outcome="1" x="8.4" y="62.0" timestamp="2026-05-19T14:58:31.630" timestamp_utc="2026-05-19T13:58:31.630" last_modified="2026-05-19T14:58:33" version="1779199112174">
+      <Q id="6428699759" qualifier_id="15"/>
+      <Q id="6428699733" qualifier_id="56" value="Back"/>
+      <Q id="6428699735" qualifier_id="140" value="27.4"/>
+      <Q id="6428699737" qualifier_id="141" value="49.9"/>
+      <Q id="6428699739" qualifier_id="212" value="21.6"/>
+      <Q id="6428699741" qualifier_id="213" value="5.89"/>
+    </Event>
+    <Event id="2939846929" event_id="664" type_id="13" period_id="2" min="80" sec="32" player_id="61778" team_id="417" outcome="1" x="81.2" y="49.7" timestamp="2026-05-19T14:58:33.284" timestamp_utc="2026-05-19T13:58:33.284" last_modified="2026-05-19T16:05:20" version="1779203120270">
+      <Q id="6428699803" qualifier_id="18"/>
+      <Q id="6428702973" qualifier_id="20"/>
+      <Q id="6428699805" qualifier_id="56" value="Center"/>
+      <Q id="6428747741" qualifier_id="73"/>
+      <Q id="6428703115" qualifier_id="102" value="60.2"/>
+      <Q id="6428703117" qualifier_id="103" value="13.9"/>
+      <Q id="6428703121" qualifier_id="146" value="91.9"/>
+      <Q id="6428703123" qualifier_id="147" value="54.2"/>
+      <Q id="6428747743" qualifier_id="153"/>
+      <Q id="6428703111" qualifier_id="160"/>
+      <Q id="6428703125" qualifier_id="230" value="98.8"/>
+      <Q id="6428703127" qualifier_id="231" value="49.6"/>
+      <Q id="6428703119" qualifier_id="458"/>
+    </Event>
+    <Event id="2939846933" event_id="768" type_id="12" period_id="2" min="80" sec="32" player_id="627127" team_id="244" outcome="1" x="10.3" y="38.3" timestamp="2026-05-19T14:58:33.384" timestamp_utc="2026-05-19T13:58:33.384" last_modified="2026-05-19T16:05:16" version="1779203116433">
+      <Q id="6428699827" qualifier_id="56" value="Back"/>
+      <Q id="6428747867" qualifier_id="140" value="32.8"/>
+      <Q id="6428747869" qualifier_id="141" value="54.2"/>
+      <Q id="6428747871" qualifier_id="212" value="26.0"/>
+      <Q id="6428747873" qualifier_id="213" value="0.43"/>
+    </Event>
+    <Event id="2939846965" event_id="665" type_id="1" period_id="2" min="80" sec="35" player_id="570078" team_id="417" outcome="1" x="67.6" y="52.1" timestamp="2026-05-19T14:58:35.861" timestamp_utc="2026-05-19T13:58:35.861" last_modified="2026-05-19T14:58:41" version="1779199116412">
+      <Q id="6428700009" qualifier_id="1"/>
+      <Q id="6428699999" qualifier_id="56" value="Back"/>
+      <Q id="6428700001" qualifier_id="140" value="34.1"/>
+      <Q id="6428700003" qualifier_id="141" value="56.0"/>
+      <Q id="6428700005" qualifier_id="212" value="35.3"/>
+      <Q id="6428700007" qualifier_id="213" value="3.07"/>
+    </Event>
+    <Event id="2939846993" event_id="666" type_id="1" period_id="2" min="80" sec="41" player_id="565487" team_id="417" outcome="1" x="32.6" y="49.1" timestamp="2026-05-19T14:58:41.748" timestamp_utc="2026-05-19T13:58:41.748" last_modified="2026-05-19T14:58:49" version="1779199127069">
+      <Q id="6428700205" qualifier_id="1"/>
+      <Q id="6428700195" qualifier_id="56" value="Right"/>
+      <Q id="6428700197" qualifier_id="140" value="84.2"/>
+      <Q id="6428700199" qualifier_id="141" value="10.6"/>
+      <Q id="6428700193" qualifier_id="155"/>
+      <Q id="6428700201" qualifier_id="212" value="60.2"/>
+      <Q id="6428700203" qualifier_id="213" value="5.83"/>
+    </Event>
+    <Event id="2939846985" event_id="769" type_id="83" period_id="2" min="80" sec="46" player_id="515742" team_id="244" outcome="0" x="9.8" y="88.4" timestamp="2026-05-19T14:58:47.542" timestamp_utc="2026-05-19T13:58:47.542" last_modified="2026-05-19T14:58:53" version="1779199133449">
+      <Q id="6428700401" qualifier_id="399" value="157851"/>
+    </Event>
+    <Event id="2939846997" event_id="667" type_id="50" period_id="2" min="80" sec="48" player_id="157851" team_id="417" outcome="1" x="87.2" y="13.9" timestamp="2026-05-19T14:58:48.932" timestamp_utc="2026-05-19T13:58:48.932" last_modified="2026-05-19T15:26:46" version="1779200796927">
+      <Q id="6428700213" qualifier_id="56" value="Right"/>
+      <Q id="6428700275" qualifier_id="233" value="770"/>
+      <Q id="6428700215" qualifier_id="286"/>
+    </Event>
+    <Event id="2939847003" event_id="770" type_id="7" period_id="2" min="80" sec="48" player_id="515742" team_id="244" outcome="1" x="12.8" y="86.1" timestamp="2026-05-19T14:58:48.933" timestamp_utc="2026-05-19T13:58:48.933" last_modified="2026-05-19T15:26:46" version="1779200796921">
+      <Q id="6428700247" qualifier_id="56" value="Back"/>
+      <Q id="6428700251" qualifier_id="178"/>
+      <Q id="6428700271" qualifier_id="233" value="667"/>
+      <Q id="6428700249" qualifier_id="285"/>
+    </Event>
+    <Event id="2939847007" event_id="771" type_id="49" period_id="2" min="80" sec="49" player_id="515742" team_id="244" outcome="1" x="10.9" y="82.6" timestamp="2026-05-19T14:58:49.944" timestamp_utc="2026-05-19T13:58:49.944" last_modified="2026-05-19T14:58:50" version="1779199129945"/>
+    <Event id="2939847035" event_id="772" type_id="1" period_id="2" min="80" sec="51" player_id="515742" team_id="244" outcome="1" x="25.4" y="85.6" timestamp="2026-05-19T14:58:51.918" timestamp_utc="2026-05-19T13:58:51.918" last_modified="2026-05-19T14:58:54" version="1779199132113">
+      <Q id="6428700429" qualifier_id="56" value="Back"/>
+      <Q id="6428700431" qualifier_id="140" value="29.2"/>
+      <Q id="6428700433" qualifier_id="141" value="81.5"/>
+      <Q id="6428700435" qualifier_id="212" value="4.9"/>
+      <Q id="6428700437" qualifier_id="213" value="5.67"/>
+    </Event>
+    <Event id="2939847049" event_id="773" type_id="1" period_id="2" min="80" sec="53" player_id="508143" team_id="244" outcome="1" x="25.4" y="84.7" timestamp="2026-05-19T14:58:54.406" timestamp_utc="2026-05-19T13:58:54.406" last_modified="2026-05-19T14:58:56" version="1779199135525">
+      <Q id="6428700501" qualifier_id="56" value="Back"/>
+      <Q id="6428700503" qualifier_id="140" value="33.5"/>
+      <Q id="6428700505" qualifier_id="141" value="81.2"/>
+      <Q id="6428700507" qualifier_id="212" value="8.8"/>
+      <Q id="6428700509" qualifier_id="213" value="6.01"/>
+    </Event>
+    <Event id="2939847079" event_id="774" type_id="1" period_id="2" min="80" sec="55" player_id="515742" team_id="244" outcome="1" x="37.1" y="82.9" timestamp="2026-05-19T14:58:56.006" timestamp_utc="2026-05-19T13:58:56.006" last_modified="2026-05-19T14:59:00" version="1779199136601">
+      <Q id="6428700649" qualifier_id="56" value="Back"/>
+      <Q id="6428700651" qualifier_id="140" value="33.7"/>
+      <Q id="6428700653" qualifier_id="141" value="71.1"/>
+      <Q id="6428700655" qualifier_id="212" value="8.8"/>
+      <Q id="6428700657" qualifier_id="213" value="4.29"/>
+    </Event>
+    <Event id="2939847055" event_id="668" type_id="83" period_id="2" min="80" sec="56" player_id="624620" team_id="417" outcome="0" x="68.4" y="12.0" timestamp="2026-05-19T14:58:57.355" timestamp_utc="2026-05-19T13:58:57.355" last_modified="2026-05-19T15:02:40" version="1779199360414">
+      <Q id="6428700695" qualifier_id="399" value="246081"/>
+    </Event>
+    <Event id="2939847083" event_id="775" type_id="1" period_id="2" min="80" sec="59" player_id="246081" team_id="244" outcome="0" x="42.0" y="56.4" timestamp="2026-05-19T14:58:59.950" timestamp_utc="2026-05-19T13:58:59.950" last_modified="2026-05-19T14:59:03" version="1779199142928">
+      <Q id="6428700745" qualifier_id="1"/>
+      <Q id="6428700673" qualifier_id="56" value="Center"/>
+      <Q id="6428700675" qualifier_id="140" value="71.2"/>
+      <Q id="6428700677" qualifier_id="141" value="37.4"/>
+      <Q id="6428700679" qualifier_id="212" value="33.3"/>
+      <Q id="6428700681" qualifier_id="213" value="5.88"/>
+    </Event>
+    <Event id="2939847101" event_id="669" type_id="49" period_id="2" min="81" sec="2" player_id="61778" team_id="417" outcome="1" x="25.2" y="62.1" timestamp="2026-05-19T14:59:03.364" timestamp_utc="2026-05-19T13:59:03.364" last_modified="2026-05-19T14:59:03" version="1779199143366"/>
+    <Event id="2939847147" event_id="670" type_id="1" period_id="2" min="81" sec="11" player_id="61778" team_id="417" outcome="1" x="34.6" y="23.9" timestamp="2026-05-19T14:59:12.526" timestamp_utc="2026-05-19T13:59:12.526" last_modified="2026-05-19T14:59:15" version="1779199154509">
+      <Q id="6428701091" qualifier_id="1"/>
+      <Q id="6428701081" qualifier_id="56" value="Center"/>
+      <Q id="6428701083" qualifier_id="140" value="70.3"/>
+      <Q id="6428701085" qualifier_id="141" value="46.6"/>
+      <Q id="6428701079" qualifier_id="155"/>
+      <Q id="6428701087" qualifier_id="212" value="40.5"/>
+      <Q id="6428701089" qualifier_id="213" value="0.39"/>
+    </Event>
+    <Event id="2939847149" event_id="671" type_id="1" period_id="2" min="81" sec="14" player_id="445539" team_id="417" outcome="0" x="70.3" y="46.6" timestamp="2026-05-19T14:59:15.500" timestamp_utc="2026-05-19T13:59:15.500" last_modified="2026-05-19T14:59:17" version="1779199156661">
+      <Q id="6428701095" qualifier_id="3"/>
+      <Q id="6428701097" qualifier_id="56" value="Center"/>
+      <Q id="6428701099" qualifier_id="140" value="66.3"/>
+      <Q id="6428701101" qualifier_id="141" value="57.9"/>
+      <Q id="6428701113" qualifier_id="156"/>
+      <Q id="6428701103" qualifier_id="212" value="8.8"/>
+      <Q id="6428701105" qualifier_id="213" value="2.07"/>
+    </Event>
+    <Event id="2939847159" event_id="777" type_id="49" period_id="2" min="81" sec="17" player_id="180662" team_id="244" outcome="1" x="24.3" y="36.9" timestamp="2026-05-19T14:59:18.023" timestamp_utc="2026-05-19T13:59:18.023" last_modified="2026-05-19T14:59:18" version="1779199158024"/>
+    <Event id="2939847187" event_id="778" type_id="1" period_id="2" min="81" sec="17" player_id="180662" team_id="244" outcome="0" x="24.3" y="36.9" timestamp="2026-05-19T14:59:18.223" timestamp_utc="2026-05-19T13:59:18.223" last_modified="2026-05-19T15:00:37" version="1779199237524">
+      <Q id="6428701291" qualifier_id="1"/>
+      <Q id="6428701281" qualifier_id="56" value="Center"/>
+      <Q id="6428701283" qualifier_id="140" value="88.4"/>
+      <Q id="6428701285" qualifier_id="141" value="30.9"/>
+      <Q id="6428701279" qualifier_id="157"/>
+      <Q id="6428701287" qualifier_id="212" value="67.4"/>
+      <Q id="6428701289" qualifier_id="213" value="6.22"/>
+    </Event>
+    <Event id="2939847199" event_id="672" type_id="52" period_id="2" min="81" sec="23" player_id="565487" team_id="417" outcome="1" x="13.4" y="70.9" timestamp="2026-05-19T14:59:24.451" timestamp_utc="2026-05-19T13:59:24.451" last_modified="2026-05-19T14:59:24" version="1779199164452"/>
+    <Event id="2939847239" event_id="673" type_id="1" period_id="2" min="81" sec="25" player_id="565487" team_id="417" outcome="1" x="13.4" y="70.9" timestamp="2026-05-19T14:59:26.100" timestamp_utc="2026-05-19T13:59:26.100" last_modified="2026-05-19T14:59:30" version="1779199166349">
+      <Q id="6428701551" qualifier_id="56" value="Back"/>
+      <Q id="6428701549" qualifier_id="123"/>
+      <Q id="6428701553" qualifier_id="140" value="27.5"/>
+      <Q id="6428701555" qualifier_id="141" value="59.1"/>
+      <Q id="6428701557" qualifier_id="212" value="16.8"/>
+      <Q id="6428701559" qualifier_id="213" value="5.79"/>
+    </Event>
+    <Event id="2939847257" event_id="674" type_id="1" period_id="2" min="81" sec="30" player_id="61812" team_id="417" outcome="1" x="26.5" y="58.4" timestamp="2026-05-19T14:59:30.595" timestamp_utc="2026-05-19T13:59:30.595" last_modified="2026-05-19T14:59:36" version="1779199170838">
+      <Q id="6428701657" qualifier_id="56" value="Back"/>
+      <Q id="6428701659" qualifier_id="140" value="25.5"/>
+      <Q id="6428701661" qualifier_id="141" value="38.2"/>
+      <Q id="6428701663" qualifier_id="212" value="13.8"/>
+      <Q id="6428701665" qualifier_id="213" value="4.64"/>
+    </Event>
+    <Event id="2939847275" event_id="675" type_id="1" period_id="2" min="81" sec="35" player_id="531784" team_id="417" outcome="0" x="28.5" y="24.7" timestamp="2026-05-19T14:59:35.979" timestamp_utc="2026-05-19T13:59:35.979" last_modified="2026-05-19T14:59:40" version="1779199180211">
+      <Q id="6428701795" qualifier_id="1"/>
+      <Q id="6428701785" qualifier_id="56" value="Right"/>
+      <Q id="6428701787" qualifier_id="140" value="72.0"/>
+      <Q id="6428701789" qualifier_id="141" value="19.8"/>
+      <Q id="6428701783" qualifier_id="155"/>
+      <Q id="6428701791" qualifier_id="212" value="45.8"/>
+      <Q id="6428701793" qualifier_id="213" value="6.21"/>
+    </Event>
+    <Event id="2939847281" event_id="779" type_id="49" period_id="2" min="81" sec="41" player_id="180662" team_id="244" outcome="1" x="13.9" y="86.3" timestamp="2026-05-19T14:59:41.694" timestamp_utc="2026-05-19T13:59:41.694" last_modified="2026-05-19T15:00:36" version="1779199236268"/>
+    <Event id="2939847295" event_id="780" type_id="1" period_id="2" min="81" sec="41" player_id="180662" team_id="244" outcome="1" x="13.2" y="85.7" timestamp="2026-05-19T14:59:41.985" timestamp_utc="2026-05-19T13:59:41.985" last_modified="2026-05-19T14:59:43" version="1779199183197">
+      <Q id="6428701877" qualifier_id="56" value="Back"/>
+      <Q id="6428701879" qualifier_id="140" value="4.9"/>
+      <Q id="6428701881" qualifier_id="141" value="61.2"/>
+      <Q id="6428701883" qualifier_id="212" value="18.8"/>
+      <Q id="6428701885" qualifier_id="213" value="4.23"/>
+    </Event>
+    <Event id="2939847323" event_id="781" type_id="1" period_id="2" min="81" sec="43" player_id="578592" team_id="244" outcome="1" x="4.9" y="61.2" timestamp="2026-05-19T14:59:43.774" timestamp_utc="2026-05-19T13:59:43.774" last_modified="2026-05-19T14:59:50" version="1779199187753">
+      <Q id="6428702035" qualifier_id="1"/>
+      <Q id="6428702025" qualifier_id="56" value="Back"/>
+      <Q id="6428702027" qualifier_id="140" value="38.7"/>
+      <Q id="6428702029" qualifier_id="141" value="87.2"/>
+      <Q id="6428702023" qualifier_id="157"/>
+      <Q id="6428702031" qualifier_id="212" value="39.6"/>
+      <Q id="6428702033" qualifier_id="213" value="0.46"/>
+    </Event>
+    <Event id="2939847327" event_id="782" type_id="1" period_id="2" min="81" sec="49" player_id="207884" team_id="244" outcome="0" x="36.0" y="91.2" timestamp="2026-05-19T14:59:50.046" timestamp_utc="2026-05-19T13:59:50.046" last_modified="2026-05-19T14:59:55" version="1779199195646">
+      <Q id="6428702051" qualifier_id="56" value="Back"/>
+      <Q id="6428702259" qualifier_id="140" value="42.2"/>
+      <Q id="6428702261" qualifier_id="141" value="82.2"/>
+      <Q id="6428702263" qualifier_id="212" value="8.9"/>
+      <Q id="6428702265" qualifier_id="213" value="5.53"/>
+    </Event>
+    <Event id="2939847353" event_id="676" type_id="1" period_id="2" min="81" sec="51" player_id="683488" team_id="417" outcome="1" x="52.1" y="24.3" timestamp="2026-05-19T14:59:52.211" timestamp_utc="2026-05-19T13:59:52.211" last_modified="2026-05-19T14:59:55" version="1779199192407">
+      <Q id="6428702227" qualifier_id="56" value="Back"/>
+      <Q id="6428702229" qualifier_id="140" value="36.5"/>
+      <Q id="6428702231" qualifier_id="141" value="54.3"/>
+      <Q id="6428702233" qualifier_id="212" value="26.2"/>
+      <Q id="6428702235" qualifier_id="213" value="2.25"/>
+    </Event>
+    <Event id="2939847357" event_id="677" type_id="49" period_id="2" min="81" sec="54" player_id="624620" team_id="417" outcome="1" x="49.0" y="65.5" timestamp="2026-05-19T14:59:55.125" timestamp_utc="2026-05-19T13:59:55.125" last_modified="2026-05-19T14:59:55" version="1779199195126"/>
+    <Event id="2939847385" event_id="678" type_id="1" period_id="2" min="81" sec="55" player_id="624620" team_id="417" outcome="1" x="56.1" y="73.5" timestamp="2026-05-19T14:59:56.235" timestamp_utc="2026-05-19T13:59:56.235" last_modified="2026-05-19T14:59:59" version="1779199196511">
+      <Q id="6428702391" qualifier_id="56" value="Left"/>
+      <Q id="6428702393" qualifier_id="140" value="67.7"/>
+      <Q id="6428702395" qualifier_id="141" value="83.9"/>
+      <Q id="6428702397" qualifier_id="212" value="14.1"/>
+      <Q id="6428702399" qualifier_id="213" value="0.53"/>
+    </Event>
+    <Event id="2939847401" event_id="679" type_id="1" period_id="2" min="81" sec="58" player_id="570078" team_id="417" outcome="1" x="67.6" y="78.4" timestamp="2026-05-19T14:59:59.499" timestamp_utc="2026-05-19T13:59:59.499" last_modified="2026-05-19T15:00:02" version="1779199199833">
+      <Q id="6428702513" qualifier_id="56" value="Center"/>
+      <Q id="6428702515" qualifier_id="140" value="60.9"/>
+      <Q id="6428702517" qualifier_id="141" value="51.9"/>
+      <Q id="6428702519" qualifier_id="212" value="19.3"/>
+      <Q id="6428702521" qualifier_id="213" value="4.34"/>
+    </Event>
+    <Event id="2939847411" event_id="680" type_id="1" period_id="2" min="82" sec="2" player_id="683488" team_id="417" outcome="1" x="62.7" y="52.8" timestamp="2026-05-19T15:00:02.851" timestamp_utc="2026-05-19T14:00:02.851" last_modified="2026-05-19T15:00:05" version="1779199204854">
+      <Q id="6428702579" qualifier_id="1"/>
+      <Q id="6428702569" qualifier_id="56" value="Right"/>
+      <Q id="6428702571" qualifier_id="140" value="83.7"/>
+      <Q id="6428702573" qualifier_id="141" value="15.6"/>
+      <Q id="6428702567" qualifier_id="155"/>
+      <Q id="6428702575" qualifier_id="212" value="33.6"/>
+      <Q id="6428702577" qualifier_id="213" value="5.43"/>
+    </Event>
+    <Event id="2939847421" event_id="681" type_id="44" period_id="2" min="82" sec="5" player_id="157851" team_id="417" outcome="1" x="83.7" y="15.6" timestamp="2026-05-19T15:00:05.819" timestamp_utc="2026-05-19T14:00:05.819" last_modified="2026-05-19T15:45:47" version="1779201947657">
+      <Q id="6428702625" qualifier_id="56" value="Right"/>
+      <Q id="6428702679" qualifier_id="233" value="783"/>
+      <Q id="6428702627" qualifier_id="286"/>
+    </Event>
+    <Event id="2939847433" event_id="783" type_id="44" period_id="2" min="82" sec="5" player_id="575855" team_id="244" outcome="0" x="16.3" y="84.4" timestamp="2026-05-19T15:00:05.820" timestamp_utc="2026-05-19T14:00:05.820" last_modified="2026-05-19T15:45:48" version="1779201947936">
+      <Q id="6428702673" qualifier_id="56" value="Back"/>
+      <Q id="6428702705" qualifier_id="233" value="681"/>
+      <Q id="6428702675" qualifier_id="285"/>
+    </Event>
+    <Event id="2939847427" event_id="682" type_id="1" period_id="2" min="82" sec="5" player_id="157851" team_id="417" outcome="0" x="83.7" y="15.6" timestamp="2026-05-19T15:00:06.067" timestamp_utc="2026-05-19T14:00:06.067" last_modified="2026-05-19T15:45:48" version="1779201948218">
+      <Q id="6428702645" qualifier_id="3"/>
+      <Q id="6428702647" qualifier_id="56" value="Center"/>
+      <Q id="6428702649" qualifier_id="140" value="91.3"/>
+      <Q id="6428702651" qualifier_id="141" value="26.2"/>
+      <Q id="6428702653" qualifier_id="212" value="10.8"/>
+      <Q id="6428702655" qualifier_id="213" value="0.73"/>
+    </Event>
+    <Event id="2939847459" event_id="784" type_id="12" period_id="2" min="82" sec="8" player_id="180662" team_id="244" outcome="1" x="9.4" y="63.9" timestamp="2026-05-19T15:00:08.887" timestamp_utc="2026-05-19T14:00:08.887" last_modified="2026-05-19T15:00:10" version="1779199209871">
+      <Q id="6428702785" qualifier_id="56" value="Back"/>
+      <Q id="6428702787" qualifier_id="140" value="26.6"/>
+      <Q id="6428702789" qualifier_id="141" value="100.0"/>
+      <Q id="6428702811" qualifier_id="167"/>
+      <Q id="6428702791" qualifier_id="212" value="31.4"/>
+      <Q id="6428702793" qualifier_id="213" value="0.96"/>
+    </Event>
+    <Event id="2939847461" event_id="785" type_id="5" period_id="2" min="82" sec="9" player_id="180662" team_id="244" outcome="0" x="27.8" y="101.6" timestamp="2026-05-19T15:00:09.813" timestamp_utc="2026-05-19T14:00:09.813" last_modified="2026-05-19T15:26:38" version="1779200790315">
+      <Q id="6428702795" qualifier_id="56" value="Back"/>
+      <Q id="6428702999" qualifier_id="233" value="683"/>
+      <Q id="6428702797" qualifier_id="347"/>
+    </Event>
+    <Event id="2939847493" event_id="683" type_id="5" period_id="2" min="82" sec="9" player_id="157851" team_id="417" outcome="1" x="72.2" y="-1.6" timestamp="2026-05-19T15:00:09.813" timestamp_utc="2026-05-19T14:00:09.813" last_modified="2026-05-19T15:26:37" version="1779200790308">
+      <Q id="6428702967" qualifier_id="56" value="Right"/>
+      <Q id="6428702991" qualifier_id="233" value="785"/>
+      <Q id="6428702969" qualifier_id="347"/>
+    </Event>
+    <Event id="2939847569" event_id="684" type_id="1" period_id="2" min="82" sec="38" player_id="624620" team_id="417" outcome="0" x="71.5" y="0.0" timestamp="2026-05-19T15:00:39.326" timestamp_utc="2026-05-19T14:00:39.326" last_modified="2026-05-19T15:00:43" version="1779199242875">
+      <Q id="6428703535" qualifier_id="1"/>
+      <Q id="6428703525" qualifier_id="56" value="Center"/>
+      <Q id="6428703523" qualifier_id="107"/>
+      <Q id="6428703527" qualifier_id="140" value="89.5"/>
+      <Q id="6428703529" qualifier_id="141" value="36.3"/>
+      <Q id="6428703531" qualifier_id="212" value="31.8"/>
+      <Q id="6428703533" qualifier_id="213" value="0.94"/>
+    </Event>
+    <Event id="2939847575" event_id="786" type_id="44" period_id="2" min="82" sec="42" player_id="508143" team_id="244" outcome="1" x="10.5" y="63.7" timestamp="2026-05-19T15:00:42.659" timestamp_utc="2026-05-19T14:00:42.659" last_modified="2026-05-19T15:45:48" version="1779201948500">
+      <Q id="6428703557" qualifier_id="56" value="Back"/>
+      <Q id="6428703581" qualifier_id="233" value="685"/>
+      <Q id="6428703559" qualifier_id="285"/>
+    </Event>
+    <Event id="2939847573" event_id="685" type_id="44" period_id="2" min="82" sec="42" player_id="531784" team_id="417" outcome="0" x="89.5" y="36.3" timestamp="2026-05-19T15:00:42.660" timestamp_utc="2026-05-19T14:00:42.660" last_modified="2026-05-19T15:45:48" version="1779201948782">
+      <Q id="6428703545" qualifier_id="56" value="Center"/>
+      <Q id="6428703585" qualifier_id="233" value="786"/>
+      <Q id="6428703547" qualifier_id="286"/>
+    </Event>
+    <Event id="2939847585" event_id="787" type_id="12" period_id="2" min="82" sec="42" player_id="508143" team_id="244" outcome="1" x="10.5" y="63.7" timestamp="2026-05-19T15:00:42.782" timestamp_utc="2026-05-19T14:00:42.782" last_modified="2026-05-19T15:45:49" version="1779201949065">
+      <Q id="6428703651" qualifier_id="15"/>
+      <Q id="6428703629" qualifier_id="56" value="Back"/>
+      <Q id="6428703631" qualifier_id="140" value="16.9"/>
+      <Q id="6428703633" qualifier_id="141" value="40.9"/>
+      <Q id="6428703635" qualifier_id="212" value="16.9"/>
+      <Q id="6428703637" qualifier_id="213" value="5.12"/>
+    </Event>
+    <Event id="2939847587" event_id="686" type_id="13" period_id="2" min="82" sec="45" player_id="61778" team_id="417" outcome="1" x="82.7" y="64.2" timestamp="2026-05-19T15:00:45.586" timestamp_utc="2026-05-19T14:00:45.586" last_modified="2026-05-19T16:03:49" version="1779203029221">
+      <Q id="6428703641" qualifier_id="18"/>
+      <Q id="6428703643" qualifier_id="56" value="Center"/>
+      <Q id="6428705645" qualifier_id="72"/>
+      <Q id="6428705649" qualifier_id="75"/>
+      <Q id="6428705651" qualifier_id="102" value="40.5"/>
+      <Q id="6428705653" qualifier_id="103" value="13.9"/>
+      <Q id="6428705655" qualifier_id="108"/>
+      <Q id="6428705647" qualifier_id="114"/>
+      <Q id="6428705665" qualifier_id="146" value="89.1"/>
+      <Q id="6428705667" qualifier_id="147" value="55.1"/>
+      <Q id="6428705663" qualifier_id="153"/>
+      <Q id="6428705643" qualifier_id="160"/>
+      <Q id="6428705669" qualifier_id="230" value="99.0"/>
+      <Q id="6428705671" qualifier_id="231" value="50.5"/>
+      <Q id="6428705659" qualifier_id="328"/>
+      <Q id="6428746229" qualifier_id="391"/>
+      <Q id="6428705661" qualifier_id="458"/>
+    </Event>
+    <Event id="2939847593" event_id="788" type_id="12" period_id="2" min="82" sec="46" player_id="627127" team_id="244" outcome="1" x="11.4" y="43.0" timestamp="2026-05-19T15:00:47.174" timestamp_utc="2026-05-19T14:00:47.174" last_modified="2026-05-19T15:00:57" version="1779199248078">
+      <Q id="6428703681" qualifier_id="15"/>
+      <Q id="6428703657" qualifier_id="56" value="Back"/>
+      <Q id="6428703659" qualifier_id="140" value="29.2"/>
+      <Q id="6428703661" qualifier_id="141" value="28.9"/>
+      <Q id="6428703663" qualifier_id="212" value="21.0"/>
+      <Q id="6428703665" qualifier_id="213" value="5.81"/>
+    </Event>
+    <Event id="2939847607" event_id="687" type_id="2" period_id="2" min="82" sec="50" player_id="61778" team_id="417" outcome="1" x="71.4" y="68.7" timestamp="2026-05-19T15:00:50.762" timestamp_utc="2026-05-19T14:00:50.762" last_modified="2026-05-19T15:45:07" version="1779201906892">
+      <Q id="6428704107" qualifier_id="7" value="445539"/>
+      <Q id="6428703815" qualifier_id="56" value="Center"/>
+      <Q id="6428703817" qualifier_id="140" value="84.2"/>
+      <Q id="6428703819" qualifier_id="141" value="60.5"/>
+    </Event>
+    <Event id="2939847637" event_id="789" type_id="55" period_id="2" min="82" sec="50" player_id="575855" team_id="244" outcome="1" x="18.2" y="40.1" timestamp="2026-05-19T15:00:50.763" timestamp_utc="2026-05-19T14:00:50.763" last_modified="2026-05-19T15:45:09" version="1779201908933"/>
+    <Event id="2939847611" event_id="688" type_id="43" period_id="2" min="82" sec="51" player_id="445539" team_id="417" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T15:00:52.187" timestamp_utc="2026-05-19T14:00:52.187" last_modified="2026-05-19T15:00:55" version="1779199252475">
+      <Q id="6428703831" qualifier_id="56" value="Center"/>
+      <Q id="6428703833" qualifier_id="140" value="79.4"/>
+      <Q id="6428703835" qualifier_id="141" value="56.9"/>
+      <Q id="6428703875" qualifier_id="144" value="1"/>
+      <Q id="6428703837" qualifier_id="212" value="1.4"/>
+      <Q id="6428703839" qualifier_id="213" value="4.64"/>
+    </Event>
+    <Event id="2939850615" event_id="891" type_id="27" period_id="2" min="84" sec="14" team_id="244" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T15:02:15.435" timestamp_utc="2026-05-19T14:02:15.435" last_modified="2026-05-19T15:27:42" version="1779200860246">
+      <Q id="6428722331" qualifier_id="41" value="Injury"/>
+      <Q id="6428722333" qualifier_id="53" value="246081"/>
+      <Q id="6428731893" qualifier_id="233" value="797"/>
+    </Event>
+    <Event id="2939852157" event_id="797" type_id="27" period_id="2" min="84" sec="14" team_id="417" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T15:02:15.435" timestamp_utc="2026-05-19T14:02:15.435" last_modified="2026-05-19T15:27:42" version="1779200860233">
+      <Q id="6428732089" qualifier_id="233" value="891"/>
+    </Event>
+    <Event id="2939850617" event_id="892" type_id="28" period_id="2" min="84" sec="16" team_id="244" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T15:02:16.866" timestamp_utc="2026-05-19T14:02:16.866" last_modified="2026-05-19T15:27:43" version="1779200860259">
+      <Q id="6428722259" qualifier_id="55" value="891"/>
+      <Q id="6428731901" qualifier_id="233" value="798"/>
+    </Event>
+    <Event id="2939852159" event_id="798" type_id="28" period_id="2" min="84" sec="16" team_id="417" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T15:02:16.866" timestamp_utc="2026-05-19T14:02:16.866" last_modified="2026-05-19T15:27:42" version="1779200860248">
+      <Q id="6428731857" qualifier_id="55" value="797"/>
+      <Q id="6428732093" qualifier_id="233" value="892"/>
+    </Event>
+    <Event id="2939848051" event_id="792" type_id="1" period_id="2" min="84" sec="55" player_id="578592" team_id="244" outcome="1" x="20.8" y="40.4" timestamp="2026-05-19T15:02:56.199" timestamp_utc="2026-05-19T14:02:56.199" last_modified="2026-05-19T15:02:58" version="1779199377569">
+      <Q id="6428706433" qualifier_id="1"/>
+      <Q id="6428706417" qualifier_id="5"/>
+      <Q id="6428706423" qualifier_id="56" value="Center"/>
+      <Q id="6428706425" qualifier_id="140" value="63.0"/>
+      <Q id="6428706427" qualifier_id="141" value="32.4"/>
+      <Q id="6428706419" qualifier_id="157"/>
+      <Q id="6428706429" qualifier_id="212" value="44.6"/>
+      <Q id="6428706431" qualifier_id="213" value="6.16"/>
+      <Q id="6428706421" qualifier_id="241"/>
+    </Event>
+    <Event id="2939848053" event_id="793" type_id="44" period_id="2" min="84" sec="57" player_id="508143" team_id="244" outcome="1" x="63.0" y="32.4" timestamp="2026-05-19T15:02:58.416" timestamp_utc="2026-05-19T14:02:58.416" last_modified="2026-05-19T15:45:49" version="1779201949347">
+      <Q id="6428706437" qualifier_id="56" value="Center"/>
+      <Q id="6428707361" qualifier_id="233" value="691"/>
+      <Q id="6428706439" qualifier_id="286"/>
+    </Event>
+    <Event id="2939848065" event_id="691" type_id="44" period_id="2" min="84" sec="57" player_id="683488" team_id="417" outcome="0" x="37.0" y="67.6" timestamp="2026-05-19T15:02:58.417" timestamp_utc="2026-05-19T14:02:58.417" last_modified="2026-05-19T15:45:49" version="1779201949626">
+      <Q id="6428706537" qualifier_id="56" value="Back"/>
+      <Q id="6428707369" qualifier_id="233" value="793"/>
+      <Q id="6428706539" qualifier_id="285"/>
+    </Event>
+    <Event id="2939848057" event_id="794" type_id="1" period_id="2" min="84" sec="57" player_id="508143" team_id="244" outcome="0" x="63.0" y="32.4" timestamp="2026-05-19T15:02:58.549" timestamp_utc="2026-05-19T14:02:58.549" last_modified="2026-05-19T15:45:50" version="1779201949908">
+      <Q id="6428706475" qualifier_id="3"/>
+      <Q id="6428706479" qualifier_id="56" value="Center"/>
+      <Q id="6428706481" qualifier_id="140" value="72.3"/>
+      <Q id="6428706483" qualifier_id="141" value="30.0"/>
+      <Q id="6428706477" qualifier_id="168"/>
+      <Q id="6428706485" qualifier_id="212" value="9.9"/>
+      <Q id="6428706487" qualifier_id="213" value="6.12"/>
+    </Event>
+    <Event id="2939848075" event_id="692" type_id="1" period_id="2" min="85" sec="1" player_id="624620" team_id="417" outcome="1" x="24.7" y="67.9" timestamp="2026-05-19T15:03:01.577" timestamp_utc="2026-05-19T14:03:01.577" last_modified="2026-05-19T15:21:37" version="1779200497405">
+      <Q id="6428706565" qualifier_id="56" value="Back"/>
+      <Q id="6428706567" qualifier_id="140" value="37.6"/>
+      <Q id="6428706569" qualifier_id="141" value="73.6"/>
+      <Q id="6428728553" qualifier_id="155"/>
+      <Q id="6428706571" qualifier_id="212" value="14.1"/>
+      <Q id="6428706573" qualifier_id="213" value="0.28"/>
+    </Event>
+    <Event id="2939848071" event_id="795" type_id="43" period_id="2" min="85" sec="1" player_id="515742" team_id="244" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T15:03:02.438" timestamp_utc="2026-05-19T14:03:02.438" last_modified="2026-05-19T15:04:31" version="1779199383103">
+      <Q id="6428706559" qualifier_id="56" value="Center"/>
+      <Q id="6428708975" qualifier_id="144" value="61"/>
+    </Event>
+    <Event id="2939848077" event_id="693" type_id="49" period_id="2" min="85" sec="3" player_id="731191" team_id="417" outcome="1" x="54.4" y="80.9" timestamp="2026-05-19T15:03:04.041" timestamp_utc="2026-05-19T14:03:04.041" last_modified="2026-05-19T15:03:04" version="1779199384042"/>
+    <Event id="2939848079" event_id="796" type_id="83" period_id="2" min="85" sec="3" player_id="515742" team_id="244" outcome="0" x="40.6" y="18.9" timestamp="2026-05-19T15:03:04.341" timestamp_utc="2026-05-19T14:03:04.341" last_modified="2026-05-19T15:03:09" version="1779199386847">
+      <Q id="6428706671" qualifier_id="399" value="731191"/>
+    </Event>
+    <Event id="2939848085" event_id="694" type_id="3" period_id="2" min="85" sec="4" player_id="731191" team_id="417" outcome="0" x="61.0" y="84.0" timestamp="2026-05-19T15:03:05.313" timestamp_utc="2026-05-19T14:03:05.313" last_modified="2026-05-19T15:03:08" version="1779199386733">
+      <Q id="6428706599" qualifier_id="56" value="Left"/>
+      <Q id="6428706651" qualifier_id="233" value="797"/>
+      <Q id="6428706601" qualifier_id="286"/>
+    </Event>
+    <Event id="2939848089" event_id="797" type_id="7" period_id="2" min="85" sec="4" player_id="240166" team_id="244" outcome="0" x="39.0" y="16.0" timestamp="2026-05-19T15:03:05.314" timestamp_utc="2026-05-19T14:03:05.314" last_modified="2026-05-19T15:03:09" version="1779199386747">
+      <Q id="6428706623" qualifier_id="56" value="Back"/>
+      <Q id="6428706627" qualifier_id="178"/>
+      <Q id="6428706629" qualifier_id="233" value="694"/>
+      <Q id="6428706625" qualifier_id="285"/>
+    </Event>
+    <Event id="2939848099" event_id="798" type_id="83" period_id="2" min="85" sec="7" player_id="246081" team_id="244" outcome="0" x="45.3" y="11.3" timestamp="2026-05-19T15:03:07.990" timestamp_utc="2026-05-19T14:03:07.990" last_modified="2026-05-19T15:03:16" version="1779199394860">
+      <Q id="6428706915" qualifier_id="399" value="61778"/>
+    </Event>
+    <Event id="2939848105" event_id="799" type_id="83" period_id="2" min="85" sec="9" player_id="246081" team_id="244" outcome="0" x="57.1" y="14.1" timestamp="2026-05-19T15:03:09.734" timestamp_utc="2026-05-19T14:03:09.734" last_modified="2026-05-19T15:03:16" version="1779199394849">
+      <Q id="6428706899" qualifier_id="399" value="61778"/>
+    </Event>
+    <Event id="2939848113" event_id="695" type_id="4" period_id="2" min="85" sec="10" player_id="61778" team_id="417" outcome="1" x="41.2" y="83.8" timestamp="2026-05-19T15:03:10.884" timestamp_utc="2026-05-19T14:03:10.884" last_modified="2026-05-19T15:03:15" version="1779199393698">
+      <Q id="6428706803" qualifier_id="13"/>
+      <Q id="6428706807" qualifier_id="56" value="Back"/>
+      <Q id="6428706809" qualifier_id="152"/>
+      <Q id="6428706857" qualifier_id="233" value="800"/>
+      <Q id="6428706811" qualifier_id="286"/>
+      <Q id="6428706805" qualifier_id="295"/>
+    </Event>
+    <Event id="2939848111" event_id="800" type_id="4" period_id="2" min="85" sec="10" player_id="246081" team_id="244" outcome="0" x="58.8" y="16.2" timestamp="2026-05-19T15:03:10.885" timestamp_utc="2026-05-19T14:03:10.885" last_modified="2026-05-19T15:03:15" version="1779199393708">
+      <Q id="6428706845" qualifier_id="13"/>
+      <Q id="6428706849" qualifier_id="56" value="Right"/>
+      <Q id="6428706851" qualifier_id="152"/>
+      <Q id="6428706871" qualifier_id="233" value="695"/>
+      <Q id="6428706853" qualifier_id="285"/>
+      <Q id="6428706847" qualifier_id="295"/>
+    </Event>
+    <Event id="2939848143" event_id="696" type_id="1" period_id="2" min="85" sec="18" player_id="624620" team_id="417" outcome="1" x="41.0" y="80.8" timestamp="2026-05-19T15:03:19.209" timestamp_utc="2026-05-19T14:03:19.209" last_modified="2026-05-19T15:21:17" version="1779200477593">
+      <Q id="6428706973" qualifier_id="5"/>
+      <Q id="6428706977" qualifier_id="56" value="Back"/>
+      <Q id="6428706979" qualifier_id="140" value="41.3"/>
+      <Q id="6428706981" qualifier_id="141" value="69.3"/>
+      <Q id="6428706975" qualifier_id="152"/>
+      <Q id="6428707013" qualifier_id="189"/>
+      <Q id="6428706983" qualifier_id="212" value="7.8"/>
+      <Q id="6428706985" qualifier_id="213" value="4.75"/>
+    </Event>
+    <Event id="2939851153" event_id="793" type_id="1" period_id="2" min="85" sec="20" player_id="683488" team_id="417" outcome="1" x="40.6" y="63.4" timestamp="2026-05-19T15:03:21.209" timestamp_utc="2026-05-19T14:03:21.209" last_modified="2026-05-19T15:18:07" version="1779200287467">
+      <Q id="6428725435" qualifier_id="56" value="Center"/>
+      <Q id="6428725437" qualifier_id="140" value="37.6"/>
+      <Q id="6428725439" qualifier_id="141" value="31.1"/>
+      <Q id="6428725441" qualifier_id="212" value="22.2"/>
+      <Q id="6428725443" qualifier_id="213" value="1.43"/>
+    </Event>
+    <Event id="2939848189" event_id="697" type_id="1" period_id="2" min="85" sec="25" player_id="531784" team_id="417" outcome="1" x="56.6" y="22.5" timestamp="2026-05-19T15:03:25.696" timestamp_utc="2026-05-19T14:03:25.696" last_modified="2026-05-19T15:03:28" version="1779199405818">
+      <Q id="6428707209" qualifier_id="56" value="Right"/>
+      <Q id="6428707211" qualifier_id="140" value="59.3"/>
+      <Q id="6428707213" qualifier_id="141" value="15.5"/>
+      <Q id="6428707215" qualifier_id="212" value="5.5"/>
+      <Q id="6428707217" qualifier_id="213" value="5.25"/>
+    </Event>
+    <Event id="2939848195" event_id="698" type_id="1" period_id="2" min="85" sec="27" player_id="157851" team_id="417" outcome="0" x="59.2" y="15.5" timestamp="2026-05-19T15:03:27.873" timestamp_utc="2026-05-19T14:03:27.873" last_modified="2026-05-19T15:03:28" version="1779199408361">
+      <Q id="6428707245" qualifier_id="56" value="Center"/>
+      <Q id="6428707247" qualifier_id="140" value="63.3"/>
+      <Q id="6428707249" qualifier_id="141" value="21.2"/>
+      <Q id="6428707251" qualifier_id="212" value="5.8"/>
+      <Q id="6428707253" qualifier_id="213" value="0.73"/>
+    </Event>
+    <Event id="2939848197" event_id="801" type_id="49" period_id="2" min="85" sec="28" player_id="575855" team_id="244" outcome="1" x="24.5" y="86.9" timestamp="2026-05-19T15:03:28.911" timestamp_utc="2026-05-19T14:03:28.911" last_modified="2026-05-19T15:03:29" version="1779199408912"/>
+    <Event id="2939848205" event_id="802" type_id="1" period_id="2" min="85" sec="29" player_id="575855" team_id="244" outcome="1" x="24.6" y="86.9" timestamp="2026-05-19T15:03:29.605" timestamp_utc="2026-05-19T14:03:29.605" last_modified="2026-05-19T15:03:31" version="1779199409943">
+      <Q id="6428707303" qualifier_id="56" value="Back"/>
+      <Q id="6428707305" qualifier_id="140" value="29.9"/>
+      <Q id="6428707307" qualifier_id="141" value="88.9"/>
+      <Q id="6428707309" qualifier_id="212" value="5.7"/>
+      <Q id="6428707311" qualifier_id="213" value="0.24"/>
+    </Event>
+    <Event id="2939848247" event_id="803" type_id="1" period_id="2" min="85" sec="30" player_id="207884" team_id="244" outcome="1" x="32.3" y="89.9" timestamp="2026-05-19T15:03:31.213" timestamp_utc="2026-05-19T14:03:31.213" last_modified="2026-05-19T15:03:39" version="1779199411441">
+      <Q id="6428707585" qualifier_id="56" value="Back"/>
+      <Q id="6428707587" qualifier_id="140" value="37.4"/>
+      <Q id="6428707589" qualifier_id="141" value="73.3"/>
+      <Q id="6428707591" qualifier_id="212" value="12.5"/>
+      <Q id="6428707593" qualifier_id="213" value="5.16"/>
+    </Event>
+    <Event id="2939848249" event_id="804" type_id="61" period_id="2" min="85" sec="38" player_id="246081" team_id="244" outcome="0" x="55.3" y="48.4" timestamp="2026-05-19T15:03:38.902" timestamp_utc="2026-05-19T14:03:38.902" last_modified="2026-05-19T15:03:39" version="1779199418903">
+      <Q id="6428707597" qualifier_id="56" value="Center"/>
+    </Event>
+    <Event id="2939848263" event_id="699" type_id="49" period_id="2" min="85" sec="41" player_id="531784" team_id="417" outcome="1" x="39.7" y="64.9" timestamp="2026-05-19T15:03:42.336" timestamp_utc="2026-05-19T14:03:42.336" last_modified="2026-05-19T15:03:42" version="1779199422337"/>
+    <Event id="2939848293" event_id="700" type_id="1" period_id="2" min="85" sec="41" player_id="531784" team_id="417" outcome="1" x="39.7" y="64.9" timestamp="2026-05-19T15:03:42.491" timestamp_utc="2026-05-19T14:03:42.491" last_modified="2026-05-19T15:03:48" version="1779199422755">
+      <Q id="6428707805" qualifier_id="56" value="Center"/>
+      <Q id="6428707807" qualifier_id="140" value="51.5"/>
+      <Q id="6428707809" qualifier_id="141" value="75.1"/>
+      <Q id="6428707811" qualifier_id="212" value="14.2"/>
+      <Q id="6428707813" qualifier_id="213" value="0.51"/>
+    </Event>
+    <Event id="2939848305" event_id="701" type_id="1" period_id="2" min="85" sec="48" player_id="61778" team_id="417" outcome="1" x="68.8" y="86.9" timestamp="2026-05-19T15:03:48.858" timestamp_utc="2026-05-19T14:03:48.858" last_modified="2026-05-19T15:03:51" version="1779199429041">
+      <Q id="6428707883" qualifier_id="56" value="Center"/>
+      <Q id="6428707885" qualifier_id="140" value="72.8"/>
+      <Q id="6428707887" qualifier_id="141" value="67.6"/>
+      <Q id="6428707889" qualifier_id="212" value="13.8"/>
+      <Q id="6428707891" qualifier_id="213" value="5.02"/>
+    </Event>
+    <Event id="2939848325" event_id="702" type_id="1" period_id="2" min="85" sec="51" player_id="731191" team_id="417" outcome="1" x="73.1" y="68.1" timestamp="2026-05-19T15:03:51.692" timestamp_utc="2026-05-19T14:03:51.692" last_modified="2026-05-19T15:03:54" version="1779199431843">
+      <Q id="6428707963" qualifier_id="56" value="Center"/>
+      <Q id="6428707965" qualifier_id="140" value="66.6"/>
+      <Q id="6428707967" qualifier_id="141" value="46.1"/>
+      <Q id="6428707969" qualifier_id="212" value="16.4"/>
+      <Q id="6428707971" qualifier_id="213" value="4.28"/>
+    </Event>
+    <Event id="2939848309" event_id="805" type_id="83" period_id="2" min="85" sec="51" player_id="515742" team_id="244" outcome="0" x="22.7" y="30.4" timestamp="2026-05-19T15:03:52.085" timestamp_utc="2026-05-19T14:03:52.085" last_modified="2026-05-19T15:03:55" version="1779199435445">
+      <Q id="6428708089" qualifier_id="399" value="720789"/>
+    </Event>
+    <Event id="2939848343" event_id="703" type_id="1" period_id="2" min="85" sec="53" player_id="720789" team_id="417" outcome="1" x="67.5" y="49.7" timestamp="2026-05-19T15:03:54.273" timestamp_utc="2026-05-19T14:03:54.273" last_modified="2026-05-19T15:03:55" version="1779199434442">
+      <Q id="6428708061" qualifier_id="56" value="Center"/>
+      <Q id="6428708063" qualifier_id="140" value="63.4"/>
+      <Q id="6428708065" qualifier_id="141" value="23.6"/>
+      <Q id="6428708067" qualifier_id="212" value="18.3"/>
+      <Q id="6428708069" qualifier_id="213" value="4.47"/>
+    </Event>
+    <Event id="2939848353" event_id="704" type_id="1" period_id="2" min="85" sec="55" player_id="157851" team_id="417" outcome="1" x="63.4" y="23.6" timestamp="2026-05-19T15:03:55.617" timestamp_utc="2026-05-19T14:03:55.617" last_modified="2026-05-19T15:03:57" version="1779199435749">
+      <Q id="6428708137" qualifier_id="56" value="Center"/>
+      <Q id="6428708139" qualifier_id="140" value="63.4"/>
+      <Q id="6428708141" qualifier_id="141" value="37.7"/>
+      <Q id="6428708143" qualifier_id="212" value="9.6"/>
+      <Q id="6428708145" qualifier_id="213" value="1.57"/>
+    </Event>
+    <Event id="2939848383" event_id="705" type_id="1" period_id="2" min="85" sec="56" player_id="683488" team_id="417" outcome="1" x="65.8" y="50.9" timestamp="2026-05-19T15:03:57.208" timestamp_utc="2026-05-19T14:03:57.208" last_modified="2026-05-19T15:04:04" version="1779199437550">
+      <Q id="6428708315" qualifier_id="56" value="Center"/>
+      <Q id="6428708317" qualifier_id="140" value="65.1"/>
+      <Q id="6428708319" qualifier_id="141" value="71.8"/>
+      <Q id="6428708321" qualifier_id="212" value="14.2"/>
+      <Q id="6428708323" qualifier_id="213" value="1.62"/>
+    </Event>
+    <Event id="2939848415" event_id="706" type_id="1" period_id="2" min="86" sec="3" player_id="624620" team_id="417" outcome="1" x="74.8" y="85.9" timestamp="2026-05-19T15:04:04.376" timestamp_utc="2026-05-19T14:04:04.376" last_modified="2026-05-19T15:04:11" version="1779199444559">
+      <Q id="6428708501" qualifier_id="56" value="Left"/>
+      <Q id="6428708503" qualifier_id="140" value="77.4"/>
+      <Q id="6428708505" qualifier_id="141" value="90.6"/>
+      <Q id="6428708507" qualifier_id="212" value="4.2"/>
+      <Q id="6428708509" qualifier_id="213" value="0.86"/>
+    </Event>
+    <Event id="2939848645" event_id="707" type_id="1" period_id="2" min="86" sec="10" player_id="61778" team_id="417" outcome="1" x="81.6" y="85.1" assist="1" timestamp="2026-05-19T15:04:11.336" timestamp_utc="2026-05-19T14:04:11.336" last_modified="2026-05-19T16:31:40" version="1779204700554">
+      <Q id="6428709897" qualifier_id="1"/>
+      <Q id="6428709883" qualifier_id="2"/>
+      <Q id="6428710443" qualifier_id="22"/>
+      <Q id="6428709887" qualifier_id="56" value="Center"/>
+      <Q id="6428709889" qualifier_id="140" value="95.2"/>
+      <Q id="6428709891" qualifier_id="141" value="34.0"/>
+      <Q id="6428710441" qualifier_id="154"/>
+      <Q id="6428709885" qualifier_id="155"/>
+      <Q id="6428710439" qualifier_id="210" value="16"/>
+      <Q id="6428709893" qualifier_id="212" value="37.6"/>
+      <Q id="6428709895" qualifier_id="213" value="5.10"/>
+    </Event>
+    <Event id="2939848649" event_id="708" type_id="16" period_id="2" min="86" sec="14" player_id="157851" team_id="417" outcome="1" x="95.2" y="34.0" timestamp="2026-05-19T15:04:14.657" timestamp_utc="2026-05-19T14:04:14.657" last_modified="2026-05-19T15:54:30" version="1779202469784">
+      <Q id="6428710445" qualifier_id="15"/>
+      <Q id="6428709907" qualifier_id="22"/>
+      <Q id="6428710449" qualifier_id="29"/>
+      <Q id="6428710453" qualifier_id="55" value="707"/>
+      <Q id="6428709911" qualifier_id="56" value="Center"/>
+      <Q id="6428709909" qualifier_id="62"/>
+      <Q id="6428710447" qualifier_id="79"/>
+      <Q id="6428710457" qualifier_id="102" value="50.2"/>
+      <Q id="6428710459" qualifier_id="103" value="27.2"/>
+      <Q id="6428710451" qualifier_id="154"/>
+      <Q id="6428710465" qualifier_id="230" value="99.0"/>
+      <Q id="6428710467" qualifier_id="231" value="47.3"/>
+      <Q id="6428710463" qualifier_id="328"/>
+      <Q id="6428710471" qualifier_id="374" value="2026-05-19 15:04:13.937"/>
+      <Q id="6428710475" qualifier_id="375" value="86:13.380"/>
+    </Event>
+    <Event id="2939848675" event_id="806" type_id="1" period_id="2" min="87" sec="17" player_id="508143" team_id="244" outcome="1" x="49.8" y="50.1" timestamp="2026-05-19T15:05:18.302" timestamp_utc="2026-05-19T14:05:18.302" last_modified="2026-05-19T15:18:13" version="1779200293373">
+      <Q id="6428710041" qualifier_id="56" value="Back"/>
+      <Q id="6428710043" qualifier_id="140" value="40.8"/>
+      <Q id="6428710045" qualifier_id="141" value="49.7"/>
+      <Q id="6428710047" qualifier_id="212" value="9.5"/>
+      <Q id="6428710049" qualifier_id="213" value="3.17"/>
+      <Q id="6428725571" qualifier_id="279" value="G"/>
+    </Event>
+    <Event id="2939848693" event_id="807" type_id="1" period_id="2" min="87" sec="20" player_id="515742" team_id="244" outcome="1" x="40.8" y="49.7" timestamp="2026-05-19T15:05:21.293" timestamp_utc="2026-05-19T14:05:21.293" last_modified="2026-05-19T15:05:25" version="1779199522410">
+      <Q id="6428710169" qualifier_id="56" value="Back"/>
+      <Q id="6428710171" qualifier_id="140" value="36.1"/>
+      <Q id="6428710173" qualifier_id="141" value="26.7"/>
+      <Q id="6428710175" qualifier_id="212" value="16.4"/>
+      <Q id="6428710177" qualifier_id="213" value="4.41"/>
+    </Event>
+    <Event id="2939848721" event_id="808" type_id="1" period_id="2" min="87" sec="25" player_id="240166" team_id="244" outcome="1" x="37.1" y="23.6" timestamp="2026-05-19T15:05:25.557" timestamp_utc="2026-05-19T14:05:25.557" last_modified="2026-05-19T15:05:29" version="1779199527352">
+      <Q id="6428710339" qualifier_id="56" value="Back"/>
+      <Q id="6428710341" qualifier_id="140" value="31.0"/>
+      <Q id="6428710343" qualifier_id="141" value="41.3"/>
+      <Q id="6428710345" qualifier_id="212" value="13.6"/>
+      <Q id="6428710347" qualifier_id="213" value="2.06"/>
+    </Event>
+    <Event id="2939848725" event_id="809" type_id="1" period_id="2" min="87" sec="28" player_id="627127" team_id="244" outcome="1" x="32.0" y="40.7" timestamp="2026-05-19T15:05:28.877" timestamp_utc="2026-05-19T14:05:28.877" last_modified="2026-05-19T15:05:30" version="1779199529496">
+      <Q id="6428710367" qualifier_id="56" value="Back"/>
+      <Q id="6428710369" qualifier_id="140" value="44.1"/>
+      <Q id="6428710371" qualifier_id="141" value="32.4"/>
+      <Q id="6428710373" qualifier_id="212" value="13.9"/>
+      <Q id="6428710375" qualifier_id="213" value="5.87"/>
+    </Event>
+    <Event id="2939848743" event_id="810" type_id="1" period_id="2" min="87" sec="29" player_id="515742" team_id="244" outcome="1" x="44.1" y="32.4" timestamp="2026-05-19T15:05:30.062" timestamp_utc="2026-05-19T14:05:30.062" last_modified="2026-05-19T15:05:33" version="1779199530673">
+      <Q id="6428710505" qualifier_id="56" value="Back"/>
+      <Q id="6428710507" qualifier_id="140" value="44.6"/>
+      <Q id="6428710509" qualifier_id="141" value="14.1"/>
+      <Q id="6428710511" qualifier_id="212" value="12.5"/>
+      <Q id="6428710513" qualifier_id="213" value="4.75"/>
+    </Event>
+    <Event id="2939848755" event_id="811" type_id="1" period_id="2" min="87" sec="32" player_id="240166" team_id="244" outcome="1" x="50.9" y="13.8" timestamp="2026-05-19T15:05:32.917" timestamp_utc="2026-05-19T14:05:32.917" last_modified="2026-05-19T15:05:37" version="1779199533521">
+      <Q id="6428710567" qualifier_id="56" value="Right"/>
+      <Q id="6428710569" qualifier_id="140" value="62.5"/>
+      <Q id="6428710571" qualifier_id="141" value="19.7"/>
+      <Q id="6428710573" qualifier_id="212" value="12.8"/>
+      <Q id="6428710575" qualifier_id="213" value="0.32"/>
+    </Event>
+    <Event id="2939848777" event_id="812" type_id="1" period_id="2" min="87" sec="36" player_id="515742" team_id="244" outcome="1" x="69.1" y="18.8" timestamp="2026-05-19T15:05:37.318" timestamp_utc="2026-05-19T14:05:37.318" last_modified="2026-05-19T15:05:41" version="1779199539503">
+      <Q id="6428710721" qualifier_id="1"/>
+      <Q id="6428710711" qualifier_id="56" value="Left"/>
+      <Q id="6428710713" qualifier_id="140" value="78.0"/>
+      <Q id="6428710715" qualifier_id="141" value="80.9"/>
+      <Q id="6428710707" qualifier_id="155"/>
+      <Q id="6428710709" qualifier_id="196"/>
+      <Q id="6428710717" qualifier_id="212" value="43.2"/>
+      <Q id="6428710719" qualifier_id="213" value="1.35"/>
+    </Event>
+    <Event id="2939848779" event_id="813" type_id="1" period_id="2" min="87" sec="41" player_id="207884" team_id="244" outcome="0" x="77.7" y="82.1" timestamp="2026-05-19T15:05:41.749" timestamp_utc="2026-05-19T14:05:41.749" last_modified="2026-05-19T15:06:24" version="1779199583975">
+      <Q id="6428710725" qualifier_id="56" value="Center"/>
+      <Q id="6428710727" qualifier_id="140" value="82.3"/>
+      <Q id="6428710729" qualifier_id="141" value="76.7"/>
+      <Q id="6428710731" qualifier_id="212" value="6.1"/>
+      <Q id="6428710733" qualifier_id="213" value="5.63"/>
+      <Q id="6428711693" qualifier_id="233" value="709"/>
+      <Q id="6428711691" qualifier_id="236"/>
+      <Q id="6428711697" qualifier_id="286"/>
+    </Event>
+    <Event id="2939848785" event_id="709" type_id="74" period_id="2" min="87" sec="41" player_id="157851" team_id="417" outcome="1" x="17.7" y="23.3" timestamp="2026-05-19T15:05:41.750" timestamp_utc="2026-05-19T14:05:41.750" last_modified="2026-05-19T15:46:48" version="1779202008560">
+      <Q id="6428710767" qualifier_id="56" value="Back"/>
+      <Q id="6428711713" qualifier_id="233" value="813"/>
+      <Q id="6428711681" qualifier_id="285"/>
+    </Event>
+    <Event id="2939848791" event_id="814" type_id="45" period_id="2" min="87" sec="43" player_id="246081" team_id="244" outcome="0" x="75.0" y="76.6" timestamp="2026-05-19T15:05:44.543" timestamp_utc="2026-05-19T14:05:44.543" last_modified="2026-05-19T15:26:48" version="1779200797362">
+      <Q id="6428710781" qualifier_id="56" value="Center"/>
+      <Q id="6428710825" qualifier_id="233" value="710"/>
+      <Q id="6428710783" qualifier_id="286"/>
+    </Event>
+    <Event id="2939848797" event_id="710" type_id="3" period_id="2" min="87" sec="43" player_id="720789" team_id="417" outcome="1" x="25.0" y="23.4" timestamp="2026-05-19T15:05:44.543" timestamp_utc="2026-05-19T14:05:44.543" last_modified="2026-05-19T15:26:47" version="1779200797355">
+      <Q id="6428710807" qualifier_id="56" value="Back"/>
+      <Q id="6428710821" qualifier_id="233" value="814"/>
+      <Q id="6428710809" qualifier_id="285"/>
+    </Event>
+    <Event id="2939848799" event_id="711" type_id="49" period_id="2" min="87" sec="44" player_id="720789" team_id="417" outcome="1" x="26.8" y="21.5" timestamp="2026-05-19T15:05:45.224" timestamp_utc="2026-05-19T14:05:45.224" last_modified="2026-05-19T15:05:45" version="1779199545225"/>
+    <Event id="2939848813" event_id="712" type_id="1" period_id="2" min="87" sec="47" player_id="720789" team_id="417" outcome="1" x="20.2" y="29.5" timestamp="2026-05-19T15:05:48.007" timestamp_utc="2026-05-19T14:05:48.007" last_modified="2026-05-19T15:05:50" version="1779199548089">
+      <Q id="6428710935" qualifier_id="56" value="Back"/>
+      <Q id="6428710937" qualifier_id="140" value="17.8"/>
+      <Q id="6428710939" qualifier_id="141" value="18.5"/>
+      <Q id="6428710941" qualifier_id="212" value="7.9"/>
+      <Q id="6428710943" qualifier_id="213" value="4.39"/>
+    </Event>
+    <Event id="2939848817" event_id="713" type_id="1" period_id="2" min="87" sec="50" player_id="531784" team_id="417" outcome="0" x="17.5" y="20.6" timestamp="2026-05-19T15:05:50.690" timestamp_utc="2026-05-19T14:05:50.690" last_modified="2026-05-19T15:05:51" version="1779199551278">
+      <Q id="6428710963" qualifier_id="1"/>
+      <Q id="6428710953" qualifier_id="56" value="Back"/>
+      <Q id="6428710955" qualifier_id="140" value="19.5"/>
+      <Q id="6428710957" qualifier_id="141" value="20.1"/>
+      <Q id="6428710951" qualifier_id="157"/>
+      <Q id="6428710959" qualifier_id="212" value="2.1"/>
+      <Q id="6428710961" qualifier_id="213" value="6.12"/>
+      <Q id="6428710971" qualifier_id="233" value="815"/>
+      <Q id="6428710965" qualifier_id="236"/>
+      <Q id="6428710969" qualifier_id="286"/>
+    </Event>
+    <Event id="2939848815" event_id="815" type_id="74" period_id="2" min="87" sec="50" player_id="508143" team_id="244" outcome="1" x="80.5" y="79.9" timestamp="2026-05-19T15:05:50.691" timestamp_utc="2026-05-19T14:05:50.691" last_modified="2026-05-19T15:45:53" version="1779201953782">
+      <Q id="6428710947" qualifier_id="56" value="Left"/>
+      <Q id="6428710987" qualifier_id="233" value="713"/>
+      <Q id="6428710949" qualifier_id="285"/>
+    </Event>
+    <Event id="2939848837" event_id="714" type_id="1" period_id="2" min="87" sec="53" player_id="531784" team_id="417" outcome="1" x="21.7" y="22.5" timestamp="2026-05-19T15:05:53.625" timestamp_utc="2026-05-19T14:05:53.625" last_modified="2026-05-19T15:05:57" version="1779199554386">
+      <Q id="6428711113" qualifier_id="1"/>
+      <Q id="6428711101" qualifier_id="56" value="Back"/>
+      <Q id="6428711103" qualifier_id="140" value="38.8"/>
+      <Q id="6428711105" qualifier_id="141" value="30.1"/>
+      <Q id="6428711099" qualifier_id="157"/>
+      <Q id="6428711109" qualifier_id="212" value="18.7"/>
+      <Q id="6428711111" qualifier_id="213" value="0.28"/>
+    </Event>
+    <Event id="2939848923" event_id="818" type_id="83" period_id="2" min="87" sec="55" player_id="180662" team_id="244" outcome="0" x="43.8" y="69.0" timestamp="2026-05-19T15:05:55.661" timestamp_utc="2026-05-19T14:05:55.661" last_modified="2026-05-19T15:24:20" version="1779200660822">
+      <Q id="6428711765" qualifier_id="399" value="731191"/>
+    </Event>
+    <Event id="2939848843" event_id="715" type_id="1" period_id="2" min="87" sec="56" player_id="731191" team_id="417" outcome="0" x="51.8" y="38.5" timestamp="2026-05-19T15:05:57.456" timestamp_utc="2026-05-19T14:05:57.456" last_modified="2026-05-19T15:05:58" version="1779199558648">
+      <Q id="6428711161" qualifier_id="56" value="Back"/>
+      <Q id="6428711163" qualifier_id="140" value="47.9"/>
+      <Q id="6428711165" qualifier_id="141" value="57.3"/>
+      <Q id="6428711167" qualifier_id="212" value="13.4"/>
+      <Q id="6428711169" qualifier_id="213" value="1.88"/>
+    </Event>
+    <Event id="2939848839" event_id="816" type_id="43" period_id="2" min="87" sec="57" player_id="180662" team_id="244" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T15:05:57.701" timestamp_utc="2026-05-19T14:05:57.701" last_modified="2026-05-19T15:06:05" version="1779199564745">
+      <Q id="6428711299" qualifier_id="144" value="83"/>
+      <Q id="6428711283" qualifier_id="399" value="61778"/>
+    </Event>
+    <Event id="2939848849" event_id="817" type_id="4" period_id="2" min="88" sec="0" player_id="240166" team_id="244" outcome="1" x="50.4" y="47.8" timestamp="2026-05-19T15:06:01.406" timestamp_utc="2026-05-19T14:06:01.406" last_modified="2026-05-19T15:06:06" version="1779199565212">
+      <Q id="6428711211" qualifier_id="13"/>
+      <Q id="6428711213" qualifier_id="56" value="Center"/>
+      <Q id="6428711215" qualifier_id="152"/>
+      <Q id="6428711245" qualifier_id="233" value="716"/>
+      <Q id="6428711217" qualifier_id="265"/>
+      <Q id="6428711219" qualifier_id="286"/>
+    </Event>
+    <Event id="2939848853" event_id="716" type_id="4" period_id="2" min="88" sec="0" player_id="61778" team_id="417" outcome="0" x="49.6" y="52.2" timestamp="2026-05-19T15:06:01.407" timestamp_utc="2026-05-19T14:06:01.407" last_modified="2026-05-19T15:06:05" version="1779199563168">
+      <Q id="6428711233" qualifier_id="13"/>
+      <Q id="6428711235" qualifier_id="56" value="Back"/>
+      <Q id="6428711237" qualifier_id="152"/>
+      <Q id="6428711257" qualifier_id="233" value="817"/>
+      <Q id="6428711239" qualifier_id="265"/>
+      <Q id="6428711241" qualifier_id="285"/>
+    </Event>
+    <Event id="2939848879" event_id="717" type_id="17" period_id="2" min="88" sec="5" player_id="61778" team_id="417" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T15:06:05.743" timestamp_utc="2026-05-19T14:06:05.743" last_modified="2026-05-19T15:18:23" version="1779200303149">
+      <Q id="6428711383" qualifier_id="31"/>
+      <Q id="6428711981" qualifier_id="184"/>
+    </Event>
+    <Event id="2939849101" event_id="719" type_id="17" period_id="2" min="88" sec="40" team_id="417" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T15:06:40.562" timestamp_utc="2026-05-19T14:06:40.562" last_modified="2026-05-19T15:07:12" version="1779199632545">
+      <Q id="6428712647" qualifier_id="31"/>
+      <Q id="6428712651" qualifier_id="172"/>
+      <Q id="6428712649" qualifier_id="184"/>
+      <Q id="6428712653" qualifier_id="283" value="54876"/>
+    </Event>
+    <Event id="2939849297" event_id="831" type_id="18" period_id="2" min="89" sec="20" player_id="479433" team_id="244" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T15:07:21.001" timestamp_utc="2026-05-19T14:07:21.001" last_modified="2026-05-19T15:08:08" version="1779199687991">
+      <Q id="6428713789" qualifier_id="42"/>
+      <Q id="6428713791" qualifier_id="44" value="Forward"/>
+      <Q id="6428713833" qualifier_id="55" value="832"/>
+      <Q id="6428713793" qualifier_id="59" value="29"/>
+    </Event>
+    <Event id="2939849301" event_id="832" type_id="19" period_id="2" min="89" sec="20" player_id="482450" team_id="244" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T15:07:21.002" timestamp_utc="2026-05-19T14:07:21.002" last_modified="2026-05-19T15:45:28" version="1779201927940">
+      <Q id="6428713809" qualifier_id="42"/>
+      <Q id="6428713817" qualifier_id="44" value="Forward"/>
+      <Q id="6428713819" qualifier_id="55" value="831"/>
+      <Q id="6428713815" qualifier_id="59" value="11"/>
+      <Q id="6428713813" qualifier_id="145" value="7"/>
+      <Q id="6428737477" qualifier_id="292" value="9"/>
+      <Q id="6428714057" qualifier_id="293" value="3"/>
+    </Event>
+    <Event id="2939849167" event_id="820" type_id="1" period_id="2" min="89" sec="22" player_id="515742" team_id="244" outcome="1" x="47.5" y="45.4" timestamp="2026-05-19T15:07:23.549" timestamp_utc="2026-05-19T14:07:23.549" last_modified="2026-05-19T15:07:24" version="1779199644337">
+      <Q id="6428713019" qualifier_id="5"/>
+      <Q id="6428713023" qualifier_id="56" value="Back"/>
+      <Q id="6428713025" qualifier_id="140" value="46.8"/>
+      <Q id="6428713027" qualifier_id="141" value="76.0"/>
+      <Q id="6428713021" qualifier_id="152"/>
+      <Q id="6428713029" qualifier_id="212" value="20.8"/>
+      <Q id="6428713031" qualifier_id="213" value="1.61"/>
+      <Q id="6428713033" qualifier_id="279" value="G"/>
+    </Event>
+    <Event id="2939849179" event_id="821" type_id="1" period_id="2" min="89" sec="24" player_id="180662" team_id="244" outcome="1" x="46.8" y="76.0" timestamp="2026-05-19T15:07:24.669" timestamp_utc="2026-05-19T14:07:24.669" last_modified="2026-05-19T15:07:28" version="1779199645519">
+      <Q id="6428713111" qualifier_id="56" value="Left"/>
+      <Q id="6428713113" qualifier_id="140" value="58.4"/>
+      <Q id="6428713115" qualifier_id="141" value="85.0"/>
+      <Q id="6428713117" qualifier_id="212" value="13.6"/>
+      <Q id="6428713119" qualifier_id="213" value="0.47"/>
+    </Event>
+    <Event id="2939849203" event_id="822" type_id="1" period_id="2" min="89" sec="27" player_id="575855" team_id="244" outcome="1" x="54.2" y="83.6" timestamp="2026-05-19T15:07:27.869" timestamp_utc="2026-05-19T14:07:27.869" last_modified="2026-05-19T15:07:33" version="1779199650678">
+      <Q id="6428713257" qualifier_id="56" value="Back"/>
+      <Q id="6428713259" qualifier_id="140" value="43.8"/>
+      <Q id="6428713261" qualifier_id="141" value="62.0"/>
+      <Q id="6428713263" qualifier_id="212" value="18.3"/>
+      <Q id="6428713265" qualifier_id="213" value="4.07"/>
+    </Event>
+    <Event id="2939849213" event_id="824" type_id="1" period_id="2" min="89" sec="32" player_id="515742" team_id="244" outcome="1" x="52.3" y="45.5" timestamp="2026-05-19T15:07:33.253" timestamp_utc="2026-05-19T14:07:33.253" last_modified="2026-05-19T15:07:36" version="1779199653582">
+      <Q id="6428713315" qualifier_id="56" value="Right"/>
+      <Q id="6428713317" qualifier_id="140" value="61.6"/>
+      <Q id="6428713319" qualifier_id="141" value="12.2"/>
+      <Q id="6428713321" qualifier_id="212" value="24.7"/>
+      <Q id="6428713323" qualifier_id="213" value="5.12"/>
+    </Event>
+    <Event id="2939849223" event_id="825" type_id="1" period_id="2" min="89" sec="35" player_id="240166" team_id="244" outcome="1" x="60.4" y="14.1" timestamp="2026-05-19T15:07:36.094" timestamp_utc="2026-05-19T14:07:36.094" last_modified="2026-05-19T15:07:39" version="1779199658187">
+      <Q id="6428713373" qualifier_id="1"/>
+      <Q id="6428713363" qualifier_id="56" value="Center"/>
+      <Q id="6428713365" qualifier_id="140" value="81.1"/>
+      <Q id="6428713367" qualifier_id="141" value="50.3"/>
+      <Q id="6428713361" qualifier_id="155"/>
+      <Q id="6428713369" qualifier_id="212" value="32.8"/>
+      <Q id="6428713371" qualifier_id="213" value="0.85"/>
+    </Event>
+    <Event id="2939849227" event_id="826" type_id="44" period_id="2" min="89" sec="38" player_id="232091" team_id="244" outcome="1" x="81.1" y="50.3" timestamp="2026-05-19T15:07:39.061" timestamp_utc="2026-05-19T14:07:39.061" last_modified="2026-05-19T15:45:50" version="1779201950189">
+      <Q id="6428713389" qualifier_id="56" value="Center"/>
+      <Q id="6428713415" qualifier_id="233" value="720"/>
+      <Q id="6428713391" qualifier_id="286"/>
+    </Event>
+    <Event id="2939849231" event_id="720" type_id="44" period_id="2" min="89" sec="38" player_id="531784" team_id="417" outcome="0" x="18.9" y="49.7" timestamp="2026-05-19T15:07:39.062" timestamp_utc="2026-05-19T14:07:39.062" last_modified="2026-05-19T15:45:50" version="1779201950472">
+      <Q id="6428713409" qualifier_id="56" value="Back"/>
+      <Q id="6428713419" qualifier_id="233" value="826"/>
+      <Q id="6428713411" qualifier_id="285"/>
+    </Event>
+    <Event id="2939849229" event_id="827" type_id="1" period_id="2" min="89" sec="38" player_id="232091" team_id="244" outcome="0" x="81.1" y="50.3" timestamp="2026-05-19T15:07:39.165" timestamp_utc="2026-05-19T14:07:39.165" last_modified="2026-05-19T15:45:50" version="1779201950759">
+      <Q id="6428713393" qualifier_id="3"/>
+      <Q id="6428713397" qualifier_id="56" value="Center"/>
+      <Q id="6428713399" qualifier_id="140" value="89.5"/>
+      <Q id="6428713401" qualifier_id="141" value="53.1"/>
+      <Q id="6428713395" qualifier_id="168"/>
+      <Q id="6428713403" qualifier_id="212" value="9.0"/>
+      <Q id="6428713405" qualifier_id="213" value="0.21"/>
+    </Event>
+    <Event id="2939849245" event_id="828" type_id="15" period_id="2" min="89" sec="41" player_id="515742" team_id="244" outcome="1" x="82.2" y="37.0" timestamp="2026-05-19T15:07:41.925" timestamp_utc="2026-05-19T14:07:41.925" last_modified="2026-05-19T15:59:57" version="1779202797757">
+      <Q id="6428713475" qualifier_id="18"/>
+      <Q id="6428714407" qualifier_id="20"/>
+      <Q id="6428713473" qualifier_id="22"/>
+      <Q id="6428713477" qualifier_id="56" value="Center"/>
+      <Q id="6428714663" qualifier_id="80"/>
+      <Q id="6428714411" qualifier_id="82"/>
+      <Q id="6428714665" qualifier_id="102" value="47.0"/>
+      <Q id="6428714667" qualifier_id="103" value="19.0"/>
+      <Q id="6428743179" qualifier_id="108"/>
+      <Q id="6428714673" qualifier_id="146" value="86.7"/>
+      <Q id="6428714675" qualifier_id="147" value="39.5"/>
+      <Q id="6428714677" qualifier_id="230" value="97.2"/>
+      <Q id="6428714679" qualifier_id="231" value="45.1"/>
+      <Q id="6428714681" qualifier_id="233" value="722"/>
+      <Q id="6428714669" qualifier_id="328"/>
+      <Q id="6428743181" qualifier_id="391"/>
+      <Q id="6428714671" qualifier_id="458"/>
+    </Event>
+    <Event id="2939849249" event_id="722" type_id="10" period_id="2" min="89" sec="41" player_id="624620" team_id="417" outcome="1" x="11.8" y="60.8" timestamp="2026-05-19T15:07:42.025" timestamp_utc="2026-05-19T14:07:42.025" last_modified="2026-05-19T15:08:33" version="1779199713105">
+      <Q id="6428713509" qualifier_id="56" value="Back"/>
+      <Q id="6428713507" qualifier_id="94"/>
+      <Q id="6428714707" qualifier_id="233" value="828"/>
+    </Event>
+    <Event id="2939849241" event_id="721" type_id="12" period_id="2" min="89" sec="41" player_id="157851" team_id="417" outcome="1" x="9.8" y="43.0" timestamp="2026-05-19T15:07:42.223" timestamp_utc="2026-05-19T14:07:42.223" last_modified="2026-05-19T15:07:42" version="1779199662542">
+      <Q id="6428713471" qualifier_id="15"/>
+      <Q id="6428713459" qualifier_id="56" value="Back"/>
+      <Q id="6428713461" qualifier_id="140" value="11.9"/>
+      <Q id="6428713463" qualifier_id="141" value="55.4"/>
+      <Q id="6428713465" qualifier_id="212" value="8.7"/>
+      <Q id="6428713467" qualifier_id="213" value="1.32"/>
+    </Event>
+    <Event id="2939849419" event_id="724" type_id="44" period_id="2" min="89" sec="43" player_id="531784" team_id="417" outcome="1" x="11.9" y="55.4" timestamp="2026-05-19T15:07:43.900" timestamp_utc="2026-05-19T14:07:43.900" last_modified="2026-05-19T15:45:51" version="1779201951025">
+      <Q id="6428714553" qualifier_id="56" value="Back"/>
+      <Q id="6428714559" qualifier_id="233" value="829"/>
+      <Q id="6428714555" qualifier_id="285"/>
+    </Event>
+    <Event id="2939849253" event_id="829" type_id="44" period_id="2" min="89" sec="43" player_id="508143" team_id="244" outcome="0" x="88.1" y="44.6" timestamp="2026-05-19T15:07:43.901" timestamp_utc="2026-05-19T14:07:43.901" last_modified="2026-05-19T15:45:51" version="1779201951290">
+      <Q id="6428713523" qualifier_id="56" value="Center"/>
+      <Q id="6428714587" qualifier_id="233" value="724"/>
+      <Q id="6428713525" qualifier_id="286"/>
+    </Event>
+    <Event id="2939849431" event_id="725" type_id="12" period_id="2" min="89" sec="44" player_id="531784" team_id="417" outcome="1" x="11.9" y="55.4" timestamp="2026-05-19T15:07:44.789" timestamp_utc="2026-05-19T14:07:44.789" last_modified="2026-05-19T15:45:51" version="1779201951560">
+      <Q id="6428714657" qualifier_id="15"/>
+      <Q id="6428714629" qualifier_id="56" value="Back"/>
+      <Q id="6428714631" qualifier_id="140" value="15.5"/>
+      <Q id="6428714633" qualifier_id="141" value="36.9"/>
+      <Q id="6428714635" qualifier_id="212" value="13.1"/>
+      <Q id="6428714637" qualifier_id="213" value="5.00"/>
+    </Event>
+    <Event id="2939849639" event_id="836" type_id="61" period_id="2" min="89" sec="44" player_id="508143" team_id="244" outcome="1" x="89.2" y="52.7" assist="1" timestamp="2026-05-19T15:07:44.976" timestamp_utc="2026-05-19T14:07:44.976" last_modified="2026-05-19T15:09:52" version="1779199791893">
+      <Q id="6428716011" qualifier_id="56" value="Center"/>
+    </Event>
+    <Event id="2939849265" event_id="830" type_id="16" period_id="2" min="89" sec="45" player_id="575855" team_id="244" outcome="1" x="86.1" y="55.6" timestamp="2026-05-19T15:07:46.517" timestamp_utc="2026-05-19T14:07:46.517" last_modified="2026-05-19T16:04:12" version="1779203052544">
+      <Q id="6428713583" qualifier_id="17"/>
+      <Q id="6428715165" qualifier_id="20"/>
+      <Q id="6428713581" qualifier_id="22"/>
+      <Q id="6428716123" qualifier_id="29"/>
+      <Q id="6428716125" qualifier_id="55" value="836"/>
+      <Q id="6428713585" qualifier_id="56" value="Center"/>
+      <Q id="6428715419" qualifier_id="80"/>
+      <Q id="6428715421" qualifier_id="102" value="47.8"/>
+      <Q id="6428715423" qualifier_id="103" value="1.9"/>
+      <Q id="6428715433" qualifier_id="230" value="98.9"/>
+      <Q id="6428715435" qualifier_id="231" value="53.2"/>
+      <Q id="6428715429" qualifier_id="328"/>
+      <Q id="6428715169" qualifier_id="374" value="2026-05-19 15:07:45.611"/>
+      <Q id="6428715173" qualifier_id="375" value="89:45.054"/>
+    </Event>
+    <Event id="2939849509" event_id="726" type_id="1" period_id="2" min="90" sec="53" player_id="731191" team_id="417" outcome="1" x="50.3" y="49.6" timestamp="2026-05-19T15:08:53.894" timestamp_utc="2026-05-19T14:08:53.894" last_modified="2026-05-19T15:09:07" version="1779199747540">
+      <Q id="6428715149" qualifier_id="56" value="Back"/>
+      <Q id="6428715151" qualifier_id="140" value="42.4"/>
+      <Q id="6428715153" qualifier_id="141" value="53.0"/>
+      <Q id="6428715155" qualifier_id="212" value="8.6"/>
+      <Q id="6428715157" qualifier_id="213" value="2.87"/>
+      <Q id="6428715511" qualifier_id="279" value="G"/>
+    </Event>
+    <Event id="2939849521" event_id="727" type_id="1" period_id="2" min="90" sec="54" player_id="683488" team_id="417" outcome="1" x="42.3" y="53.0" timestamp="2026-05-19T15:08:54.989" timestamp_utc="2026-05-19T14:08:54.989" last_modified="2026-05-19T15:09:37" version="1779199777306">
+      <Q id="6428715201" qualifier_id="56" value="Left"/>
+      <Q id="6428715203" qualifier_id="140" value="56.5"/>
+      <Q id="6428715205" qualifier_id="141" value="88.9"/>
+      <Q id="6428715207" qualifier_id="212" value="28.6"/>
+      <Q id="6428715209" qualifier_id="213" value="1.02"/>
+    </Event>
+    <Event id="2939849531" event_id="728" type_id="1" period_id="2" min="90" sec="55" player_id="624620" team_id="417" outcome="1" x="56.5" y="88.9" timestamp="2026-05-19T15:08:56.549" timestamp_utc="2026-05-19T14:08:56.549" last_modified="2026-05-19T15:08:58" version="1779199736639">
+      <Q id="6428715291" qualifier_id="56" value="Back"/>
+      <Q id="6428715293" qualifier_id="140" value="43.0"/>
+      <Q id="6428715295" qualifier_id="141" value="73.3"/>
+      <Q id="6428715297" qualifier_id="212" value="17.7"/>
+      <Q id="6428715299" qualifier_id="213" value="3.78"/>
+    </Event>
+    <Event id="2939849533" event_id="729" type_id="50" period_id="2" min="90" sec="58" player_id="61778" team_id="417" outcome="1" x="41.4" y="76.6" timestamp="2026-05-19T15:08:58.620" timestamp_utc="2026-05-19T14:08:58.620" last_modified="2026-05-19T15:20:43" version="1779200443571">
+      <Q id="6428715313" qualifier_id="56" value="Back"/>
+      <Q id="6428717633" qualifier_id="233" value="848"/>
+      <Q id="6428715315" qualifier_id="286"/>
+    </Event>
+    <Event id="2939849911" event_id="848" type_id="7" period_id="2" min="90" sec="58" player_id="508143" team_id="244" outcome="1" x="58.6" y="23.4" timestamp="2026-05-19T15:08:58.621" timestamp_utc="2026-05-19T14:08:58.621" last_modified="2026-05-19T15:11:00" version="1779199858325">
+      <Q id="6428717619" qualifier_id="56" value="Center"/>
+      <Q id="6428717623" qualifier_id="178"/>
+      <Q id="6428717625" qualifier_id="233" value="729"/>
+      <Q id="6428717621" qualifier_id="285"/>
+    </Event>
+    <Event id="2939850069" event_id="853" type_id="1" period_id="2" min="91" sec="4" player_id="508143" team_id="244" outcome="1" x="73.6" y="18.6" timestamp="2026-05-19T15:09:04.637" timestamp_utc="2026-05-19T14:09:04.637" last_modified="2026-05-19T15:11:34" version="1779199894217">
+      <Q id="6428718481" qualifier_id="56" value="Center"/>
+      <Q id="6428718483" qualifier_id="140" value="68.7"/>
+      <Q id="6428718485" qualifier_id="141" value="43.6"/>
+      <Q id="6428718487" qualifier_id="212" value="17.8"/>
+      <Q id="6428718489" qualifier_id="213" value="1.86"/>
+    </Event>
+    <Event id="2939850081" event_id="854" type_id="1" period_id="2" min="91" sec="6" player_id="246081" team_id="244" outcome="1" x="65.5" y="48.7" keypass="1" timestamp="2026-05-19T15:09:07.445" timestamp_utc="2026-05-19T14:09:07.445" last_modified="2026-05-19T16:31:45" version="1779204705285">
+      <Q id="6428718593" qualifier_id="56" value="Center"/>
+      <Q id="6428718595" qualifier_id="140" value="82.7"/>
+      <Q id="6428718597" qualifier_id="141" value="65.4"/>
+      <Q id="6428748219" qualifier_id="154"/>
+      <Q id="6428726313" qualifier_id="210" value="15"/>
+      <Q id="6428718599" qualifier_id="212" value="21.3"/>
+      <Q id="6428718601" qualifier_id="213" value="0.56"/>
+    </Event>
+    <Event id="2939849565" event_id="833" type_id="15" period_id="2" min="91" sec="7" player_id="207884" team_id="244" outcome="1" x="82.7" y="65.4" timestamp="2026-05-19T15:09:08.278" timestamp_utc="2026-05-19T14:09:08.278" last_modified="2026-05-19T16:05:38" version="1779203137674">
+      <Q id="6428748239" qualifier_id="18"/>
+      <Q id="6428726193" qualifier_id="20"/>
+      <Q id="6428726053" qualifier_id="22"/>
+      <Q id="6428726317" qualifier_id="29"/>
+      <Q id="6428726319" qualifier_id="55" value="854"/>
+      <Q id="6428726057" qualifier_id="56" value="Center"/>
+      <Q id="6428726315" qualifier_id="78"/>
+      <Q id="6428726199" qualifier_id="82"/>
+      <Q id="6428726323" qualifier_id="102" value="49.8"/>
+      <Q id="6428726325" qualifier_id="103" value="19.0"/>
+      <Q id="6428726329" qualifier_id="146" value="86.2"/>
+      <Q id="6428726331" qualifier_id="147" value="62.3"/>
+      <Q id="6428748243" qualifier_id="154"/>
+      <Q id="6428726333" qualifier_id="230" value="98.2"/>
+      <Q id="6428726335" qualifier_id="231" value="49.6"/>
+      <Q id="6428726351" qualifier_id="233" value="740"/>
+      <Q id="6428748255" qualifier_id="328"/>
+    </Event>
+    <Event id="2939849845" event_id="740" type_id="10" period_id="2" min="91" sec="7" player_id="531784" team_id="417" outcome="1" x="12.3" y="36.1" timestamp="2026-05-19T15:09:08.378" timestamp_utc="2026-05-19T14:09:08.378" last_modified="2026-05-19T15:18:57" version="1779200336596">
+      <Q id="6428717217" qualifier_id="56" value="Back"/>
+      <Q id="6428717215" qualifier_id="94"/>
+      <Q id="6428726355" qualifier_id="233" value="833"/>
+    </Event>
+    <Event id="2939849579" event_id="834" type_id="49" period_id="2" min="91" sec="12" player_id="515742" team_id="244" outcome="1" x="58.7" y="69.7" timestamp="2026-05-19T15:09:12.702" timestamp_utc="2026-05-19T14:09:12.702" last_modified="2026-05-19T15:09:12" version="1779199752703"/>
+    <Event id="2939849585" event_id="835" type_id="4" period_id="2" min="91" sec="14" player_id="515742" team_id="244" outcome="1" x="61.4" y="76.3" timestamp="2026-05-19T15:09:15.549" timestamp_utc="2026-05-19T14:09:15.549" last_modified="2026-05-19T15:09:20" version="1779199760098">
+      <Q id="6428715681" qualifier_id="13"/>
+      <Q id="6428715683" qualifier_id="56" value="Center"/>
+      <Q id="6428715685" qualifier_id="152"/>
+      <Q id="6428715755" qualifier_id="233" value="730"/>
+      <Q id="6428715687" qualifier_id="265"/>
+      <Q id="6428715689" qualifier_id="286"/>
+    </Event>
+    <Event id="2939849595" event_id="730" type_id="4" period_id="2" min="91" sec="14" player_id="683488" team_id="417" outcome="0" x="38.6" y="23.8" timestamp="2026-05-19T15:09:15.550" timestamp_utc="2026-05-19T14:09:15.550" last_modified="2026-05-19T15:09:19" version="1779199758050">
+      <Q id="6428715739" qualifier_id="13"/>
+      <Q id="6428715741" qualifier_id="56" value="Back"/>
+      <Q id="6428715743" qualifier_id="152"/>
+      <Q id="6428715757" qualifier_id="233" value="835"/>
+      <Q id="6428715745" qualifier_id="265"/>
+      <Q id="6428715747" qualifier_id="285"/>
+    </Event>
+    <Event id="2939849601" event_id="731" type_id="70" period_id="2" min="91" sec="19" team_id="417" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T15:09:20.504" timestamp_utc="2026-05-19T14:09:20.504" last_modified="2026-05-19T15:09:20" version="1779199760505">
+      <Q id="6428715793" qualifier_id="277" value="7"/>
+    </Event>
+    <Event id="2939849651" event_id="837" type_id="1" period_id="2" min="91" sec="46" player_id="207884" team_id="244" outcome="0" x="64.8" y="81.1" timestamp="2026-05-19T15:09:46.725" timestamp_utc="2026-05-19T14:09:46.725" last_modified="2026-05-19T15:09:47" version="1779199787245">
+      <Q id="6428716073" qualifier_id="1"/>
+      <Q id="6428716055" qualifier_id="2"/>
+      <Q id="6428716057" qualifier_id="5"/>
+      <Q id="6428716063" qualifier_id="56" value="Center"/>
+      <Q id="6428716065" qualifier_id="140" value="90.8"/>
+      <Q id="6428716067" qualifier_id="141" value="56.3"/>
+      <Q id="6428716061" qualifier_id="152"/>
+      <Q id="6428716059" qualifier_id="155"/>
+      <Q id="6428716069" qualifier_id="212" value="32.1"/>
+      <Q id="6428716071" qualifier_id="213" value="5.73"/>
+    </Event>
+    <Event id="2939849653" event_id="732" type_id="12" period_id="2" min="91" sec="47" player_id="531784" team_id="417" outcome="1" x="10.5" y="40.9" timestamp="2026-05-19T15:09:47.797" timestamp_utc="2026-05-19T14:09:47.797" last_modified="2026-05-19T15:09:48" version="1779199788141">
+      <Q id="6428716087" qualifier_id="15"/>
+      <Q id="6428716075" qualifier_id="56" value="Back"/>
+      <Q id="6428716077" qualifier_id="140" value="21.2"/>
+      <Q id="6428716079" qualifier_id="141" value="22.5"/>
+      <Q id="6428716081" qualifier_id="212" value="16.8"/>
+      <Q id="6428716083" qualifier_id="213" value="5.44"/>
+    </Event>
+    <Event id="2939849655" event_id="733" type_id="12" period_id="2" min="91" sec="50" player_id="720789" team_id="417" outcome="1" x="23.8" y="34.3" timestamp="2026-05-19T15:09:50.655" timestamp_utc="2026-05-19T14:09:50.655" last_modified="2026-05-19T15:09:51" version="1779199790962">
+      <Q id="6428716113" qualifier_id="15"/>
+      <Q id="6428716103" qualifier_id="56" value="Back"/>
+      <Q id="6428716105" qualifier_id="140" value="38.4"/>
+      <Q id="6428716107" qualifier_id="141" value="21.6"/>
+      <Q id="6428716109" qualifier_id="212" value="17.6"/>
+      <Q id="6428716111" qualifier_id="213" value="5.77"/>
+    </Event>
+    <Event id="2939849657" event_id="838" type_id="1" period_id="2" min="91" sec="52" player_id="207884" team_id="244" outcome="0" x="66.7" y="76.1" timestamp="2026-05-19T15:09:53.421" timestamp_utc="2026-05-19T14:09:53.421" last_modified="2026-05-19T15:19:38" version="1779200378721">
+      <Q id="6428726935" qualifier_id="56" value="Center"/>
+      <Q id="6428726937" qualifier_id="140" value="88.5"/>
+      <Q id="6428726939" qualifier_id="141" value="59.3"/>
+      <Q id="6428726933" qualifier_id="155"/>
+      <Q id="6428726941" qualifier_id="212" value="25.6"/>
+      <Q id="6428726943" qualifier_id="213" value="5.82"/>
+    </Event>
+    <Event id="2939849659" event_id="734" type_id="44" period_id="2" min="91" sec="53" player_id="61812" team_id="417" outcome="1" x="11.5" y="40.7" timestamp="2026-05-19T15:09:53.636" timestamp_utc="2026-05-19T14:09:53.636" last_modified="2026-05-19T15:46:50" version="1779202010312">
+      <Q id="6428716131" qualifier_id="56" value="Back"/>
+      <Q id="6428716169" qualifier_id="233" value="839"/>
+      <Q id="6428716133" qualifier_id="285"/>
+    </Event>
+    <Event id="2939849665" event_id="839" type_id="44" period_id="2" min="91" sec="53" player_id="232091" team_id="244" outcome="0" x="88.5" y="59.3" timestamp="2026-05-19T15:09:53.637" timestamp_utc="2026-05-19T14:09:53.637" last_modified="2026-05-19T15:46:50" version="1779202010337">
+      <Q id="6428716155" qualifier_id="56" value="Center"/>
+      <Q id="6428716173" qualifier_id="233" value="734"/>
+      <Q id="6428716157" qualifier_id="286"/>
+    </Event>
+    <Event id="2939849663" event_id="735" type_id="12" period_id="2" min="91" sec="53" player_id="61812" team_id="417" outcome="1" x="11.5" y="40.7" timestamp="2026-05-19T15:09:53.934" timestamp_utc="2026-05-19T14:09:53.934" last_modified="2026-05-19T15:46:51" version="1779202010357">
+      <Q id="6428716151" qualifier_id="15"/>
+      <Q id="6428716141" qualifier_id="56" value="Back"/>
+      <Q id="6428716143" qualifier_id="140" value="32.7"/>
+      <Q id="6428716145" qualifier_id="141" value="60.6"/>
+      <Q id="6428716147" qualifier_id="212" value="26.1"/>
+      <Q id="6428716149" qualifier_id="213" value="0.55"/>
+    </Event>
+    <Event id="2939849675" event_id="736" type_id="12" period_id="2" min="91" sec="53" player_id="61778" team_id="417" outcome="1" x="32.5" y="58.1" timestamp="2026-05-19T15:09:54.141" timestamp_utc="2026-05-19T14:09:54.141" last_modified="2026-05-19T15:20:25" version="1779200425241">
+      <Q id="6428726969" qualifier_id="15"/>
+      <Q id="6428716229" qualifier_id="56" value="Back"/>
+      <Q id="6428716231" qualifier_id="140" value="38.7"/>
+      <Q id="6428716233" qualifier_id="141" value="50.0"/>
+      <Q id="6428716235" qualifier_id="212" value="8.5"/>
+      <Q id="6428716237" qualifier_id="213" value="5.58"/>
+    </Event>
+    <Event id="2939851453" event_id="906" type_id="8" period_id="2" min="91" sec="54" player_id="575855" team_id="244" outcome="1" x="60.5" y="43.3" timestamp="2026-05-19T15:09:54.557" timestamp_utc="2026-05-19T14:09:54.557" last_modified="2026-05-19T15:20:03" version="1779200403065">
+      <Q id="6428727303" qualifier_id="15"/>
+      <Q id="6428727287" qualifier_id="56" value="Center"/>
+    </Event>
+    <Event id="2939849677" event_id="840" type_id="1" period_id="2" min="91" sec="56" player_id="246081" team_id="244" outcome="1" x="67.5" y="52.5" timestamp="2026-05-19T15:09:56.949" timestamp_utc="2026-05-19T14:09:56.949" last_modified="2026-05-19T15:09:59" version="1779199798432">
+      <Q id="6428716257" qualifier_id="1"/>
+      <Q id="6428716247" qualifier_id="56" value="Center"/>
+      <Q id="6428716249" qualifier_id="140" value="87.6"/>
+      <Q id="6428716251" qualifier_id="141" value="43.3"/>
+      <Q id="6428716245" qualifier_id="157"/>
+      <Q id="6428716253" qualifier_id="212" value="22.0"/>
+      <Q id="6428716255" qualifier_id="213" value="6.00"/>
+    </Event>
+    <Event id="2939849679" event_id="841" type_id="61" period_id="2" min="91" sec="58" player_id="508143" team_id="244" outcome="1" x="87.5" y="43.3" keypass="1" timestamp="2026-05-19T15:09:59.245" timestamp_utc="2026-05-19T14:09:59.245" last_modified="2026-05-19T15:10:26" version="1779199826574">
+      <Q id="6428716267" qualifier_id="56" value="Center"/>
+    </Event>
+    <Event id="2939849685" event_id="842" type_id="15" period_id="2" min="91" sec="59" player_id="232091" team_id="244" outcome="1" x="81.2" y="44.6" timestamp="2026-05-19T15:10:00.029" timestamp_utc="2026-05-19T14:10:00.029" last_modified="2026-05-19T16:07:05" version="1779203225048">
+      <Q id="6428716285" qualifier_id="18"/>
+      <Q id="6428716773" qualifier_id="20"/>
+      <Q id="6428716283" qualifier_id="22"/>
+      <Q id="6428716875" qualifier_id="29"/>
+      <Q id="6428716877" qualifier_id="55" value="841"/>
+      <Q id="6428716287" qualifier_id="56" value="Center"/>
+      <Q id="6428749623" qualifier_id="76"/>
+      <Q id="6428716777" qualifier_id="82"/>
+      <Q id="6428716881" qualifier_id="102" value="53.1"/>
+      <Q id="6428716883" qualifier_id="103" value="19.0"/>
+      <Q id="6428716885" qualifier_id="146" value="88.0"/>
+      <Q id="6428716887" qualifier_id="147" value="47.7"/>
+      <Q id="6428716889" qualifier_id="230" value="100.0"/>
+      <Q id="6428716891" qualifier_id="231" value="49.6"/>
+      <Q id="6428716897" qualifier_id="233" value="737"/>
+    </Event>
+    <Event id="2939849693" event_id="737" type_id="10" period_id="2" min="91" sec="59" player_id="531784" team_id="417" outcome="1" x="11.9" y="57.0" timestamp="2026-05-19T15:10:00.129" timestamp_utc="2026-05-19T14:10:00.129" last_modified="2026-05-19T15:20:25" version="1779200424876">
+      <Q id="6428716343" qualifier_id="56" value="Back"/>
+      <Q id="6428716341" qualifier_id="94"/>
+      <Q id="6428716911" qualifier_id="233" value="842"/>
+    </Event>
+    <Event id="2939849713" event_id="843" type_id="1" period_id="2" min="92" sec="5" player_id="508143" team_id="244" outcome="1" x="86.9" y="69.0" timestamp="2026-05-19T15:10:05.685" timestamp_utc="2026-05-19T14:10:05.685" last_modified="2026-05-19T15:10:09" version="1779199806159">
+      <Q id="6428716497" qualifier_id="56" value="Center"/>
+      <Q id="6428716499" qualifier_id="140" value="75.0"/>
+      <Q id="6428716501" qualifier_id="141" value="71.4"/>
+      <Q id="6428716503" qualifier_id="212" value="12.6"/>
+      <Q id="6428716505" qualifier_id="213" value="3.01"/>
+    </Event>
+    <Event id="2939849717" event_id="844" type_id="61" period_id="2" min="92" sec="9" player_id="575855" team_id="244" outcome="1" x="79.9" y="79.3" timestamp="2026-05-19T15:10:09.789" timestamp_utc="2026-05-19T14:10:09.789" last_modified="2026-05-19T15:10:10" version="1779199809791">
+      <Q id="6428716523" qualifier_id="56" value="Left"/>
+    </Event>
+    <Event id="2939851499" event_id="796" type_id="83" period_id="2" min="92" sec="10" player_id="157851" team_id="417" outcome="0" x="20.4" y="16.8" timestamp="2026-05-19T15:10:10.557" timestamp_utc="2026-05-19T14:10:10.557" last_modified="2026-05-19T15:20:29" version="1779200429463">
+      <Q id="6428727631" qualifier_id="399" value="207884"/>
+    </Event>
+    <Event id="2939849725" event_id="845" type_id="50" period_id="2" min="92" sec="11" player_id="207884" team_id="244" outcome="1" x="89.7" y="92.4" timestamp="2026-05-19T15:10:12.326" timestamp_utc="2026-05-19T14:10:12.326" last_modified="2026-05-19T15:10:18" version="1779199817879">
+      <Q id="6428716561" qualifier_id="56" value="Left"/>
+      <Q id="6428716671" qualifier_id="233" value="738"/>
+      <Q id="6428716563" qualifier_id="286"/>
+    </Event>
+    <Event id="2939849747" event_id="738" type_id="7" period_id="2" min="92" sec="11" player_id="720789" team_id="417" outcome="1" x="10.2" y="7.5" timestamp="2026-05-19T15:10:12.327" timestamp_utc="2026-05-19T14:10:12.327" last_modified="2026-05-19T15:10:17" version="1779199816081">
+      <Q id="6428716641" qualifier_id="56" value="Back"/>
+      <Q id="6428716639" qualifier_id="167"/>
+      <Q id="6428716645" qualifier_id="178"/>
+      <Q id="6428716661" qualifier_id="233" value="845"/>
+      <Q id="6428716643" qualifier_id="285"/>
+    </Event>
+    <Event id="2939849737" event_id="846" type_id="6" period_id="2" min="92" sec="13" player_id="207884" team_id="244" outcome="1" x="90.4" y="93.3" timestamp="2026-05-19T15:10:13.989" timestamp_utc="2026-05-19T14:10:13.989" last_modified="2026-05-19T15:10:20" version="1779199818427">
+      <Q id="6428716623" qualifier_id="56" value="Left"/>
+      <Q id="6428716625" qualifier_id="73"/>
+      <Q id="6428716685" qualifier_id="233" value="739"/>
+    </Event>
+    <Event id="2939849751" event_id="739" type_id="6" period_id="2" min="92" sec="13" player_id="720789" team_id="417" outcome="0" x="9.6" y="6.8" timestamp="2026-05-19T15:10:13.989" timestamp_utc="2026-05-19T14:10:13.989" last_modified="2026-05-19T15:27:45" version="1779200864965">
+      <Q id="6428716679" qualifier_id="56" value="Back"/>
+      <Q id="6428716681" qualifier_id="73"/>
+      <Q id="6428716695" qualifier_id="233" value="846"/>
+    </Event>
+    <Event id="2939849859" event_id="847" type_id="1" period_id="2" min="92" sec="39" player_id="207884" team_id="244" outcome="0" x="99.5" y="99.5" timestamp="2026-05-19T15:10:40.414" timestamp_utc="2026-05-19T14:10:40.414" last_modified="2026-05-19T15:10:43" version="1779199843613">
+      <Q id="6428717331" qualifier_id="1"/>
+      <Q id="6428717313" qualifier_id="2"/>
+      <Q id="6428717315" qualifier_id="6"/>
+      <Q id="6428717321" qualifier_id="56" value="Center"/>
+      <Q id="6428717323" qualifier_id="140" value="99.3"/>
+      <Q id="6428717325" qualifier_id="141" value="44.8"/>
+      <Q id="6428717317" qualifier_id="155"/>
+      <Q id="6428717327" qualifier_id="212" value="37.2"/>
+      <Q id="6428717329" qualifier_id="213" value="4.71"/>
+      <Q id="6428717319" qualifier_id="223"/>
+    </Event>
+    <Event id="2939849873" event_id="741" type_id="11" period_id="2" min="92" sec="45" player_id="565487" team_id="417" outcome="1" x="0.7" y="55.2" timestamp="2026-05-19T15:10:46.204" timestamp_utc="2026-05-19T14:10:46.204" last_modified="2026-05-19T15:45:58" version="1779201957957">
+      <Q id="6428717387" qualifier_id="56" value="Back"/>
+      <Q id="6428717389" qualifier_id="88"/>
+    </Event>
+    <Event id="2939849899" event_id="742" type_id="1" period_id="2" min="92" sec="50" player_id="565487" team_id="417" outcome="1" x="12.0" y="49.6" timestamp="2026-05-19T15:10:51.445" timestamp_utc="2026-05-19T14:10:51.445" last_modified="2026-05-19T15:10:53" version="1779199851542">
+      <Q id="6428717525" qualifier_id="56" value="Back"/>
+      <Q id="6428717523" qualifier_id="123"/>
+      <Q id="6428717527" qualifier_id="140" value="11.8"/>
+      <Q id="6428717529" qualifier_id="141" value="48.2"/>
+      <Q id="6428717531" qualifier_id="212" value="1.0"/>
+      <Q id="6428717533" qualifier_id="213" value="4.50"/>
+    </Event>
+    <Event id="2939849901" event_id="743" type_id="1" period_id="2" min="92" sec="52" player_id="61812" team_id="417" outcome="1" x="16.4" y="51.5" timestamp="2026-05-19T15:10:53.268" timestamp_utc="2026-05-19T14:10:53.268" last_modified="2026-05-19T15:10:55" version="1779199853468">
+      <Q id="6428717541" qualifier_id="56" value="Back"/>
+      <Q id="6428717543" qualifier_id="140" value="22.1"/>
+      <Q id="6428717545" qualifier_id="141" value="40.4"/>
+      <Q id="6428717547" qualifier_id="212" value="9.6"/>
+      <Q id="6428717549" qualifier_id="213" value="5.38"/>
+    </Event>
+    <Event id="2939849917" event_id="744" type_id="1" period_id="2" min="92" sec="54" player_id="531784" team_id="417" outcome="1" x="26.1" y="39.5" timestamp="2026-05-19T15:10:55.334" timestamp_utc="2026-05-19T14:10:55.334" last_modified="2026-05-19T15:10:59" version="1779199855557">
+      <Q id="6428717669" qualifier_id="56" value="Back"/>
+      <Q id="6428717671" qualifier_id="140" value="31.8"/>
+      <Q id="6428717673" qualifier_id="141" value="59.3"/>
+      <Q id="6428717675" qualifier_id="212" value="14.7"/>
+      <Q id="6428717677" qualifier_id="213" value="1.15"/>
+    </Event>
+    <Event id="2939849941" event_id="745" type_id="1" period_id="2" min="92" sec="58" player_id="61778" team_id="417" outcome="1" x="39.2" y="68.1" timestamp="2026-05-19T15:10:59.340" timestamp_utc="2026-05-19T14:10:59.340" last_modified="2026-05-19T15:11:02" version="1779199860120">
+      <Q id="6428717811" qualifier_id="56" value="Left"/>
+      <Q id="6428717813" qualifier_id="140" value="60.0"/>
+      <Q id="6428717815" qualifier_id="141" value="88.1"/>
+      <Q id="6428717817" qualifier_id="212" value="25.7"/>
+      <Q id="6428717819" qualifier_id="213" value="0.56"/>
+    </Event>
+    <Event id="2939849959" event_id="746" type_id="1" period_id="2" min="93" sec="2" player_id="570078" team_id="417" outcome="1" x="58.6" y="92.3" timestamp="2026-05-19T15:11:02.628" timestamp_utc="2026-05-19T14:11:02.628" last_modified="2026-05-19T15:11:04" version="1779199862760">
+      <Q id="6428717913" qualifier_id="56" value="Center"/>
+      <Q id="6428717915" qualifier_id="140" value="54.3"/>
+      <Q id="6428717917" qualifier_id="141" value="77.8"/>
+      <Q id="6428717919" qualifier_id="212" value="10.8"/>
+      <Q id="6428717921" qualifier_id="213" value="4.28"/>
+    </Event>
+    <Event id="2939849965" event_id="849" type_id="45" period_id="2" min="93" sec="3" player_id="508143" team_id="244" outcome="0" x="44.3" y="18.7" timestamp="2026-05-19T15:11:04.453" timestamp_utc="2026-05-19T14:11:04.453" last_modified="2026-05-19T15:26:48" version="1779200797376">
+      <Q id="6428717951" qualifier_id="56" value="Back"/>
+      <Q id="6428718015" qualifier_id="233" value="747"/>
+      <Q id="6428717953" qualifier_id="285"/>
+    </Event>
+    <Event id="2939849973" event_id="747" type_id="3" period_id="2" min="93" sec="3" player_id="61778" team_id="417" outcome="1" x="55.7" y="81.3" timestamp="2026-05-19T15:11:04.453" timestamp_utc="2026-05-19T14:11:04.453" last_modified="2026-05-19T15:26:48" version="1779200797370">
+      <Q id="6428717973" qualifier_id="56" value="Left"/>
+      <Q id="6428717987" qualifier_id="233" value="849"/>
+      <Q id="6428717975" qualifier_id="286"/>
+    </Event>
+    <Event id="2939849997" event_id="748" type_id="1" period_id="2" min="93" sec="7" player_id="61778" team_id="417" outcome="1" x="59.8" y="62.9" timestamp="2026-05-19T15:11:08.172" timestamp_utc="2026-05-19T14:11:08.172" last_modified="2026-05-19T15:11:12" version="1779199868429">
+      <Q id="6428718093" qualifier_id="56" value="Center"/>
+      <Q id="6428718095" qualifier_id="140" value="67.8"/>
+      <Q id="6428718097" qualifier_id="141" value="40.7"/>
+      <Q id="6428718099" qualifier_id="212" value="17.3"/>
+      <Q id="6428718101" qualifier_id="213" value="5.22"/>
+    </Event>
+    <Event id="2939849987" event_id="850" type_id="83" period_id="2" min="93" sec="10" player_id="207884" team_id="244" outcome="0" x="21.7" y="49.7" timestamp="2026-05-19T15:11:10.973" timestamp_utc="2026-05-19T14:11:10.973" last_modified="2026-05-19T15:11:17" version="1779199876846">
+      <Q id="6428718197" qualifier_id="399" value="720789"/>
+    </Event>
+    <Event id="2939850007" event_id="749" type_id="1" period_id="2" min="93" sec="11" player_id="720789" team_id="417" outcome="1" x="71.7" y="33.7" timestamp="2026-05-19T15:11:12.180" timestamp_utc="2026-05-19T14:11:12.180" last_modified="2026-05-19T15:11:14" version="1779199872429">
+      <Q id="6428718125" qualifier_id="56" value="Right"/>
+      <Q id="6428718127" qualifier_id="140" value="78.6"/>
+      <Q id="6428718129" qualifier_id="141" value="18.0"/>
+      <Q id="6428718131" qualifier_id="212" value="12.9"/>
+      <Q id="6428718133" qualifier_id="213" value="5.31"/>
+    </Event>
+    <Event id="2939850015" event_id="750" type_id="1" period_id="2" min="93" sec="13" player_id="157851" team_id="417" outcome="1" x="85.3" y="4.7" timestamp="2026-05-19T15:11:14.540" timestamp_utc="2026-05-19T14:11:14.540" last_modified="2026-05-19T15:11:16" version="1779199874721">
+      <Q id="6428718185" qualifier_id="56" value="Right"/>
+      <Q id="6428718187" qualifier_id="140" value="75.0"/>
+      <Q id="6428718189" qualifier_id="141" value="12.6"/>
+      <Q id="6428718191" qualifier_id="212" value="12.1"/>
+      <Q id="6428718193" qualifier_id="213" value="2.68"/>
+    </Event>
+    <Event id="2939850019" event_id="751" type_id="1" period_id="2" min="93" sec="16" player_id="531784" team_id="417" outcome="0" x="74.5" y="10.1" timestamp="2026-05-19T15:11:17.037" timestamp_utc="2026-05-19T14:11:17.037" last_modified="2026-05-19T15:11:17" version="1779199877846">
+      <Q id="6428718221" qualifier_id="2"/>
+      <Q id="6428718225" qualifier_id="56" value="Center"/>
+      <Q id="6428718227" qualifier_id="140" value="89.5"/>
+      <Q id="6428718229" qualifier_id="141" value="39.1"/>
+      <Q id="6428718223" qualifier_id="155"/>
+      <Q id="6428718231" qualifier_id="212" value="25.2"/>
+      <Q id="6428718233" qualifier_id="213" value="0.90"/>
+    </Event>
+    <Event id="2939850027" event_id="851" type_id="12" period_id="2" min="93" sec="18" player_id="515742" team_id="244" outcome="1" x="9.7" y="63.9" timestamp="2026-05-19T15:11:18.837" timestamp_utc="2026-05-19T14:11:18.837" last_modified="2026-05-19T15:11:21" version="1779199881048">
+      <Q id="6428718273" qualifier_id="15"/>
+      <Q id="6428718263" qualifier_id="56" value="Back"/>
+      <Q id="6428718265" qualifier_id="140" value="23.8"/>
+      <Q id="6428718267" qualifier_id="141" value="100.0"/>
+      <Q id="6428718335" qualifier_id="167"/>
+      <Q id="6428718269" qualifier_id="212" value="29.3"/>
+      <Q id="6428718271" qualifier_id="213" value="1.04"/>
+    </Event>
+    <Event id="2939850041" event_id="852" type_id="5" period_id="2" min="93" sec="19" player_id="515742" team_id="244" outcome="0" x="24.4" y="101.2" timestamp="2026-05-19T15:11:20.244" timestamp_utc="2026-05-19T14:11:20.244" last_modified="2026-05-19T15:26:38" version="1779200790321">
+      <Q id="6428718331" qualifier_id="56" value="Back"/>
+      <Q id="6428718393" qualifier_id="233" value="752"/>
+      <Q id="6428718333" qualifier_id="347"/>
+    </Event>
+    <Event id="2939850051" event_id="752" type_id="5" period_id="2" min="93" sec="19" player_id="531784" team_id="417" outcome="1" x="75.6" y="-1.2" timestamp="2026-05-19T15:11:20.244" timestamp_utc="2026-05-19T14:11:20.244" last_modified="2026-05-19T15:11:29" version="1779199887328">
+      <Q id="6428718383" qualifier_id="56" value="Right"/>
+      <Q id="6428718387" qualifier_id="233" value="852"/>
+      <Q id="6428718385" qualifier_id="347"/>
+    </Event>
+    <Event id="2939850087" event_id="753" type_id="1" period_id="2" min="93" sec="38" player_id="624620" team_id="417" outcome="1" x="80.9" y="0.0" timestamp="2026-05-19T15:11:39.323" timestamp_utc="2026-05-19T14:11:39.323" last_modified="2026-05-19T15:19:02" version="1779200341888">
+      <Q id="6428718639" qualifier_id="1"/>
+      <Q id="6428718629" qualifier_id="56" value="Center"/>
+      <Q id="6428718627" qualifier_id="107"/>
+      <Q id="6428718631" qualifier_id="140" value="90.2"/>
+      <Q id="6428718633" qualifier_id="141" value="34.5"/>
+      <Q id="6428718635" qualifier_id="212" value="26.7"/>
+      <Q id="6428718637" qualifier_id="213" value="1.20"/>
+    </Event>
+    <Event id="2939851299" event_id="794" type_id="44" period_id="2" min="93" sec="40" player_id="61812" team_id="417" outcome="1" x="90.2" y="34.5" timestamp="2026-05-19T15:11:40.557" timestamp_utc="2026-05-19T14:11:40.557" last_modified="2026-05-19T15:46:53" version="1779202013584">
+      <Q id="6428726361" qualifier_id="56" value="Center"/>
+      <Q id="6428727799" qualifier_id="233" value="894"/>
+      <Q id="6428726363" qualifier_id="286"/>
+    </Event>
+    <Event id="2939850833" event_id="894" type_id="44" period_id="2" min="93" sec="40" player_id="232091" team_id="244" outcome="0" x="9.8" y="65.5" timestamp="2026-05-19T15:11:40.558" timestamp_utc="2026-05-19T14:11:40.558" last_modified="2026-05-19T15:46:54" version="1779202013604">
+      <Q id="6428723541" qualifier_id="56" value="Back"/>
+      <Q id="6428727815" qualifier_id="233" value="794"/>
+      <Q id="6428723543" qualifier_id="285"/>
+    </Event>
+    <Event id="2939851303" event_id="795" type_id="61" period_id="2" min="93" sec="41" player_id="61812" team_id="417" outcome="1" x="86.4" y="49.9" timestamp="2026-05-19T15:11:41.557" timestamp_utc="2026-05-19T14:11:41.557" last_modified="2026-05-19T16:04:29" version="1779203069286">
+      <Q id="6428726367" qualifier_id="56" value="Center"/>
+    </Event>
+    <Event id="2939850089" event_id="855" type_id="61" period_id="2" min="93" sec="42" player_id="232091" team_id="244" outcome="1" x="11.9" y="41.6" timestamp="2026-05-19T15:11:42.621" timestamp_utc="2026-05-19T14:11:42.621" last_modified="2026-05-19T16:29:57" version="1779204596980">
+      <Q id="6428718649" qualifier_id="56" value="Back"/>
+    </Event>
+    <Event id="2939850097" event_id="856" type_id="12" period_id="2" min="93" sec="43" player_id="482450" team_id="244" outcome="1" x="20.6" y="36.9" timestamp="2026-05-19T15:11:43.908" timestamp_utc="2026-05-19T14:11:43.908" last_modified="2026-05-19T15:11:45" version="1779199904166">
+      <Q id="6428718705" qualifier_id="56" value="Back"/>
+      <Q id="6428718707" qualifier_id="140" value="29.3"/>
+      <Q id="6428718709" qualifier_id="141" value="40.7"/>
+      <Q id="6428718711" qualifier_id="212" value="9.5"/>
+      <Q id="6428718713" qualifier_id="213" value="0.28"/>
+    </Event>
+    <Event id="2939850105" event_id="857" type_id="12" period_id="2" min="93" sec="44" player_id="232091" team_id="244" outcome="1" x="18.5" y="39.4" timestamp="2026-05-19T15:11:45.061" timestamp_utc="2026-05-19T14:11:45.061" last_modified="2026-05-19T15:11:48" version="1779199906933">
+      <Q id="6428718781" qualifier_id="56" value="Back"/>
+      <Q id="6428718783" qualifier_id="140" value="47.1"/>
+      <Q id="6428718785" qualifier_id="141" value="36.3"/>
+      <Q id="6428718787" qualifier_id="212" value="30.1"/>
+      <Q id="6428718789" qualifier_id="213" value="6.21"/>
+    </Event>
+    <Event id="2939850101" event_id="754" type_id="61" period_id="2" min="93" sec="45" player_id="570078" team_id="417" outcome="1" x="76.7" y="22.4" timestamp="2026-05-19T15:11:46.491" timestamp_utc="2026-05-19T14:11:46.491" last_modified="2026-05-19T15:11:46" version="1779199906493">
+      <Q id="6428718733" qualifier_id="56" value="Center"/>
+    </Event>
+    <Event id="2939850107" event_id="858" type_id="43" period_id="2" min="93" sec="47" player_id="482450" team_id="244" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T15:11:48.173" timestamp_utc="2026-05-19T14:11:48.173" last_modified="2026-05-19T15:12:03" version="1779199908174">
+      <Q id="6428718791" qualifier_id="56" value="Back"/>
+      <Q id="6428719081" qualifier_id="144" value="61"/>
+    </Event>
+    <Event id="2939850111" event_id="859" type_id="49" period_id="2" min="93" sec="49" player_id="482450" team_id="244" outcome="1" x="51.7" y="35.2" timestamp="2026-05-19T15:11:49.573" timestamp_utc="2026-05-19T14:11:49.573" last_modified="2026-05-19T15:11:49" version="1779199909575"/>
+    <Event id="2939850115" event_id="860" type_id="1" period_id="2" min="93" sec="50" player_id="482450" team_id="244" outcome="1" x="54.3" y="39.8" timestamp="2026-05-19T15:11:50.725" timestamp_utc="2026-05-19T14:11:50.725" last_modified="2026-05-19T15:17:47" version="1779200267563">
+      <Q id="6428718821" qualifier_id="56" value="Center"/>
+      <Q id="6428718823" qualifier_id="140" value="58.4"/>
+      <Q id="6428718825" qualifier_id="141" value="69.6"/>
+      <Q id="6428718827" qualifier_id="212" value="20.7"/>
+      <Q id="6428718829" qualifier_id="213" value="1.36"/>
+    </Event>
+    <Event id="2939850137" event_id="861" type_id="1" period_id="2" min="93" sec="55" player_id="207884" team_id="244" outcome="1" x="56.8" y="78.7" timestamp="2026-05-19T15:11:55.801" timestamp_utc="2026-05-19T14:11:55.801" last_modified="2026-05-19T15:17:54" version="1779200274145">
+      <Q id="6428725223" qualifier_id="1"/>
+      <Q id="6428725213" qualifier_id="56" value="Center"/>
+      <Q id="6428725215" qualifier_id="140" value="72.7"/>
+      <Q id="6428725217" qualifier_id="141" value="37.8"/>
+      <Q id="6428725211" qualifier_id="155"/>
+      <Q id="6428725219" qualifier_id="212" value="32.4"/>
+      <Q id="6428725221" qualifier_id="213" value="5.25"/>
+    </Event>
+    <Event id="2939850149" event_id="862" type_id="1" period_id="2" min="93" sec="57" player_id="508143" team_id="244" outcome="0" x="94.1" y="29.7" timestamp="2026-05-19T15:11:58.349" timestamp_utc="2026-05-19T14:11:58.349" last_modified="2026-05-19T15:12:00" version="1779199920159">
+      <Q id="6428719009" qualifier_id="56" value="Center"/>
+      <Q id="6428719011" qualifier_id="140" value="78.5"/>
+      <Q id="6428719013" qualifier_id="141" value="52.5"/>
+      <Q id="6428719019" qualifier_id="195"/>
+      <Q id="6428719015" qualifier_id="212" value="22.6"/>
+      <Q id="6428719017" qualifier_id="213" value="2.38"/>
+    </Event>
+    <Event id="2939850153" event_id="755" type_id="12" period_id="2" min="93" sec="59" player_id="624620" team_id="417" outcome="1" x="12.7" y="39.1" timestamp="2026-05-19T15:12:00.539" timestamp_utc="2026-05-19T14:12:00.539" last_modified="2026-05-19T15:12:02" version="1779199922199">
+      <Q id="6428719043" qualifier_id="56" value="Back"/>
+      <Q id="6428719045" qualifier_id="140" value="13.9"/>
+      <Q id="6428719047" qualifier_id="141" value="100.0"/>
+      <Q id="6428719077" qualifier_id="167"/>
+      <Q id="6428719049" qualifier_id="212" value="42.8"/>
+      <Q id="6428719051" qualifier_id="213" value="1.54"/>
+    </Event>
+    <Event id="2939850157" event_id="756" type_id="5" period_id="2" min="94" sec="1" player_id="624620" team_id="417" outcome="0" x="15.9" y="101.8" timestamp="2026-05-19T15:12:01.661" timestamp_utc="2026-05-19T14:12:01.661" last_modified="2026-05-19T15:26:39" version="1779200790335">
+      <Q id="6428719073" qualifier_id="56" value="Back"/>
+      <Q id="6428719215" qualifier_id="233" value="863"/>
+      <Q id="6428719075" qualifier_id="347"/>
+    </Event>
+    <Event id="2939850175" event_id="863" type_id="5" period_id="2" min="94" sec="1" player_id="508143" team_id="244" outcome="1" x="84.1" y="-1.8" timestamp="2026-05-19T15:12:01.661" timestamp_utc="2026-05-19T14:12:01.661" last_modified="2026-05-19T15:26:38" version="1779200790327">
+      <Q id="6428719173" qualifier_id="56" value="Right"/>
+      <Q id="6428719199" qualifier_id="233" value="756"/>
+      <Q id="6428719175" qualifier_id="347"/>
+    </Event>
+    <Event id="2939850245" event_id="864" type_id="1" period_id="2" min="94" sec="18" player_id="240166" team_id="244" outcome="1" x="74.5" y="0.0" timestamp="2026-05-19T15:12:19.245" timestamp_utc="2026-05-19T14:12:19.245" last_modified="2026-05-19T15:12:27" version="1779199941515">
+      <Q id="6428719561" qualifier_id="56" value="Right"/>
+      <Q id="6428719559" qualifier_id="107"/>
+      <Q id="6428719563" qualifier_id="140" value="87.2"/>
+      <Q id="6428719565" qualifier_id="141" value="10.4"/>
+      <Q id="6428719567" qualifier_id="212" value="15.2"/>
+      <Q id="6428719569" qualifier_id="213" value="0.50"/>
+    </Event>
+    <Event id="2939850223" event_id="757" type_id="83" period_id="2" min="94" sec="20" player_id="61778" team_id="417" outcome="0" x="11.0" y="87.5" timestamp="2026-05-19T15:12:21.307" timestamp_utc="2026-05-19T14:12:21.307" last_modified="2026-05-19T15:12:27" version="1779199947298">
+      <Q id="6428719607" qualifier_id="399" value="246081"/>
+    </Event>
+    <Event id="2939850237" event_id="759" type_id="83" period_id="2" min="94" sec="23" player_id="61778" team_id="417" outcome="0" x="10.6" y="85.7" timestamp="2026-05-19T15:12:23.747" timestamp_utc="2026-05-19T14:12:23.747" last_modified="2026-05-19T15:12:27" version="1779199947290">
+      <Q id="6428719605" qualifier_id="399" value="246081"/>
+    </Event>
+    <Event id="2939850247" event_id="865" type_id="1" period_id="2" min="94" sec="23" player_id="246081" team_id="244" outcome="1" x="89.3" y="10.4" timestamp="2026-05-19T15:12:24.053" timestamp_utc="2026-05-19T14:12:24.053" last_modified="2026-05-19T15:12:27" version="1779199944350">
+      <Q id="6428719575" qualifier_id="56" value="Right"/>
+      <Q id="6428719577" qualifier_id="140" value="86.5"/>
+      <Q id="6428719579" qualifier_id="141" value="7.4"/>
+      <Q id="6428719581" qualifier_id="212" value="3.6"/>
+      <Q id="6428719583" qualifier_id="213" value="3.75"/>
+    </Event>
+    <Event id="2939850255" event_id="866" type_id="61" period_id="2" min="94" sec="29" player_id="508143" team_id="244" outcome="1" x="88.3" y="8.5" timestamp="2026-05-19T15:12:30.120" timestamp_utc="2026-05-19T14:12:30.120" last_modified="2026-05-19T15:12:30" version="1779199950122">
+      <Q id="6428719655" qualifier_id="56" value="Right"/>
+    </Event>
+    <Event id="2939850265" event_id="760" type_id="83" period_id="2" min="94" sec="30" player_id="570078" team_id="417" outcome="0" x="8.7" y="90.2" timestamp="2026-05-19T15:12:31.443" timestamp_utc="2026-05-19T14:12:31.443" last_modified="2026-05-19T15:12:33" version="1779199953085">
+      <Q id="6428719785" qualifier_id="399" value="246081"/>
+    </Event>
+    <Event id="2939850269" event_id="867" type_id="1" period_id="2" min="94" sec="31" player_id="246081" team_id="244" outcome="1" x="91.7" y="14.4" timestamp="2026-05-19T15:12:31.701" timestamp_utc="2026-05-19T14:12:31.701" last_modified="2026-05-19T15:12:32" version="1779199952272">
+      <Q id="6428719757" qualifier_id="56" value="Center"/>
+      <Q id="6428719759" qualifier_id="140" value="85.2"/>
+      <Q id="6428719761" qualifier_id="141" value="27.0"/>
+      <Q id="6428719763" qualifier_id="212" value="11.0"/>
+      <Q id="6428719765" qualifier_id="213" value="2.24"/>
+    </Event>
+    <Event id="2939850271" event_id="868" type_id="1" period_id="2" min="94" sec="32" player_id="515742" team_id="244" outcome="1" x="85.2" y="27.0" keypass="1" timestamp="2026-05-19T15:12:32.829" timestamp_utc="2026-05-19T14:12:32.829" last_modified="2026-05-19T16:30:06" version="1779204606606">
+      <Q id="6428719773" qualifier_id="56" value="Center"/>
+      <Q id="6428719775" qualifier_id="140" value="76.0"/>
+      <Q id="6428719777" qualifier_id="141" value="41.9"/>
+      <Q id="6428752377" qualifier_id="154"/>
+      <Q id="6428720131" qualifier_id="210" value="14"/>
+      <Q id="6428719779" qualifier_id="212" value="14.0"/>
+      <Q id="6428719781" qualifier_id="213" value="2.33"/>
+    </Event>
+    <Event id="2939850289" event_id="869" type_id="14" period_id="2" min="94" sec="34" player_id="575855" team_id="244" outcome="1" x="76.0" y="41.9" timestamp="2026-05-19T15:12:34.829" timestamp_utc="2026-05-19T14:12:34.829" last_modified="2026-05-19T16:09:39" version="1779203379109">
+      <Q id="6428719879" qualifier_id="18"/>
+      <Q id="6428720053" qualifier_id="20"/>
+      <Q id="6428719877" qualifier_id="22"/>
+      <Q id="6428720149" qualifier_id="29"/>
+      <Q id="6428720151" qualifier_id="55" value="868"/>
+      <Q id="6428719881" qualifier_id="56" value="Center"/>
+      <Q id="6428720147" qualifier_id="74"/>
+      <Q id="6428720155" qualifier_id="102" value="52.5"/>
+      <Q id="6428720157" qualifier_id="103" value="39.9"/>
+      <Q id="6428752385" qualifier_id="154"/>
+      <Q id="6428720161" qualifier_id="230" value="97.6"/>
+      <Q id="6428720163" qualifier_id="231" value="49.1"/>
+      <Q id="6428752387" qualifier_id="328"/>
+    </Event>
+    <Event id="2939850303" event_id="761" type_id="49" period_id="2" min="94" sec="39" player_id="157851" team_id="417" outcome="1" x="17.1" y="7.3" timestamp="2026-05-19T15:12:39.620" timestamp_utc="2026-05-19T14:12:39.620" last_modified="2026-05-19T15:12:39" version="1779199959622"/>
+    <Event id="2939850305" event_id="762" type_id="1" period_id="2" min="94" sec="40" player_id="157851" team_id="417" outcome="0" x="14.1" y="12.5" timestamp="2026-05-19T15:12:40.747" timestamp_utc="2026-05-19T14:12:40.747" last_modified="2026-05-19T15:12:41" version="1779199961392">
+      <Q id="6428719989" qualifier_id="1"/>
+      <Q id="6428719979" qualifier_id="56" value="Back"/>
+      <Q id="6428719981" qualifier_id="140" value="15.5"/>
+      <Q id="6428719983" qualifier_id="141" value="13.1"/>
+      <Q id="6428719977" qualifier_id="157"/>
+      <Q id="6428719985" qualifier_id="212" value="1.5"/>
+      <Q id="6428719987" qualifier_id="213" value="0.27"/>
+      <Q id="6428720001" qualifier_id="233" value="870"/>
+      <Q id="6428719995" qualifier_id="236"/>
+      <Q id="6428719999" qualifier_id="286"/>
+    </Event>
+    <Event id="2939850307" event_id="870" type_id="74" period_id="2" min="94" sec="40" player_id="207884" team_id="244" outcome="1" x="84.5" y="86.9" timestamp="2026-05-19T15:12:40.748" timestamp_utc="2026-05-19T14:12:40.748" last_modified="2026-05-19T15:45:54" version="1779201954062">
+      <Q id="6428719991" qualifier_id="56" value="Left"/>
+      <Q id="6428720007" qualifier_id="233" value="762"/>
+      <Q id="6428719993" qualifier_id="285"/>
+    </Event>
+    <Event id="2939850311" event_id="871" type_id="5" period_id="2" min="94" sec="41" player_id="207884" team_id="244" outcome="0" x="80.5" y="101.3" timestamp="2026-05-19T15:12:42.363" timestamp_utc="2026-05-19T14:12:42.363" last_modified="2026-05-19T15:26:39" version="1779200790349">
+      <Q id="6428720035" qualifier_id="56" value="Left"/>
+      <Q id="6428720087" qualifier_id="233" value="763"/>
+      <Q id="6428720037" qualifier_id="347"/>
+    </Event>
+    <Event id="2939850315" event_id="763" type_id="5" period_id="2" min="94" sec="41" player_id="157851" team_id="417" outcome="1" x="19.5" y="-1.3" timestamp="2026-05-19T15:12:42.363" timestamp_utc="2026-05-19T14:12:42.363" last_modified="2026-05-19T15:26:39" version="1779200790344">
+      <Q id="6428720059" qualifier_id="56" value="Back"/>
+      <Q id="6428720079" qualifier_id="233" value="871"/>
+      <Q id="6428720061" qualifier_id="347"/>
+    </Event>
+    <Event id="2939850321" event_id="764" type_id="1" period_id="2" min="94" sec="44" player_id="157851" team_id="417" outcome="1" x="18.7" y="0.0" timestamp="2026-05-19T15:12:44.836" timestamp_utc="2026-05-19T14:12:44.836" last_modified="2026-05-19T15:12:48" version="1779199964995">
+      <Q id="6428720117" qualifier_id="56" value="Back"/>
+      <Q id="6428720115" qualifier_id="107"/>
+      <Q id="6428720119" qualifier_id="140" value="14.5"/>
+      <Q id="6428720121" qualifier_id="141" value="17.1"/>
+      <Q id="6428720123" qualifier_id="212" value="13.7"/>
+      <Q id="6428720125" qualifier_id="213" value="1.90"/>
+    </Event>
+    <Event id="2939850325" event_id="765" type_id="1" period_id="2" min="94" sec="47" player_id="531784" team_id="417" outcome="0" x="12.2" y="25.9" timestamp="2026-05-19T15:12:47.868" timestamp_utc="2026-05-19T14:12:47.868" last_modified="2026-05-19T15:12:48" version="1779199968707">
+      <Q id="6428720179" qualifier_id="1"/>
+      <Q id="6428720167" qualifier_id="56" value="Back"/>
+      <Q id="6428720169" qualifier_id="140" value="37.2"/>
+      <Q id="6428720171" qualifier_id="141" value="22.5"/>
+      <Q id="6428720165" qualifier_id="157"/>
+      <Q id="6428720173" qualifier_id="212" value="26.4"/>
+      <Q id="6428720175" qualifier_id="213" value="6.20"/>
+    </Event>
+    <Event id="2939850341" event_id="872" type_id="1" period_id="2" min="94" sec="50" player_id="575855" team_id="244" outcome="1" x="50.5" y="73.9" timestamp="2026-05-19T15:12:51.540" timestamp_utc="2026-05-19T14:12:51.540" last_modified="2026-05-19T15:14:51" version="1779200091299">
+      <Q id="6428720267" qualifier_id="3"/>
+      <Q id="6428720269" qualifier_id="56" value="Back"/>
+      <Q id="6428720271" qualifier_id="140" value="48.0"/>
+      <Q id="6428720273" qualifier_id="141" value="73.5"/>
+      <Q id="6428720275" qualifier_id="212" value="2.6"/>
+      <Q id="6428720277" qualifier_id="213" value="3.24"/>
+    </Event>
+    <Event id="2939850343" event_id="873" type_id="1" period_id="2" min="94" sec="51" player_id="627127" team_id="244" outcome="1" x="48.0" y="73.5" timestamp="2026-05-19T15:12:52.284" timestamp_utc="2026-05-19T14:12:52.284" last_modified="2026-05-19T15:12:53" version="1779199972822">
+      <Q id="6428720283" qualifier_id="56" value="Left"/>
+      <Q id="6428720285" qualifier_id="140" value="61.6"/>
+      <Q id="6428720287" qualifier_id="141" value="79.7"/>
+      <Q id="6428720289" qualifier_id="212" value="14.9"/>
+      <Q id="6428720291" qualifier_id="213" value="0.29"/>
+    </Event>
+    <Event id="2939850347" event_id="874" type_id="49" period_id="2" min="94" sec="53" player_id="207884" team_id="244" outcome="1" x="66.3" y="82.0" timestamp="2026-05-19T15:12:53.565" timestamp_utc="2026-05-19T14:12:53.565" last_modified="2026-05-19T15:12:53" version="1779199973566"/>
+    <Event id="2939850351" event_id="875" type_id="3" period_id="2" min="94" sec="53" player_id="207884" team_id="244" outcome="1" x="68.2" y="86.8" timestamp="2026-05-19T15:12:53.897" timestamp_utc="2026-05-19T14:12:53.897" last_modified="2026-05-19T15:26:48" version="1779200797382">
+      <Q id="6428720325" qualifier_id="56" value="Left"/>
+      <Q id="6428721033" qualifier_id="233" value="766"/>
+      <Q id="6428720327" qualifier_id="286"/>
+    </Event>
+    <Event id="2939850363" event_id="766" type_id="45" period_id="2" min="94" sec="53" player_id="157851" team_id="417" outcome="0" x="31.8" y="13.2" timestamp="2026-05-19T15:12:53.897" timestamp_utc="2026-05-19T14:12:53.897" last_modified="2026-05-19T15:26:49" version="1779200797388">
+      <Q id="6428720409" qualifier_id="56" value="Back"/>
+      <Q id="6428721037" qualifier_id="233" value="875"/>
+      <Q id="6428720411" qualifier_id="285"/>
+    </Event>
+    <Event id="2939850353" event_id="876" type_id="3" period_id="2" min="94" sec="54" player_id="207884" team_id="244" outcome="0" x="68.9" y="86.4" timestamp="2026-05-19T15:12:54.749" timestamp_utc="2026-05-19T14:12:54.749" last_modified="2026-05-19T15:26:46" version="1779200796941">
+      <Q id="6428720333" qualifier_id="56" value="Left"/>
+      <Q id="6428721045" qualifier_id="233" value="767"/>
+      <Q id="6428720335" qualifier_id="286"/>
+    </Event>
+    <Event id="2939850377" event_id="767" type_id="7" period_id="2" min="94" sec="54" player_id="531784" team_id="417" outcome="1" x="31.1" y="13.6" timestamp="2026-05-19T15:12:54.750" timestamp_utc="2026-05-19T14:12:54.750" last_modified="2026-05-19T15:26:46" version="1779200796934">
+      <Q id="6428720499" qualifier_id="56" value="Back"/>
+      <Q id="6428720503" qualifier_id="178"/>
+      <Q id="6428721041" qualifier_id="233" value="876"/>
+      <Q id="6428720501" qualifier_id="285"/>
+    </Event>
+    <Event id="2939850367" event_id="877" type_id="43" period_id="2" min="94" sec="58" player_id="627127" team_id="244" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T15:12:59.509" timestamp_utc="2026-05-19T14:12:59.509" last_modified="2026-05-19T15:13:06" version="1779199979510">
+      <Q id="6428720429" qualifier_id="56" value="Center"/>
+      <Q id="6428720587" qualifier_id="144" value="8"/>
+    </Event>
+    <Event id="2939850379" event_id="768" type_id="4" period_id="2" min="95" sec="1" player_id="731191" team_id="417" outcome="1" x="43.8" y="30.4" timestamp="2026-05-19T15:13:02.203" timestamp_utc="2026-05-19T14:13:02.203" last_modified="2026-05-19T15:20:55" version="1779200454932">
+      <Q id="6428720505" qualifier_id="13"/>
+      <Q id="6428720507" qualifier_id="56" value="Back"/>
+      <Q id="6428720509" qualifier_id="152"/>
+      <Q id="6428720997" qualifier_id="233" value="878"/>
+      <Q id="6428720513" qualifier_id="286"/>
+      <Q id="6428727967" qualifier_id="295"/>
+    </Event>
+    <Event id="2939850381" event_id="878" type_id="4" period_id="2" min="95" sec="1" player_id="627127" team_id="244" outcome="0" x="56.2" y="69.6" timestamp="2026-05-19T15:13:02.204" timestamp_utc="2026-05-19T14:13:02.204" last_modified="2026-05-19T15:20:55" version="1779200454940">
+      <Q id="6428720545" qualifier_id="13"/>
+      <Q id="6428720549" qualifier_id="56" value="Center"/>
+      <Q id="6428720551" qualifier_id="152"/>
+      <Q id="6428721003" qualifier_id="233" value="768"/>
+      <Q id="6428720995" qualifier_id="285"/>
+      <Q id="6428720547" qualifier_id="295"/>
+    </Event>
+    <Event id="2939850417" event_id="769" type_id="1" period_id="2" min="95" sec="10" player_id="683488" team_id="417" outcome="1" x="45.0" y="23.9" timestamp="2026-05-19T15:13:11.119" timestamp_utc="2026-05-19T14:13:11.119" last_modified="2026-05-19T15:13:13" version="1779199991395">
+      <Q id="6428720711" qualifier_id="5"/>
+      <Q id="6428720715" qualifier_id="56" value="Back"/>
+      <Q id="6428720717" qualifier_id="140" value="41.5"/>
+      <Q id="6428720719" qualifier_id="141" value="51.8"/>
+      <Q id="6428720713" qualifier_id="152"/>
+      <Q id="6428720721" qualifier_id="212" value="19.3"/>
+      <Q id="6428720723" qualifier_id="213" value="1.76"/>
+    </Event>
+    <Event id="2939850441" event_id="770" type_id="1" period_id="2" min="95" sec="12" player_id="624620" team_id="417" outcome="1" x="46.2" y="59.1" timestamp="2026-05-19T15:13:13.546" timestamp_utc="2026-05-19T14:13:13.546" last_modified="2026-05-19T15:13:20" version="1779199994260">
+      <Q id="6428720855" qualifier_id="56" value="Left"/>
+      <Q id="6428720857" qualifier_id="140" value="61.6"/>
+      <Q id="6428720859" qualifier_id="141" value="85.3"/>
+      <Q id="6428720861" qualifier_id="212" value="24.1"/>
+      <Q id="6428720863" qualifier_id="213" value="0.83"/>
+    </Event>
+    <Event id="2939850445" event_id="771" type_id="1" period_id="2" min="95" sec="19" player_id="61778" team_id="417" outcome="0" x="62.4" y="86.8" timestamp="2026-05-19T15:13:19.987" timestamp_utc="2026-05-19T14:13:19.987" last_modified="2026-05-19T15:13:20" version="1779200000357">
+      <Q id="6428720885" qualifier_id="56" value="Left"/>
+      <Q id="6428720887" qualifier_id="140" value="62.4"/>
+      <Q id="6428720889" qualifier_id="141" value="86.3"/>
+      <Q id="6428720883" qualifier_id="155"/>
+      <Q id="6428720891" qualifier_id="212" value="0.3"/>
+      <Q id="6428720893" qualifier_id="213" value="4.71"/>
+    </Event>
+    <Event id="2939850453" event_id="879" type_id="61" period_id="2" min="95" sec="21" player_id="240166" team_id="244" outcome="1" x="36.6" y="18.0" timestamp="2026-05-19T15:13:22.094" timestamp_utc="2026-05-19T14:13:22.094" last_modified="2026-05-19T15:13:22" version="1779200002095">
+      <Q id="6428720933" qualifier_id="56" value="Back"/>
+    </Event>
+    <Event id="2939850457" event_id="880" type_id="5" period_id="2" min="95" sec="21" player_id="240166" team_id="244" outcome="0" x="40.8" y="-1.1" timestamp="2026-05-19T15:13:22.226" timestamp_utc="2026-05-19T14:13:22.226" last_modified="2026-05-19T15:26:40" version="1779200790363">
+      <Q id="6428720951" qualifier_id="56" value="Back"/>
+      <Q id="6428721069" qualifier_id="233" value="772"/>
+      <Q id="6428720953" qualifier_id="347"/>
+    </Event>
+    <Event id="2939850469" event_id="772" type_id="5" period_id="2" min="95" sec="21" player_id="61778" team_id="417" outcome="1" x="59.2" y="101.1" timestamp="2026-05-19T15:13:22.226" timestamp_utc="2026-05-19T14:13:22.226" last_modified="2026-05-19T15:26:39" version="1779200790358">
+      <Q id="6428721029" qualifier_id="56" value="Left"/>
+      <Q id="6428721061" qualifier_id="233" value="880"/>
+      <Q id="6428721031" qualifier_id="347"/>
+    </Event>
+    <Event id="2939850483" event_id="773" type_id="1" period_id="2" min="95" sec="33" player_id="61778" team_id="417" outcome="1" x="59.9" y="100.0" timestamp="2026-05-19T15:13:33.886" timestamp_utc="2026-05-19T14:13:33.886" last_modified="2026-05-19T15:13:38" version="1779200014723">
+      <Q id="6428721127" qualifier_id="56" value="Left"/>
+      <Q id="6428721125" qualifier_id="107"/>
+      <Q id="6428721129" qualifier_id="140" value="72.2"/>
+      <Q id="6428721131" qualifier_id="141" value="87.8"/>
+      <Q id="6428721133" qualifier_id="212" value="15.9"/>
+      <Q id="6428721135" qualifier_id="213" value="5.66"/>
+    </Event>
+    <Event id="2939850485" event_id="774" type_id="1" period_id="2" min="95" sec="36" player_id="624620" team_id="417" outcome="0" x="71.2" y="86.9" timestamp="2026-05-19T15:13:36.874" timestamp_utc="2026-05-19T14:13:36.874" last_modified="2026-05-19T15:45:19" version="1779201919466">
+      <Q id="6428721143" qualifier_id="56" value="Left"/>
+      <Q id="6428721145" qualifier_id="140" value="73.8"/>
+      <Q id="6428721147" qualifier_id="141" value="86.9"/>
+      <Q id="6428721141" qualifier_id="168"/>
+      <Q id="6428721149" qualifier_id="212" value="2.7"/>
+      <Q id="6428721151" qualifier_id="213" value="0.00"/>
+    </Event>
+    <Event id="2939850487" event_id="881" type_id="1" period_id="2" min="95" sec="36" player_id="180662" team_id="244" outcome="1" x="14.5" y="17.7" timestamp="2026-05-19T15:13:37.390" timestamp_utc="2026-05-19T14:13:37.390" last_modified="2026-05-19T15:13:39" version="1779200018757">
+      <Q id="6428721177" qualifier_id="1"/>
+      <Q id="6428721167" qualifier_id="56" value="Back"/>
+      <Q id="6428721169" qualifier_id="140" value="44.9"/>
+      <Q id="6428721171" qualifier_id="141" value="19.4"/>
+      <Q id="6428721165" qualifier_id="157"/>
+      <Q id="6428721173" qualifier_id="212" value="31.9"/>
+      <Q id="6428721175" qualifier_id="213" value="0.04"/>
+    </Event>
+    <Event id="2939850489" event_id="882" type_id="49" period_id="2" min="95" sec="39" player_id="508143" team_id="244" outcome="1" x="42.3" y="22.5" timestamp="2026-05-19T15:13:39.678" timestamp_utc="2026-05-19T14:13:39.678" last_modified="2026-05-19T15:13:40" version="1779200019679"/>
+    <Event id="2939850499" event_id="883" type_id="1" period_id="2" min="95" sec="39" player_id="508143" team_id="244" outcome="1" x="42.3" y="22.5" keypass="1" timestamp="2026-05-19T15:13:39.821" timestamp_utc="2026-05-19T14:13:39.821" last_modified="2026-05-19T15:14:03" version="1779200043839">
+      <Q id="6428721261" qualifier_id="56" value="Back"/>
+      <Q id="6428721263" qualifier_id="140" value="45.0"/>
+      <Q id="6428721265" qualifier_id="141" value="15.0"/>
+      <Q id="6428721685" qualifier_id="210" value="15"/>
+      <Q id="6428721267" qualifier_id="212" value="5.8"/>
+      <Q id="6428721269" qualifier_id="213" value="5.22"/>
+    </Event>
+    <Event id="2939850501" event_id="884" type_id="15" period_id="2" min="95" sec="48" player_id="482450" team_id="244" outcome="1" x="91.5" y="33.6" timestamp="2026-05-19T15:13:49.157" timestamp_utc="2026-05-19T14:13:49.157" last_modified="2026-05-19T16:12:20" version="1779203540845">
+      <Q id="6428721509" qualifier_id="20"/>
+      <Q id="6428754259" qualifier_id="23"/>
+      <Q id="6428721691" qualifier_id="29"/>
+      <Q id="6428721693" qualifier_id="55" value="883"/>
+      <Q id="6428721277" qualifier_id="56" value="Center"/>
+      <Q id="6428721275" qualifier_id="63"/>
+      <Q id="6428755227" qualifier_id="76"/>
+      <Q id="6428721513" qualifier_id="82"/>
+      <Q id="6428721703" qualifier_id="100"/>
+      <Q id="6428755229" qualifier_id="101"/>
+      <Q id="6428721697" qualifier_id="102" value="52.3"/>
+      <Q id="6428721699" qualifier_id="103" value="19.0"/>
+      <Q id="6428721705" qualifier_id="146" value="97.6"/>
+      <Q id="6428721707" qualifier_id="147" value="46.9"/>
+      <Q id="6428721701" qualifier_id="215"/>
+      <Q id="6428721709" qualifier_id="230" value="97.5"/>
+      <Q id="6428721711" qualifier_id="231" value="42.8"/>
+      <Q id="6428721713" qualifier_id="233" value="775"/>
+    </Event>
+    <Event id="2939850509" event_id="775" type_id="10" period_id="2" min="95" sec="48" player_id="531784" team_id="417" outcome="1" x="1.5" y="54.5" timestamp="2026-05-19T15:13:49.257" timestamp_utc="2026-05-19T14:13:49.257" last_modified="2026-05-19T16:12:29" version="1779203549755">
+      <Q id="6428755335" qualifier_id="14"/>
+      <Q id="6428721325" qualifier_id="56" value="Back"/>
+      <Q id="6428721323" qualifier_id="94"/>
+      <Q id="6428721717" qualifier_id="233" value="884"/>
+    </Event>
+    <Event id="2939850525" event_id="776" type_id="12" period_id="2" min="95" sec="53" player_id="720789" team_id="417" outcome="1" x="9.6" y="39.5" timestamp="2026-05-19T15:13:53.890" timestamp_utc="2026-05-19T14:13:53.890" last_modified="2026-05-19T15:13:59" version="1779200034125">
+      <Q id="6428721483" qualifier_id="56" value="Back"/>
+      <Q id="6428721485" qualifier_id="140" value="28.0"/>
+      <Q id="6428721487" qualifier_id="141" value="20.4"/>
+      <Q id="6428721489" qualifier_id="212" value="23.3"/>
+      <Q id="6428721491" qualifier_id="213" value="5.69"/>
+    </Event>
+    <Event id="2939850519" event_id="885" type_id="1" period_id="2" min="95" sec="57" player_id="575855" team_id="244" outcome="0" x="69.0" y="91.1" timestamp="2026-05-19T15:13:57.836" timestamp_utc="2026-05-19T14:13:57.836" last_modified="2026-05-19T15:13:58" version="1779200038312">
+      <Q id="6428721447" qualifier_id="56" value="Left"/>
+      <Q id="6428721449" qualifier_id="140" value="75.6"/>
+      <Q id="6428721451" qualifier_id="141" value="100.0"/>
+      <Q id="6428721453" qualifier_id="212" value="9.7"/>
+      <Q id="6428721455" qualifier_id="213" value="0.78"/>
+    </Event>
+    <Event id="2939850521" event_id="886" type_id="5" period_id="2" min="95" sec="57" player_id="575855" team_id="244" outcome="0" x="75.6" y="101.3" timestamp="2026-05-19T15:13:58.333" timestamp_utc="2026-05-19T14:13:58.333" last_modified="2026-05-19T15:26:40" version="1779200790378">
+      <Q id="6428721457" qualifier_id="56" value="Left"/>
+      <Q id="6428721649" qualifier_id="233" value="777"/>
+      <Q id="6428721459" qualifier_id="347"/>
+    </Event>
+    <Event id="2939850537" event_id="777" type_id="5" period_id="2" min="95" sec="57" player_id="720789" team_id="417" outcome="1" x="24.4" y="-1.3" timestamp="2026-05-19T15:13:58.333" timestamp_utc="2026-05-19T14:13:58.333" last_modified="2026-05-19T15:26:40" version="1779200790370">
+      <Q id="6428721619" qualifier_id="56" value="Back"/>
+      <Q id="6428721625" qualifier_id="233" value="886"/>
+      <Q id="6428721621" qualifier_id="347"/>
+    </Event>
+    <Event id="2939850543" event_id="778" type_id="1" period_id="2" min="95" sec="59" player_id="157851" team_id="417" outcome="1" x="24.8" y="0.0" timestamp="2026-05-19T15:14:00.498" timestamp_utc="2026-05-19T14:14:00.498" last_modified="2026-05-19T15:24:02" version="1779200642392">
+      <Q id="6428721655" qualifier_id="56" value="Back"/>
+      <Q id="6428721653" qualifier_id="107"/>
+      <Q id="6428721657" qualifier_id="140" value="39.1"/>
+      <Q id="6428721659" qualifier_id="141" value="12.5"/>
+      <Q id="6428721661" qualifier_id="212" value="17.9"/>
+      <Q id="6428721663" qualifier_id="213" value="0.57"/>
+    </Event>
+    <Event id="2939850663" event_id="780" type_id="1" period_id="2" min="96" sec="0" player_id="445539" team_id="417" outcome="0" x="42.2" y="12.0" timestamp="2026-05-19T15:14:01.482" timestamp_utc="2026-05-19T14:14:01.482" last_modified="2026-05-19T15:23:58" version="1779200638015">
+      <Q id="6428722541" qualifier_id="56" value="Back"/>
+      <Q id="6428722543" qualifier_id="140" value="49.4"/>
+      <Q id="6428722545" qualifier_id="141" value="13.5"/>
+      <Q id="6428722547" qualifier_id="212" value="7.6"/>
+      <Q id="6428722549" qualifier_id="213" value="0.13"/>
+      <Q id="6428722557" qualifier_id="233" value="893"/>
+      <Q id="6428722551" qualifier_id="236"/>
+      <Q id="6428722555" qualifier_id="286"/>
+    </Event>
+    <Event id="2939850661" event_id="893" type_id="74" period_id="2" min="96" sec="0" player_id="627127" team_id="244" outcome="1" x="50.6" y="86.5" timestamp="2026-05-19T15:14:01.483" timestamp_utc="2026-05-19T14:14:01.483" last_modified="2026-05-19T15:45:54" version="1779201954342">
+      <Q id="6428722537" qualifier_id="56" value="Left"/>
+      <Q id="6428722563" qualifier_id="233" value="780"/>
+      <Q id="6428722539" qualifier_id="285"/>
+    </Event>
+    <Event id="2939850581" event_id="889" type_id="49" period_id="2" min="96" sec="4" player_id="627127" team_id="244" outcome="1" x="54.4" y="80.8" timestamp="2026-05-19T15:14:05.109" timestamp_utc="2026-05-19T14:14:05.109" last_modified="2026-05-19T15:14:27" version="1779200067280"/>
+    <Event id="2939850561" event_id="887" type_id="1" period_id="2" min="96" sec="5" player_id="627127" team_id="244" outcome="1" x="47.0" y="82.1" timestamp="2026-05-19T15:14:05.772" timestamp_utc="2026-05-19T14:14:05.772" last_modified="2026-05-19T15:14:12" version="1779200048096">
+      <Q id="6428721827" qualifier_id="56" value="Center"/>
+      <Q id="6428721829" qualifier_id="140" value="58.6"/>
+      <Q id="6428721831" qualifier_id="141" value="72.1"/>
+      <Q id="6428721833" qualifier_id="212" value="13.9"/>
+      <Q id="6428721835" qualifier_id="213" value="5.77"/>
+    </Event>
+    <Event id="2939850563" event_id="888" type_id="4" period_id="2" min="96" sec="12" player_id="246081" team_id="244" outcome="1" x="59.6" y="76.8" timestamp="2026-05-19T15:14:12.820" timestamp_utc="2026-05-19T14:14:12.820" last_modified="2026-05-19T15:26:42" version="1779200795473">
+      <Q id="6428721853" qualifier_id="13"/>
+      <Q id="6428721855" qualifier_id="56" value="Center"/>
+      <Q id="6428721857" qualifier_id="152"/>
+      <Q id="6428727995" qualifier_id="233" value="779"/>
+      <Q id="6428721859" qualifier_id="265"/>
+      <Q id="6428721861" qualifier_id="286"/>
+    </Event>
+    <Event id="2939850569" event_id="779" type_id="4" period_id="2" min="96" sec="12" player_id="683488" team_id="417" outcome="0" x="40.4" y="23.2" timestamp="2026-05-19T15:14:12.821" timestamp_utc="2026-05-19T14:14:12.821" last_modified="2026-05-19T15:26:42" version="1779200795481">
+      <Q id="6428721941" qualifier_id="13"/>
+      <Q id="6428721943" qualifier_id="56" value="Back"/>
+      <Q id="6428721945" qualifier_id="152"/>
+      <Q id="6428727999" qualifier_id="233" value="888"/>
+      <Q id="6428721947" qualifier_id="265"/>
+      <Q id="6428721949" qualifier_id="285"/>
+    </Event>
+    <Event id="2939850727" event_id="781" type_id="17" period_id="2" min="97" sec="15" player_id="683488" team_id="417" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T15:15:16.409" timestamp_utc="2026-05-19T14:15:16.409" last_modified="2026-05-19T15:16:01" version="1779200160773">
+      <Q id="6428723017" qualifier_id="13" value="243"/>
+      <Q id="6428723013" qualifier_id="31"/>
+      <Q id="6428723203" qualifier_id="189"/>
+      <Q id="6428723015" qualifier_id="392"/>
+    </Event>
+    <Event id="2939850839" event_id="895" type_id="1" period_id="2" min="98" sec="26" player_id="575855" team_id="244" outcome="1" x="57.5" y="80.9" timestamp="2026-05-19T15:16:27.317" timestamp_utc="2026-05-19T14:16:27.317" last_modified="2026-05-19T15:18:20" version="1779200300395">
+      <Q id="6428723585" qualifier_id="5"/>
+      <Q id="6428723589" qualifier_id="56" value="Left"/>
+      <Q id="6428723591" qualifier_id="140" value="69.5"/>
+      <Q id="6428723593" qualifier_id="141" value="91.8"/>
+      <Q id="6428723587" qualifier_id="152"/>
+      <Q id="6428723595" qualifier_id="212" value="14.6"/>
+      <Q id="6428723597" qualifier_id="213" value="0.53"/>
+    </Event>
+    <Event id="2939850843" event_id="896" type_id="3" period_id="2" min="98" sec="28" player_id="207884" team_id="244" outcome="0" x="70.8" y="92.8" timestamp="2026-05-19T15:16:28.788" timestamp_utc="2026-05-19T14:16:28.788" last_modified="2026-05-19T15:16:34" version="1779200192136">
+      <Q id="6428723617" qualifier_id="56" value="Left"/>
+      <Q id="6428723679" qualifier_id="233" value="782"/>
+      <Q id="6428723619" qualifier_id="286"/>
+    </Event>
+    <Event id="2939850849" event_id="782" type_id="7" period_id="2" min="98" sec="28" player_id="157851" team_id="417" outcome="1" x="29.3" y="7.2" timestamp="2026-05-19T15:16:28.789" timestamp_utc="2026-05-19T14:16:28.789" last_modified="2026-05-19T15:16:34" version="1779200192166">
+      <Q id="6428723651" qualifier_id="56" value="Back"/>
+      <Q id="6428723649" qualifier_id="167"/>
+      <Q id="6428723655" qualifier_id="178"/>
+      <Q id="6428723657" qualifier_id="233" value="896"/>
+      <Q id="6428723653" qualifier_id="285"/>
+    </Event>
+    <Event id="2939850859" event_id="783" type_id="5" period_id="2" min="98" sec="29" player_id="157851" team_id="417" outcome="0" x="30.6" y="-1.0" timestamp="2026-05-19T15:16:29.869" timestamp_utc="2026-05-19T14:16:29.869" last_modified="2026-05-19T15:26:41" version="1779200790392">
+      <Q id="6428723709" qualifier_id="56" value="Back"/>
+      <Q id="6428723801" qualifier_id="233" value="897"/>
+      <Q id="6428723711" qualifier_id="347"/>
+    </Event>
+    <Event id="2939850873" event_id="897" type_id="5" period_id="2" min="98" sec="29" player_id="207884" team_id="244" outcome="1" x="69.4" y="101.0" timestamp="2026-05-19T15:16:29.869" timestamp_utc="2026-05-19T14:16:29.869" last_modified="2026-05-19T15:26:40" version="1779200790386">
+      <Q id="6428723769" qualifier_id="56" value="Left"/>
+      <Q id="6428723791" qualifier_id="233" value="783"/>
+      <Q id="6428723771" qualifier_id="347"/>
+    </Event>
+    <Event id="2939850891" event_id="898" type_id="1" period_id="2" min="98" sec="41" player_id="575855" team_id="244" outcome="1" x="62.8" y="100.0" timestamp="2026-05-19T15:16:42.316" timestamp_utc="2026-05-19T14:16:42.316" last_modified="2026-05-19T15:16:47" version="1779200203663">
+      <Q id="6428723889" qualifier_id="56" value="Left"/>
+      <Q id="6428723887" qualifier_id="107"/>
+      <Q id="6428723891" qualifier_id="140" value="76.1"/>
+      <Q id="6428723893" qualifier_id="141" value="92.0"/>
+      <Q id="6428723895" qualifier_id="212" value="15.5"/>
+      <Q id="6428723897" qualifier_id="213" value="5.83"/>
+    </Event>
+    <Event id="2939850893" event_id="899" type_id="1" period_id="2" min="98" sec="46" player_id="508143" team_id="244" outcome="0" x="81.9" y="95.7" timestamp="2026-05-19T15:16:47.380" timestamp_utc="2026-05-19T14:16:47.380" last_modified="2026-05-19T15:16:48" version="1779200207861">
+      <Q id="6428723901" qualifier_id="56" value="Left"/>
+      <Q id="6428723903" qualifier_id="140" value="100.0"/>
+      <Q id="6428723905" qualifier_id="141" value="85.9"/>
+      <Q id="6428723907" qualifier_id="212" value="20.5"/>
+      <Q id="6428723909" qualifier_id="213" value="5.95"/>
+    </Event>
+    <Event id="2939850901" event_id="784" type_id="5" period_id="2" min="98" sec="47" player_id="157851" team_id="417" outcome="1" x="-0.8" y="14.8" timestamp="2026-05-19T15:16:47.874" timestamp_utc="2026-05-19T14:16:47.874" last_modified="2026-05-19T15:26:41" version="1779200790400">
+      <Q id="6428723953" qualifier_id="56" value="Back"/>
+      <Q id="6428724265" qualifier_id="233" value="900"/>
+      <Q id="6428723955" qualifier_id="346"/>
+    </Event>
+    <Event id="2939850957" event_id="900" type_id="5" period_id="2" min="98" sec="47" player_id="508143" team_id="244" outcome="0" x="100.8" y="85.2" timestamp="2026-05-19T15:16:47.874" timestamp_utc="2026-05-19T14:16:47.874" last_modified="2026-05-19T15:17:08" version="1779200227671">
+      <Q id="6428724259" qualifier_id="56" value="Left"/>
+      <Q id="6428724269" qualifier_id="233" value="784"/>
+      <Q id="6428724261" qualifier_id="346"/>
+    </Event>
+    <Event id="2939850919" event_id="785" type_id="1" period_id="2" min="98" sec="49" player_id="565487" team_id="417" outcome="1" x="3.9" y="51.6" timestamp="2026-05-19T15:16:49.952" timestamp_utc="2026-05-19T14:16:49.952" last_modified="2026-05-19T15:16:56" version="1779200210200">
+      <Q id="6428724041" qualifier_id="56" value="Back"/>
+      <Q id="6428724039" qualifier_id="124"/>
+      <Q id="6428724043" qualifier_id="140" value="18.5"/>
+      <Q id="6428724045" qualifier_id="141" value="73.3"/>
+      <Q id="6428724047" qualifier_id="212" value="21.3"/>
+      <Q id="6428724049" qualifier_id="213" value="0.77"/>
+      <Q id="6428724053" qualifier_id="237"/>
+    </Event>
+    <Event id="2939850923" event_id="786" type_id="1" period_id="2" min="98" sec="55" player_id="570078" team_id="417" outcome="1" x="36.4" y="78.7" timestamp="2026-05-19T15:16:55.952" timestamp_utc="2026-05-19T14:16:55.952" last_modified="2026-05-19T15:16:57" version="1779200216489">
+      <Q id="6428724069" qualifier_id="56" value="Left"/>
+      <Q id="6428724071" qualifier_id="140" value="58.8"/>
+      <Q id="6428724073" qualifier_id="141" value="85.9"/>
+      <Q id="6428724075" qualifier_id="212" value="24.0"/>
+      <Q id="6428724077" qualifier_id="213" value="0.21"/>
+    </Event>
+    <Event id="2939850953" event_id="787" type_id="1" period_id="2" min="98" sec="57" player_id="61778" team_id="417" outcome="1" x="58.8" y="85.9" timestamp="2026-05-19T15:16:57.728" timestamp_utc="2026-05-19T14:16:57.728" last_modified="2026-05-19T15:17:03" version="1779200218201">
+      <Q id="6428724217" qualifier_id="56" value="Center"/>
+      <Q id="6428724219" qualifier_id="140" value="76.2"/>
+      <Q id="6428724221" qualifier_id="141" value="77.3"/>
+      <Q id="6428724223" qualifier_id="212" value="19.2"/>
+      <Q id="6428724225" qualifier_id="213" value="5.97"/>
+    </Event>
+    <Event id="2939850967" event_id="788" type_id="1" period_id="2" min="99" sec="3" player_id="624620" team_id="417" outcome="1" x="96.8" y="81.5" keypass="1" timestamp="2026-05-19T15:17:03.608" timestamp_utc="2026-05-19T14:17:03.608" last_modified="2026-05-19T16:31:40" version="1779204700818">
+      <Q id="6428724299" qualifier_id="2"/>
+      <Q id="6428724303" qualifier_id="56" value="Center"/>
+      <Q id="6428724305" qualifier_id="140" value="85.6"/>
+      <Q id="6428724307" qualifier_id="141" value="40.1"/>
+      <Q id="6428725365" qualifier_id="154"/>
+      <Q id="6428724301" qualifier_id="155"/>
+      <Q id="6428725363" qualifier_id="210" value="13"/>
+      <Q id="6428724309" qualifier_id="212" value="30.5"/>
+      <Q id="6428724311" qualifier_id="213" value="4.32"/>
+    </Event>
+    <Event id="2939850969" event_id="789" type_id="13" period_id="2" min="99" sec="7" player_id="157851" team_id="417" outcome="1" x="85.6" y="40.1" timestamp="2026-05-19T15:17:08.072" timestamp_utc="2026-05-19T14:17:08.072" last_modified="2026-05-19T15:55:23" version="1779202523222">
+      <Q id="6428724317" qualifier_id="17"/>
+      <Q id="6428725371" qualifier_id="20"/>
+      <Q id="6428724315" qualifier_id="22"/>
+      <Q id="6428725375" qualifier_id="29"/>
+      <Q id="6428725379" qualifier_id="55" value="788"/>
+      <Q id="6428724319" qualifier_id="56" value="Center"/>
+      <Q id="6428725373" qualifier_id="73"/>
+      <Q id="6428725383" qualifier_id="102" value="63.2"/>
+      <Q id="6428725385" qualifier_id="103" value="18.1"/>
+      <Q id="6428725391" qualifier_id="146" value="87.2"/>
+      <Q id="6428725393" qualifier_id="147" value="50.2"/>
+      <Q id="6428725389" qualifier_id="153"/>
+      <Q id="6428725377" qualifier_id="154"/>
+      <Q id="6428725395" qualifier_id="230" value="98.5"/>
+      <Q id="6428725397" qualifier_id="231" value="48.4"/>
+      <Q id="6428740957" qualifier_id="328"/>
+    </Event>
+    <Event id="2939850963" event_id="902" type_id="43" period_id="2" min="99" sec="8" player_id="627127" team_id="244" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T15:17:08.643" timestamp_utc="2026-05-19T14:17:08.643" last_modified="2026-05-19T15:17:12" version="1779200228644">
+      <Q id="6428724379" qualifier_id="144" value="49"/>
+    </Event>
+    <Event id="2939850959" event_id="901" type_id="61" period_id="2" min="99" sec="8" player_id="508143" team_id="244" outcome="1" x="14.1" y="36.3" timestamp="2026-05-19T15:17:09.402" timestamp_utc="2026-05-19T14:17:09.402" last_modified="2026-05-19T15:21:17" version="1779200477665">
+      <Q id="6428724267" qualifier_id="56" value="Back"/>
+    </Event>
+    <Event id="2939850995" event_id="903" type_id="30" period_id="2" min="99" sec="17" team_id="244" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T15:17:17.917" timestamp_utc="2026-05-19T14:17:17.917" last_modified="2026-05-19T15:17:18" version="1779200237923">
+      <Q id="6428724483" qualifier_id="57" value="0"/>
+      <Q id="6428724485" qualifier_id="209"/>
+    </Event>
+    <Event id="2939850997" event_id="790" type_id="30" period_id="2" min="99" sec="17" team_id="417" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T15:17:17.917" timestamp_utc="2026-05-19T14:17:17.917" last_modified="2026-05-19T15:17:18" version="1779200238417">
+      <Q id="6428724487" qualifier_id="57" value="0"/>
+      <Q id="6428724489" qualifier_id="209"/>
+    </Event>
+    <Event id="2939662025" event_id="261" type_id="43" period_id="14" min="0" sec="0" team_id="417" outcome="1" x="0.0" y="0.0" timestamp="2026-05-18T19:34:12.723" timestamp_utc="2026-05-18T18:34:12.723" last_modified="2026-05-19T13:13:35" version="1779129252724">
+      <Q id="6427659487" qualifier_id="54" value="3"/>
+      <Q id="6427659485" qualifier_id="57" value="1"/>
+      <Q id="6428523521" qualifier_id="144" value="30"/>
+      <Q id="6427659489" qualifier_id="209" value="0"/>
+    </Event>
+    <Event id="2939662035" event_id="387" type_id="43" period_id="14" min="0" sec="0" team_id="244" outcome="1" x="0.0" y="0.0" timestamp="2026-05-18T19:34:12.723" timestamp_utc="2026-05-18T18:34:12.723" last_modified="2026-05-19T13:13:35" version="1779129252748">
+      <Q id="6427659515" qualifier_id="54" value="3"/>
+      <Q id="6427659513" qualifier_id="57" value="1"/>
+      <Q id="6428523569" qualifier_id="144" value="30"/>
+      <Q id="6427659517" qualifier_id="209" value="0"/>
+    </Event>
+    <Event id="2939662031" event_id="262" type_id="43" period_id="14" min="0" sec="0" team_id="417" outcome="1" x="0.0" y="0.0" timestamp="2026-05-18T19:34:12.740" timestamp_utc="2026-05-18T18:34:12.740" last_modified="2026-05-19T13:13:34" version="1779129700219">
+      <Q id="6428523509" qualifier_id="144" value="37"/>
+      <Q id="6427689379" qualifier_id="302" value="0"/>
+    </Event>
+    <Event id="2939662043" event_id="388" type_id="43" period_id="14" min="0" sec="0" team_id="244" outcome="1" x="0.0" y="0.0" timestamp="2026-05-18T19:34:12.740" timestamp_utc="2026-05-18T18:34:12.740" last_modified="2026-05-19T13:13:35" version="1779129700224">
+      <Q id="6428523533" qualifier_id="144" value="37"/>
+      <Q id="6427689737" qualifier_id="302" value="0"/>
+    </Event>
+    <Event id="2939816633" event_id="264" type_id="43" period_id="14" min="0" sec="0" team_id="417" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T13:13:37.331" timestamp_utc="2026-05-19T12:13:37.331" last_modified="2026-05-19T13:13:49" version="1779192817332">
+      <Q id="6428523673" qualifier_id="54" value="2"/>
+      <Q id="6428523671" qualifier_id="57" value="1"/>
+      <Q id="6428524057" qualifier_id="144" value="30"/>
+      <Q id="6428523675" qualifier_id="209" value="0"/>
+      <Q id="6428523677" qualifier_id="226" value="0"/>
+    </Event>
+    <Event id="2939816637" event_id="390" type_id="43" period_id="14" min="0" sec="0" team_id="244" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T13:13:37.331" timestamp_utc="2026-05-19T12:13:37.331" last_modified="2026-05-19T13:14:01" version="1779192817378">
+      <Q id="6428523709" qualifier_id="54" value="2"/>
+      <Q id="6428523707" qualifier_id="57" value="1"/>
+      <Q id="6428524443" qualifier_id="144" value="30"/>
+      <Q id="6428523711" qualifier_id="209" value="0"/>
+      <Q id="6428523713" qualifier_id="226" value="0"/>
+    </Event>
+    <Event id="2939816641" event_id="265" type_id="43" period_id="14" min="0" sec="0" team_id="417" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T13:13:37.381" timestamp_utc="2026-05-19T12:13:37.381" last_modified="2026-05-19T13:13:48" version="1779192817382">
+      <Q id="6428524041" qualifier_id="144" value="37"/>
+    </Event>
+    <Event id="2939816643" event_id="391" type_id="43" period_id="14" min="0" sec="0" team_id="244" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T13:13:37.381" timestamp_utc="2026-05-19T12:13:37.381" last_modified="2026-05-19T13:14:01" version="1779192817387">
+      <Q id="6428524421" qualifier_id="144" value="37"/>
+    </Event>
+    <Event id="2939851007" event_id="904" type_id="30" period_id="14" min="0" sec="0" team_id="244" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T15:17:19.933" timestamp_utc="2026-05-19T14:17:19.933" last_modified="2026-05-19T15:17:20" version="1779200239936">
+      <Q id="6428724537" qualifier_id="57" value="1"/>
+      <Q id="6428724539" qualifier_id="209"/>
+    </Event>
+    <Event id="2939851019" event_id="791" type_id="30" period_id="14" min="0" sec="0" team_id="417" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T15:17:19.933" timestamp_utc="2026-05-19T14:17:19.933" last_modified="2026-05-19T15:17:22" version="1779200242758">
+      <Q id="6428724607" qualifier_id="57" value="1"/>
+      <Q id="6428724609" qualifier_id="209"/>
+    </Event>
+    <Event id="2939851009" event_id="905" type_id="37" period_id="14" min="0" sec="0" team_id="244" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T15:17:19.948" timestamp_utc="2026-05-19T14:17:19.948" last_modified="2026-05-19T16:32:15" version="1779204735275">
+      <Q id="6428732471" qualifier_id="302"/>
+    </Event>
+    <Event id="2939851023" event_id="792" type_id="37" period_id="14" min="0" sec="0" team_id="417" outcome="1" x="0.0" y="0.0" timestamp="2026-05-19T15:17:19.948" timestamp_utc="2026-05-19T14:17:19.948" last_modified="2026-05-19T16:32:15" version="1779204735281">
+      <Q id="6428732625" qualifier_id="302"/>
+    </Event>
+  </Game>
+</Games>

--- a/kloppy/tests/files/opta_abandonment_f7.xml
+++ b/kloppy/tests/files/opta_abandonment_f7.xml
@@ -1,0 +1,400 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2001-2026 Opta Sportsdata Ltd. All rights reserved. -->
+
+<!-- PRODUCTION HEADER
+     produced on:        inxopta-djobq07.nexus.opta.net
+     production time:    20260519T153219,759Z
+     production module:  Opta::Feed::XML::Soccer::F7
+-->
+<SoccerFeed TimeStamp="20260519T163218+0100">
+  <SoccerDocument Type="Result" detail_id="1" uID="f2615297">
+    <Competition uID="c226">
+      <Country>Sweden</Country>
+      <Name>Swedish Allsvenskan</Name>
+      <Stat Type="season_id">2026</Stat>
+      <Stat Type="season_name">Season 2026/2027</Stat>
+      <Stat Type="symid">SE_AS</Stat>
+      <Stat Type="matchday">8</Stat>
+    </Competition>
+    <MatchData>
+      <MatchInfo AdditionalInfo="Behind Closed Doors" MatchType="Regular" Period="FullTime" PostMatch="1" TimeFrameLengthId="1" TimeStamp="20260519T151719+0100">
+        <Date>20260519T140000+0100</Date>
+        <DateLocal>20260519T150000+0200</DateLocal>
+        <DateUtc>20260519T130000+0000</DateUtc>
+        <Result Type="NormalResult" Winner="t244" />
+      </MatchInfo>
+      <MatchOfficial uID="o43887">
+        <OfficialData>
+          <OfficialRef Type="Main" />
+        </OfficialData>
+        <OfficialName>
+          <First>Glenn</First>
+          <Last>Nyberg</Last>
+        </OfficialName>
+      </MatchOfficial>
+      <AssistantOfficials>
+        <AssistantOfficial FirstName="Mahbod" LastName="Beigi" Type="Assistant Referee 1" uID="o45474" />
+        <AssistantOfficial FirstName="Andreas" LastName="Söderkvist" Type="Assistant Referee 2" uID="o45567" />
+        <AssistantOfficial FirstName="Niclas" LastName="Karlsson" Type="Fourth official" uID="o67795" />
+      </AssistantOfficials>
+      <Stat Type="match_time">100</Stat>
+      <Stat Type="first_half_start">20260518T180549+0100</Stat>
+      <Stat Type="first_half_start_utc">20260518T170549+0000</Stat>
+      <Stat Type="first_half_time">50</Stat>
+      <Stat Type="first_half_stop">20260519T141103+0100</Stat>
+      <Stat Type="first_half_stop_utc">20260519T131103+0000</Stat>
+      <Stat Type="second_half_start">20260519T142300+0100</Stat>
+      <Stat Type="second_half_start_utc">20260519T132300+0000</Stat>
+      <Stat Type="second_half_time">55</Stat>
+      <Stat Type="second_half_stop">20260519T151717+0100</Stat>
+      <Stat Type="second_half_stop_utc">20260519T141717+0000</Stat>
+      <TeamData AverageAge="27.9" Formation="532" Score="2" Side="Home" TeamRef="t417">
+        <Booking Card="Yellow" CardType="Yellow" EventID="2939848879" EventNumber="2891" Min="88" Period="SecondHalf" PlayerRef="p61778" Reason="Dissent" Sec="5" Time="89" TimeStamp="20260519T150605+0100" TimeStampUTC="20260519T140605+0000" uID="b417-1" />
+        <Booking Card="Yellow" CardType="Yellow" EventID="2939849101" EventNumber="2892" ManagerRef="man54876" Min="88" Period="SecondHalf" Reason="Dissent" Sec="40" Time="89" TimeStamp="20260519T150640+0100" TimeStampUTC="20260519T140640+0000" uID="b417-2" />
+        <Booking Card="Yellow" CardType="Yellow" EventID="2939850727" EventNumber="2983" Min="97" Period="SecondHalf" PlayerRef="p683488" Reason="Foul" Sec="15" Time="98" TimeStamp="20260519T151516+0100" TimeStampUTC="20260519T141516+0000" uID="b417-3" />
+        <Goal EventID="2939640345" EventNumber="1374" Min="36" Period="FirstHalf" PlayerRef="p685390" Sec="41" Time="37" TimeStamp="20260518T185404+0100" TimeStampUTC="20260518T175404+0000" Type="Goal" uID="g417-1">
+          <Assist PlayerRef="p61778">p61778</Assist>
+        </Goal>
+        <Goal EventID="2939848649" EventNumber="2875" Min="86" Period="SecondHalf" PlayerRef="p157851" Sec="14" Time="87" TimeStamp="20260519T150414+0100" TimeStampUTC="20260519T140414+0000" Type="Goal" uID="g417-2">
+          <Assist PlayerRef="p61778">p61778</Assist>
+        </Goal>
+        <PlayerLineUp>
+          <MatchPlayer Formation_Place="1" PlayerRef="p565487" Position="Goalkeeper" ShirtNumber="44" Status="Start" />
+          <MatchPlayer Formation_Place="5" PlayerRef="p61812" Position="Defender" ShirtNumber="6" Status="Start" />
+          <MatchPlayer Formation_Place="3" PlayerRef="p164593" Position="Defender" ShirtNumber="19" Status="Start" />
+          <MatchPlayer Formation_Place="6" PlayerRef="p531784" Position="Defender" ShirtNumber="5" Status="Start" />
+          <MatchPlayer Captain="1" Formation_Place="2" PlayerRef="p157851" Position="Defender" ShirtNumber="14" Status="Start" />
+          <MatchPlayer Formation_Place="4" PlayerRef="p624620" Position="Defender" ShirtNumber="2" Status="Start" />
+          <MatchPlayer Formation_Place="8" PlayerRef="p218339" Position="Midfielder" ShirtNumber="23" Status="Start" />
+          <MatchPlayer Formation_Place="7" PlayerRef="p685390" Position="Midfielder" ShirtNumber="17" Status="Start" />
+          <MatchPlayer Formation_Place="11" PlayerRef="p720682" Position="Midfielder" ShirtNumber="8" Status="Start" />
+          <MatchPlayer Formation_Place="10" PlayerRef="p445539" Position="Striker" ShirtNumber="11" Status="Start" />
+          <MatchPlayer Formation_Place="9" PlayerRef="p61778" Position="Striker" ShirtNumber="22" Status="Start" />
+          <MatchPlayer Formation_Place="0" PlayerRef="p548847" Position="Substitute" ShirtNumber="33" Status="Sub" SubPosition="Defender" />
+          <MatchPlayer Formation_Place="0" PlayerRef="p587639" Position="Substitute" ShirtNumber="34" Status="Sub" SubPosition="Goalkeeper" />
+          <MatchPlayer Formation_Place="0" PlayerRef="p731191" Position="Substitute" ShirtNumber="15" Status="Sub" SubPosition="Forward" />
+          <MatchPlayer Formation_Place="0" PlayerRef="p565492" Position="Substitute" ShirtNumber="21" Status="Sub" SubPosition="Midfielder" />
+          <MatchPlayer Formation_Place="0" PlayerRef="p106936" Position="Substitute" ShirtNumber="3" Status="Sub" SubPosition="Defender" />
+          <MatchPlayer Formation_Place="0" PlayerRef="p570081" Position="Substitute" ShirtNumber="24" Status="Sub" SubPosition="Defender" />
+          <MatchPlayer Formation_Place="0" PlayerRef="p720789" Position="Substitute" ShirtNumber="29" Status="Sub" SubPosition="Defender" />
+          <MatchPlayer Formation_Place="0" PlayerRef="p570078" Position="Substitute" ShirtNumber="16" Status="Sub" SubPosition="Defender" />
+          <MatchPlayer Formation_Place="0" PlayerRef="p683488" Position="Substitute" ShirtNumber="25" Status="Sub" SubPosition="Midfielder" />
+        </PlayerLineUp>
+        <Substitution EventID="2939843369" EventNumber="2706" Min="69" Period="2" Reason="Tactical" Sec="12" SubOff="p164593" SubOn="p683488" SubstitutePosition="3" Time="70" TimeStamp="20260519T144713+0100" TimeStampUTC="20260519T134713+0000" uID="s417-1" />
+        <Substitution EventID="2939843407" EventNumber="2707" Min="69" Period="2" Reason="Tactical" Sec="15" SubOff="p218339" SubOn="p570078" SubstitutePosition="2" Time="70" TimeStamp="20260519T144716+0100" TimeStampUTC="20260519T134716+0000" uID="s417-2" />
+        <Substitution EventID="2939845015" EventNumber="2758" Min="74" Period="2" Reason="Tactical" Sec="30" SubOff="p720682" SubOn="p731191" SubstitutePosition="4" Time="75" TimeStamp="20260519T145230+0100" TimeStampUTC="20260519T135230+0000" uID="s417-3" />
+        <Substitution EventID="2939845045" EventNumber="2759" Min="74" Period="2" Reason="Tactical" Sec="30" SubOff="p685390" SubOn="p720789" SubstitutePosition="2" Time="75" TimeStamp="20260519T145231+0100" TimeStampUTC="20260519T135231+0000" uID="s417-4" />
+      </TeamData>
+      <TeamData AverageAge="24.8" Formation="442" Score="3" Side="Away" TeamRef="t244">
+        <Booking Card="Yellow" CardType="Yellow" EventID="2939625661" EventNumber="11810" Min="17" Period="FirstHalf" PlayerRef="p207884" Reason="Foul" Sec="15" Time="18" TimeStamp="20260518T183438+0100" TimeStampUTC="20260518T173438+0000" uID="b244-1" />
+        <Booking Card="Yellow" CardType="Yellow" EventID="2939843069" EventNumber="26911" Min="68" Period="SecondHalf" PlayerRef="p232091" Reason="Foul" Sec="29" Time="69" TimeStamp="20260519T144629+0100" TimeStampUTC="20260519T134629+0000" uID="b244-2" />
+        <Booking Card="Yellow" CardType="Yellow" EventID="2939846279" EventNumber="27912" Min="78" Period="SecondHalf" PlayerRef="p180662" Reason="Foul" Sec="27" Time="79" TimeStamp="20260519T145627+0100" TimeStampUTC="20260519T135627+0000" uID="b244-3" />
+        <Goal EventID="2939628327" EventNumber="12113" Min="20" Period="FirstHalf" PlayerRef="p232091" Sec="11" Time="21" TimeStamp="20260518T183733+0100" TimeStampUTC="20260518T173733+0000" Type="Goal" uID="g244-1">
+          <Assist PlayerRef="p625775">p625775</Assist>
+        </Goal>
+        <Goal EventID="2939634429" EventNumber="12814" Min="27" Period="FirstHalf" PlayerRef="p648131" Sec="47" Time="28" TimeStamp="20260518T184510+0100" TimeStampUTC="20260518T174510+0000" Type="Goal" uID="g244-2">
+          <Assist PlayerRef="p625775">p625775</Assist>
+        </Goal>
+        <Goal EventID="2939849265" EventNumber="29015" Min="89" Period="SecondHalf" PlayerRef="p575855" Sec="45" Time="90" TimeStamp="20260519T150746+0100" TimeStampUTC="20260519T140746+0000" Type="Goal" uID="g244-3">
+          <Assist PlayerRef="p508143">p508143</Assist>
+        </Goal>
+        <PlayerLineUp>
+          <MatchPlayer Formation_Place="1" PlayerRef="p578592" Position="Goalkeeper" ShirtNumber="25" Status="Start" />
+          <MatchPlayer Formation_Place="2" PlayerRef="p240166" Position="Defender" ShirtNumber="17" Status="Start" />
+          <MatchPlayer Formation_Place="3" PlayerRef="p575855" Position="Defender" ShirtNumber="18" Status="Start" />
+          <MatchPlayer Formation_Place="5" PlayerRef="p627127" Position="Defender" ShirtNumber="4" Status="Start" />
+          <MatchPlayer Formation_Place="6" PlayerRef="p180662" Position="Defender" ShirtNumber="5" Status="Start" />
+          <MatchPlayer Formation_Place="7" PlayerRef="p479433" Position="Midfielder" ShirtNumber="29" Status="Start" />
+          <MatchPlayer Formation_Place="8" PlayerRef="p515742" Position="Midfielder" ShirtNumber="15" Status="Start" />
+          <MatchPlayer Formation_Place="11" PlayerRef="p648131" Position="Midfielder" ShirtNumber="26" Status="Start" />
+          <MatchPlayer Captain="1" Formation_Place="4" PlayerRef="p232091" Position="Midfielder" ShirtNumber="3" Status="Start" />
+          <MatchPlayer Formation_Place="9" PlayerRef="p207884" Position="Striker" ShirtNumber="14" Status="Start" />
+          <MatchPlayer Formation_Place="10" PlayerRef="p625775" Position="Striker" ShirtNumber="7" Status="Start" />
+          <MatchPlayer Formation_Place="0" PlayerRef="p246081" Position="Substitute" ShirtNumber="23" Status="Sub" SubPosition="Midfielder" />
+          <MatchPlayer Formation_Place="0" PlayerRef="p495426" Position="Substitute" ShirtNumber="8" Status="Sub" SubPosition="Midfielder" />
+          <MatchPlayer Formation_Place="0" PlayerRef="p508143" Position="Substitute" ShirtNumber="9" Status="Sub" SubPosition="Forward" />
+          <MatchPlayer Formation_Place="0" PlayerRef="p157846" Position="Substitute" ShirtNumber="34" Status="Sub" SubPosition="Goalkeeper" />
+          <MatchPlayer Formation_Place="0" PlayerRef="p531792" Position="Substitute" ShirtNumber="16" Status="Sub" SubPosition="Midfielder" />
+          <MatchPlayer Formation_Place="0" PlayerRef="p482450" Position="Substitute" ShirtNumber="11" Status="Sub" SubPosition="Forward" />
+          <MatchPlayer Formation_Place="0" PlayerRef="p689776" Position="Substitute" ShirtNumber="27" Status="Sub" SubPosition="Forward" />
+          <MatchPlayer Formation_Place="0" PlayerRef="p213399" Position="Substitute" ShirtNumber="10" Status="Sub" SubPosition="Midfielder" />
+          <MatchPlayer Formation_Place="0" PlayerRef="p581866" Position="Substitute" ShirtNumber="30" Status="Sub" SubPosition="Forward" />
+        </PlayerLineUp>
+        <Substitution EventID="2939843457" EventNumber="27016" Min="69" Period="2" Reason="Tactical" Sec="10" SubOff="p625775" SubOn="p508143" SubstitutePosition="4" Time="70" TimeStamp="20260519T144711+0100" TimeStampUTC="20260519T134711+0000" uID="s244-1" />
+        <Substitution EventID="2939843513" EventNumber="26917" Min="68" Period="2" Reason="Tactical" Sec="54" SubOff="p648131" SubOn="p246081" SubstitutePosition="3" Time="69" TimeStamp="20260519T144654+0100" TimeStampUTC="20260519T134654+0000" uID="s244-2" />
+        <Substitution EventID="2939849301" EventNumber="29018" Min="89" Period="2" Reason="Tactical" Sec="20" SubOff="p479433" SubOn="p482450" SubstitutePosition="4" Time="90" TimeStamp="20260519T150721+0100" TimeStampUTC="20260519T140721+0000" uID="s244-3" />
+      </TeamData>
+    </MatchData>
+    <Team uID="t417">
+      <Country>Sweden</Country>
+      <Kit id="28364" colour1="#990000" type="home" />
+      <Name>Örgryte</Name>
+      <Official_name>Örgryte IS</Official_name>
+      <Player Position="Goalkeeper" uID="p565487">
+        <PersonName>
+          <First>Hampus</First>
+          <Last>Gustafsson</Last>
+        </PersonName>
+      </Player>
+      <Player Position="Defender" uID="p61812">
+        <PersonName>
+          <First>Mikael</First>
+          <Last>Dyrestam</Last>
+        </PersonName>
+      </Player>
+      <Player Position="Defender" uID="p164593">
+        <PersonName>
+          <First>Anton</First>
+          <Last>Andreasson</Last>
+        </PersonName>
+      </Player>
+      <Player Position="Defender" uID="p531784">
+        <PersonName>
+          <First>Christoffer</First>
+          <Last>Styffe</Last>
+        </PersonName>
+      </Player>
+      <Player Position="Defender" uID="p157851">
+        <PersonName>
+          <First>Daniel</First>
+          <Last>Paulson</Last>
+        </PersonName>
+      </Player>
+      <Player Position="Defender" uID="p624620">
+        <PersonName>
+          <First>Michael</First>
+          <Last>Parker</Last>
+        </PersonName>
+      </Player>
+      <Player Position="Midfielder" uID="p218339">
+        <PersonName>
+          <First>Owen</First>
+          <Last>Parker-Price</Last>
+        </PersonName>
+      </Player>
+      <Player Position="Midfielder" uID="p685390">
+        <PersonName>
+          <First>William</First>
+          <Last>Hofvander</Last>
+        </PersonName>
+      </Player>
+      <Player Position="Midfielder" uID="p720682">
+        <PersonName>
+          <First>Benjamin</First>
+          <Last>Laturnus</Last>
+        </PersonName>
+      </Player>
+      <Player Position="Striker" uID="p445539">
+        <PersonName>
+          <First>Noah</First>
+          <Last>Christoffersson</Last>
+        </PersonName>
+      </Player>
+      <Player Position="Striker" uID="p61778">
+        <PersonName>
+          <First>Tobias</First>
+          <Last>Sana</Last>
+        </PersonName>
+      </Player>
+      <Player Position="Substitute" uID="p548847">
+        <PersonName>
+          <First>Sebastian</First>
+          <Last>Lagerlund</Last>
+        </PersonName>
+      </Player>
+      <Player Position="Substitute" uID="p587639">
+        <PersonName>
+          <First>Alex</First>
+          <Last>Rahm</Last>
+        </PersonName>
+      </Player>
+      <Player Position="Substitute" uID="p731191">
+        <PersonName>
+          <First>Jerome</First>
+          <Last>Tibbling Ugwo</Last>
+        </PersonName>
+      </Player>
+      <Player Position="Substitute" uID="p565492">
+        <PersonName>
+          <First>William</First>
+          <Last>Kenndal</Last>
+        </PersonName>
+      </Player>
+      <Player Position="Substitute" uID="p106936">
+        <PersonName>
+          <First>Jonathan</First>
+          <Last>Azulay</Last>
+        </PersonName>
+      </Player>
+      <Player Position="Substitute" uID="p570081">
+        <PersonName>
+          <First>William</First>
+          <Last>Svensson</Last>
+        </PersonName>
+      </Player>
+      <Player Position="Substitute" uID="p720789">
+        <PersonName>
+          <First>Marlon</First>
+          <Last>Ebietomere</Last>
+        </PersonName>
+      </Player>
+      <Player Position="Substitute" uID="p570078">
+        <PersonName>
+          <First>Hampus</First>
+          <Last>Dahlqvist</Last>
+        </PersonName>
+      </Player>
+      <Player Position="Substitute" uID="p683488">
+        <PersonName>
+          <First>Demirel</First>
+          <Last>Hodzic</Last>
+        </PersonName>
+      </Player>
+      <Short_name>Örgryte</Short_name>
+      <TeamOfficial Type="Manager" uID="man54876">
+        <PersonName>
+          <First>Andreas</First>
+          <Last>Holmberg</Last>
+        </PersonName>
+      </TeamOfficial>
+    </Team>
+    <Team uID="t244">
+      <Country>Sweden</Country>
+      <Kit id="30572" colour1="#ffffff" colour2="#0941ec" type="home" />
+      <Name>IFK Göteborg</Name>
+      <Official_name>IFK Göteborg</Official_name>
+      <Player Position="Goalkeeper" uID="p578592">
+        <PersonName>
+          <First>Elis</First>
+          <Last>Bishesari</Last>
+        </PersonName>
+      </Player>
+      <Player Position="Defender" uID="p240166">
+        <PersonName>
+          <First>Alexander</First>
+          <Last>Jallow</Last>
+        </PersonName>
+      </Player>
+      <Player Position="Defender" uID="p575855">
+        <PersonName>
+          <First>Felix</First>
+          <Last>Eriksson</Last>
+        </PersonName>
+      </Player>
+      <Player Position="Defender" uID="p627127">
+        <PersonName>
+          <First>Rockson</First>
+          <Last>Yeboah</Last>
+        </PersonName>
+      </Player>
+      <Player Position="Defender" uID="p180662">
+        <PersonName>
+          <First>Jonas</First>
+          <Last>Bager</Last>
+        </PersonName>
+      </Player>
+      <Player Position="Midfielder" uID="p479433">
+        <PersonName>
+          <First>Adam</First>
+          <Last>Wiberg</Last>
+        </PersonName>
+      </Player>
+      <Player Position="Midfielder" uID="p515742">
+        <PersonName>
+          <First>David</First>
+          <Last>Kruse</Last>
+        </PersonName>
+      </Player>
+      <Player Position="Midfielder" uID="p648131">
+        <PersonName>
+          <First>Benjamin</First>
+          <Last>Brantlind</Last>
+        </PersonName>
+      </Player>
+      <Player Position="Midfielder" uID="p232091">
+        <PersonName>
+          <First>August</First>
+          <Last>Erlingmark</Last>
+        </PersonName>
+      </Player>
+      <Player Position="Striker" uID="p207884">
+        <PersonName>
+          <First>Tobias</First>
+          <Last>Heintz</Last>
+        </PersonName>
+      </Player>
+      <Player Position="Striker" uID="p625775">
+        <PersonName>
+          <First>Sebastian</First>
+          <Last>Clemmensen</Last>
+        </PersonName>
+      </Player>
+      <Player Position="Substitute" uID="p246081">
+        <PersonName>
+          <First>Kolbeinn</First>
+          <Last>Thórdarson</Last>
+        </PersonName>
+      </Player>
+      <Player Position="Substitute" uID="p495426">
+        <PersonName>
+          <First>Imam</First>
+          <Last>Jagne</Last>
+        </PersonName>
+      </Player>
+      <Player Position="Substitute" uID="p508143">
+        <PersonName>
+          <First>Max</First>
+          <Last>Fenger</Last>
+        </PersonName>
+      </Player>
+      <Player Position="Substitute" uID="p157846">
+        <PersonName>
+          <First>Fredrik</First>
+          <Known>Fredrik Andersson</Known>
+          <Last>Andersson</Last>
+        </PersonName>
+      </Player>
+      <Player Position="Substitute" uID="p531792">
+        <PersonName>
+          <First>Filip</First>
+          <Last>Ottosson</Last>
+        </PersonName>
+      </Player>
+      <Player Position="Substitute" uID="p482450">
+        <PersonName>
+          <First>Saidou</First>
+          <Last>Alioum</Last>
+        </PersonName>
+      </Player>
+      <Player Position="Substitute" uID="p689776">
+        <PersonName>
+          <First>Alfons</First>
+          <Last>Borén</Last>
+        </PersonName>
+      </Player>
+      <Player Position="Substitute" uID="p213399">
+        <PersonName>
+          <First>Ramon</First>
+          <Last>Lundqvist</Last>
+        </PersonName>
+      </Player>
+      <Player Position="Substitute" uID="p581866">
+        <PersonName>
+          <First>Tiago</First>
+          <Last>Coimbra</Last>
+        </PersonName>
+      </Player>
+      <Short_name>IFK Göteborg</Short_name>
+      <TeamOfficial Type="Manager" uID="man43882">
+        <PersonName>
+          <First>Stefan</First>
+          <Last>Billborn</Last>
+        </PersonName>
+      </TeamOfficial>
+    </Team>
+    <Venue uID="v5231">
+      <Country>Sweden</Country>
+      <Name>Gamla Ullevi</Name>
+    </Venue>
+  </SoccerDocument>
+</SoccerFeed>

--- a/kloppy/tests/files/opta_f24.xml
+++ b/kloppy/tests/files/opta_f24.xml
@@ -358,7 +358,7 @@
     <Event id="2614243655" event_id="1010" type_id="32" period_id="4" min="105" sec="0" team_id="569" outcome="1" x="0.0" y="0.0" timestamp="2018-09-23T18:35:01.810" last_modified="2023-11-06T00:22:52" version="1699230172396">
       <Q id="4637465517" qualifier_id="127" value="Left to Right" />
     </Event>
-    <Event id="2614243657" event_id="899" type_id="1" period_id="4" min="105" sec="0" player_id="460842" team_id="2592" outcome="1" x="49.9" y="50.4" timestamp="2023-11-06T00:22:52.306" timestamp_utc="2023-11-06T00:22:52.306" last_modified="2023-11-06T00:22:54" version="1699230173937">
+    <Event id="2614243657" event_id="899" type_id="1" period_id="4" min="105" sec="0" player_id="460842" team_id="2592" outcome="1" x="49.9" y="50.4" timestamp="2018-09-23T18:35:01.810" timestamp_utc="2018-09-23T17:35:01.810" last_modified="2023-11-06T00:22:54" version="1699230173937">
       <Q id="4637465527" qualifier_id="140" value="40.8" />
       <Q id="4637465531" qualifier_id="212" value="10.5" />
       <Q id="4637465529" qualifier_id="141" value="56.9" />

--- a/kloppy/tests/test_opta.py
+++ b/kloppy/tests/test_opta.py
@@ -543,6 +543,75 @@ class TestOptaBlockEvent:
         assert event.event_name == "block"
 
 
+class TestOptaAbandonment:
+    """Regression tests for matches abandoned and later resumed.
+
+    When the wall-clock between two consecutive F24 events spans an extended
+    pause (abandonment + resume), the deserializer must shift subsequent
+    wall-clock timestamps back so that `period.duration` and `event.timestamp`
+    reflect game-clock semantics. Otherwise downstream consumers that assume
+    game-clock (notably `aggregate("minutes_played", breakdown_key=...)`) blow
+    up by hours.
+
+    The fixture is the real Allsvenskan match Örgryte IS - IFK Göteborg
+    (2026-05-18), abandoned at ~minute 40 and resumed the next day.
+    """
+
+    @pytest.fixture(scope="class")
+    def abandoned_dataset(self, base_dir) -> EventDataset:
+        return opta.load(
+            f7_data=base_dir / "files" / "opta_abandonment_f7.xml",
+            f24_data=base_dir / "files" / "opta_abandonment_f24.xml",
+            coordinates="opta",
+            exclude_penalty_shootouts=True,
+        )
+
+    def test_period_duration_reflects_game_clock(self, abandoned_dataset):
+        """Period 1 duration should be game-clock (~50 min), not wall-clock (~20 h)."""
+        period_1 = abandoned_dataset.metadata.periods[0]
+        assert period_1.duration < timedelta(minutes=90)
+        assert period_1.duration > timedelta(minutes=45)
+
+    def test_minutes_played_breakdown_sums_match_total(
+        self, abandoned_dataset
+    ):
+        """Per-player IN+OUT+DEAD must equal the no-breakdown total."""
+        totals = {
+            row.key.player: row.duration
+            for row in abandoned_dataset.aggregate("minutes_played")
+            if row.key.player is not None
+        }
+        breakdown_sums: dict = {}
+        for row in abandoned_dataset.aggregate(
+            "minutes_played", breakdown_key="possession_state"
+        ):
+            if row.key.player is None:
+                continue
+            breakdown_sums[row.key.player] = (
+                breakdown_sums.get(row.key.player, timedelta(0)) + row.duration
+            )
+
+        assert breakdown_sums.keys() == totals.keys()
+        for player, total in totals.items():
+            assert (
+                abs((breakdown_sums[player] - total).total_seconds()) < 1
+            ), f"{player}: breakdown sum {breakdown_sums[player]} != total {total}"
+
+    def test_minutes_played_breakdown_within_realistic_bounds(
+        self, abandoned_dataset
+    ):
+        """Every breakdown row must be non-negative and under 180 min."""
+        max_duration = timedelta(minutes=180)
+        for row in abandoned_dataset.aggregate(
+            "minutes_played", breakdown_key="possession_state"
+        ):
+            assert timedelta(0) <= row.duration <= max_duration, (
+                f"row out of range: {row.duration} "
+                f"{row.key.possession_state} "
+                f"{row.key.player or row.key.team}"
+            )
+
+
 class TestOptaCardEvent:
     """Tests related to deserialzing card events"""
 


### PR DESCRIPTION
## Summary

When a match is suspended and resumed (Örgryte IS - IFK Göteborg, 2026-05-18, abandoned ~min 40 and resumed ~20h later), Opta F24 records the wall-clock gap directly in event timestamps while the game-clock (min/sec) correctly freezes. The minutes-played aggregator with `breakdown_key=\"possession_state\"` then attributes the entire 19h gap to whichever ball-state was active at the suspension, producing hours-long possession buckets and negative team rows.

This blocks event ingestion in \`data-processing\` (asserts every breakdown row is in [0, 180 min]).

## Fix

In the F24 deserializer, detect consecutive events whose wall-clock delta exceeds game-clock delta by more than 15 minutes, treat the excess as a suspension, and subtract a running per-period shift from subsequent events (including the END_PERIOD event, so \`period.duration\` reflects game-clock too).

Scope is contained to F24 only (gated on \`inputs.event_feed.upper() == \"F24\"\`); MA1/MA3/StatsPerform paths are untouched.

Threshold of 15 minutes deliberately ignores routine in-play delays (VAR/injury ~minutes) and only catches true match suspensions.

## Verification

For Örgryte - IFK Göteborg:

| | Before | After |
|---|---|---|
| Period 1 duration | 20:05:13 (wall-clock) | 1:00:48 (game-clock) |
| Full-match player IN+OUT+DEAD | ~21 h (IN row alone ~19h30m) | 1:55:06 (= no-breakdown total) |
| Out-of-range breakdown rows | many | 0 |

## Other changes

- \`kloppy/tests/files/opta_f24.xml\`: 1-line fix for a fixture typo on event \`2614243657\` (the \`timestamp\` field had the \`last_modified\` value, \`2023-11-06T00:22:52.306\`; corrected to the period-4 START time). The normalizer correctly detected this anomaly and shifted subsequent events, breaking \`test_periods\`. Fixing the fixture is the right call since real Opta wouldn't emit that.

## Test plan

- [x] \`pytest kloppy/tests/test_opta.py::TestOptaAbandonment\` — 3 new tests pass
- [x] \`pytest kloppy/tests/test_opta.py kloppy/tests/test_statsperform.py kloppy/tests/test_time.py\` — 94 passed (2 pre-existing failures on \`mgp-fork/v11\` deselected)
- [ ] Confirm \`data-processing\` ingestion of this match no longer trips the [0, 180 min] assert