### PR TITLE
feat(scisports): emit names as team/player identifiers

### DIFF
--- a/kloppy/infra/serializers/event/scisports/deserializer.py
+++ b/kloppy/infra/serializers/event/scisports/deserializer.py
@@ -52,7 +52,7 @@ class SciSportsDeserializer(EventDataDeserializer[SciSportsInputs]):
 
         # Create teams and players
         with performance_logging("parse teams and players", logger=logger):
-            teams = self._create_teams_and_players(raw_data)
+            teams, players_by_raw_id = self._create_teams_and_players(raw_data)
 
         # Create periods
         with performance_logging("parse periods", logger=logger):
@@ -77,7 +77,7 @@ class SciSportsDeserializer(EventDataDeserializer[SciSportsInputs]):
 
             # Pre-process substitution events to pair SUBBED_OUT with SUBBED_IN
             substitution_pairs = self._pair_substitution_events(
-                raw_events, teams
+                raw_events, players_by_raw_id
             )
 
             for raw_event in raw_events:
@@ -101,6 +101,7 @@ class SciSportsDeserializer(EventDataDeserializer[SciSportsInputs]):
                     event_objects = self._create_events(
                         raw_event,
                         teams,
+                        players_by_raw_id,
                         periods,
                         substitution_pairs,
                         possession_team,
@@ -137,9 +138,22 @@ class SciSportsDeserializer(EventDataDeserializer[SciSportsInputs]):
 
     def _create_teams_and_players(
         self, raw_data: Dict[str, Any]
-    ) -> Dict[str, Team]:
-        """Create Team and Player objects from SciSports data"""
+    ) -> tuple[Dict[str, Team], Dict[str, Player]]:
+        """Create Team and Player objects from SciSports data.
+
+        SciSports team/player ids are integers scoped to a SciSports account
+        (one competition pool) and collide across accounts, so they are useless
+        as global identifiers. We therefore emit the *name* as the identifier
+        (``Team.team_id`` = team name, ``Player.player_id`` = player name), which
+        is globally stable and exactly the identity our downstream needs.
+
+        The internal ``teams`` dict stays keyed by the raw numeric team id and a
+        ``players_by_raw_id`` map (raw numeric player id -> Player) is returned
+        alongside it, so the raw ids in event rows can still be resolved to the
+        right Team/Player objects at lookup time.
+        """
         teams = {}
+        players_by_raw_id = {}
 
         # Get unique teams from metadata and players
         home_team_id = raw_data["metaData"]["homeTeamId"]
@@ -148,16 +162,18 @@ class SciSportsDeserializer(EventDataDeserializer[SciSportsInputs]):
         # Parse starting formations from FORMATION events
         starting_formations = self._parse_starting_formations(raw_data)
 
-        # Create teams with starting formations
+        # Create teams with starting formations.
+        # team_id is the team *name* (globally stable); the local dict below
+        # stays keyed by the raw numeric id for event resolution.
         home_team = Team(
-            team_id=str(home_team_id),
+            team_id=raw_data["metaData"]["homeTeamName"],
             name=raw_data["metaData"]["homeTeamName"],
             ground=Ground.HOME,
             starting_formation=starting_formations.get(str(home_team_id)),
         )
 
         away_team = Team(
-            team_id=str(away_team_id),
+            team_id=raw_data["metaData"]["awayTeamName"],
             name=raw_data["metaData"]["awayTeamName"],
             ground=Ground.AWAY,
             starting_formation=starting_formations.get(str(away_team_id)),
@@ -175,9 +191,13 @@ class SciSportsDeserializer(EventDataDeserializer[SciSportsInputs]):
         # Add players to teams
         for player_data in raw_data.get("players", []):
             team_id = str(player_data["teamId"])
-            player_id = str(player_data["playerId"])
+            # The raw numeric id is used only for internal resolution (starter
+            # detection, the players_by_raw_id map); the player *name* is the
+            # globally stable identity we expose as player_id.
+            raw_player_id = str(player_data["playerId"])
+            player_name = player_data.get("playerName")
             if team_id in teams:
-                is_starter = player_id in starting_players
+                is_starter = raw_player_id in starting_players
 
                 # Only use starting position from POSITION events if the player is a starter
                 # Otherwise, starting_position should be None for substitutes
@@ -185,23 +205,24 @@ class SciSportsDeserializer(EventDataDeserializer[SciSportsInputs]):
                 if is_starter:
                     # Use position from STARTING_POSITION events if available, otherwise fallback to player metadata
                     position_id = starting_positions.get(
-                        player_id, player_data.get("positionId", -1)
+                        raw_player_id, player_data.get("positionId", -1)
                     )
                     starting_position = SS.get_position_type(position_id)
 
                 player = Player(
-                    player_id=player_id,
+                    player_id=player_name,
                     team=teams[team_id],
                     jersey_no=player_data.get("shirtNumber"),
-                    name=player_data.get("playerName"),
+                    name=player_name,
                     first_name=None,
                     last_name=None,
                     starting=is_starter,
                     starting_position=starting_position,
                 )
                 teams[team_id].players.append(player)
+                players_by_raw_id[raw_player_id] = player
 
-        return teams
+        return teams, players_by_raw_id
 
     def _identify_starting_players(self, raw_data: Dict[str, Any]) -> set[str]:
         """Identify starting players by analyzing substitution events"""
@@ -354,7 +375,9 @@ class SciSportsDeserializer(EventDataDeserializer[SciSportsInputs]):
         return periods
 
     def _pair_substitution_events(
-        self, raw_events: List[Dict[str, Any]], teams: Dict[str, Team]
+        self,
+        raw_events: List[Dict[str, Any]],
+        players_by_raw_id: Dict[str, Player],
     ) -> Dict[str, Player]:
         """Pre-process substitution events to pair SUBBED_OUT with SUBBED_IN events"""
         substitution_pairs = (
@@ -402,18 +425,14 @@ class SciSportsDeserializer(EventDataDeserializer[SciSportsInputs]):
             # If we found a match, create the pairing
             if best_match:
                 replacement_player_id = str(best_match.get("playerId"))
-                team_id = str(best_match.get("teamId"))
-
-                if team_id in teams:
-                    team = teams[team_id]
-                    replacement_player = team.get_player_by_id(
-                        replacement_player_id
-                    )
-                    if replacement_player:
-                        substitution_pairs[
-                            str(out_event.get("eventId"))
-                        ] = replacement_player
-                        used_subbed_in_events.add(best_match.get("eventId"))
+                replacement_player = players_by_raw_id.get(
+                    replacement_player_id
+                )
+                if replacement_player:
+                    substitution_pairs[
+                        str(out_event.get("eventId"))
+                    ] = replacement_player
+                    used_subbed_in_events.add(best_match.get("eventId"))
 
         return substitution_pairs
 
@@ -421,6 +440,7 @@ class SciSportsDeserializer(EventDataDeserializer[SciSportsInputs]):
         self,
         raw_event: Dict[str, Any],
         teams: Dict[str, Team],
+        players_by_raw_id: Dict[str, Player],
         periods: list[Period],
         substitution_pairs: Dict[str, Player] = None,
         possession_team: Team = None,
@@ -434,7 +454,7 @@ class SciSportsDeserializer(EventDataDeserializer[SciSportsInputs]):
             return []
 
         # Set references to teams and periods
-        event_obj.set_refs(teams, periods, possession_team)
+        event_obj.set_refs(teams, players_by_raw_id, periods, possession_team)
 
         # Check if we have valid team and player
         if not event_obj.team:

--- a/kloppy/infra/serializers/event/scisports/specification.py
+++ b/kloppy/infra/serializers/event/scisports/specification.py
@@ -264,8 +264,17 @@ class EVENT:
     def __init__(self, raw_event: Dict):
         self.raw_event = raw_event
 
-    def set_refs(self, teams, periods, possession_team=None):
-        """Set references to teams and periods"""
+    def set_refs(
+        self, teams, players_by_raw_id, periods, possession_team=None
+    ):
+        """Set references to teams and periods.
+
+        SciSports identifies teams/players by raw numeric ids that are only
+        unique within a SciSports account. Team/Player objects expose the
+        *name* as their identifier, so raw ids are resolved here via the
+        ``players_by_raw_id`` map (numeric id -> Player) rather than via
+        ``Team.get_player_by_id`` (which now keys on the name).
+        """
         from .helpers import get_team_by_id, get_period_by_id
 
         self.team = get_team_by_id(self.raw_event.get("teamId"), teams)
@@ -273,11 +282,10 @@ class EVENT:
             self.raw_event.get("partId", 1), periods
         )
         self.possession_team = possession_team
+        self.players_by_raw_id = players_by_raw_id
 
-        self.player = None
-        if self.team:
-            player_id = str(self.raw_event.get("playerId", -1))
-            self.player = self.team.get_player_by_id(player_id)
+        player_id = str(self.raw_event.get("playerId", -1))
+        self.player = players_by_raw_id.get(player_id)
 
         return self
 
@@ -490,15 +498,17 @@ class PASS(EVENT):
                 milliseconds=duration
             )
 
-        # Try to find receiver player
+        # Try to find receiver player. Only resolve same-team receivers, and
+        # compare against the raw numeric team id (Team.team_id is the name).
         receiver_player = None
         receiver_id = self.raw_event.get("receiverId")
         if receiver_id and receiver_id != -1:
-            team = generic_event_kwargs["team"]
-            # Check if receiver is on the same team
             receiver_team_id = self.raw_event.get("receiverTeamId")
-            if receiver_team_id and str(receiver_team_id) == str(team.team_id):
-                receiver_player = team.get_player_by_id(str(receiver_id))
+            event_team_id = self.raw_event.get("teamId")
+            if receiver_team_id and str(receiver_team_id) == str(
+                event_team_id
+            ):
+                receiver_player = self.players_by_raw_id.get(str(receiver_id))
 
         pass_event = event_factory.build_pass(
             result=result,

--- a/kloppy/tests/test_scisports.py
+++ b/kloppy/tests/test_scisports.py
@@ -84,6 +84,10 @@ class TestSciSportsMetadata:
         assert dataset.metadata.teams[0].name == "Team Alpha"
         assert dataset.metadata.teams[1].name == "Team Beta"
 
+        # Team ids are the team names (globally stable across SciSports accounts)
+        assert dataset.metadata.teams[0].team_id == "Team Alpha"
+        assert dataset.metadata.teams[1].team_id == "Team Beta"
+
         # The teams should have the correct players
         home_team = dataset.metadata.teams[0]
         away_team = dataset.metadata.teams[1]
@@ -92,12 +96,13 @@ class TestSciSportsMetadata:
         assert len(home_team.players) == 14
         assert len(away_team.players) == 14
 
-        # Check a specific player
-        player_116 = home_team.get_player_by_id("116")
-        assert player_116 is not None
-        assert player_116.player_id == "116"
-        assert player_116.jersey_no == 21
-        assert player_116.name == "Player 06"
+        # Check a specific player. SciSports ids collide across accounts, so
+        # the deserializer emits the player *name* as player_id.
+        player_06 = home_team.get_player_by_id("Player 06")
+        assert player_06 is not None
+        assert player_06.player_id == "Player 06"
+        assert player_06.jersey_no == 21
+        assert player_06.name == "Player 06"
 
     def test_starting_players(self, dataset):
         """It should correctly identify starting players vs substitutes"""
@@ -119,15 +124,15 @@ class TestSciSportsMetadata:
         assert len(away_subs) == 3
 
         # Check specific examples - players who were substituted out should be starters
-        # Player 09 (121) was substituted out, so should be a starter
-        player_121 = home_team.get_player_by_id("121")
-        assert player_121 is not None
-        assert player_121.starting
+        # Player 09 was substituted out, so should be a starter
+        player_09 = home_team.get_player_by_id("Player 09")
+        assert player_09 is not None
+        assert player_09.starting
 
-        # Player 18 (122) was substituted in, so should not be a starter
-        player_122 = home_team.get_player_by_id("122")
-        assert player_122 is not None
-        assert not player_122.starting
+        # Player 18 was substituted in, so should not be a starter
+        player_18 = home_team.get_player_by_id("Player 18")
+        assert player_18 is not None
+        assert not player_18.starting
 
     def test_periods(self, dataset):
         """It should create the periods"""
@@ -261,7 +266,7 @@ class TestSciSportsPassEvent:
         assert kick_off_pass.timestamp == timedelta(seconds=0.07)
 
         assert kick_off_pass.receiver_coordinates == Point(x=-13.65, y=0.68)
-        assert kick_off_pass.receiver_player.player_id == "124"
+        assert kick_off_pass.receiver_player.player_id == "Player 15"
 
     def test_pass_result_checks(self, dataset: EventDataset):
         """Test pass result types (complete/incomplete)"""
@@ -551,8 +556,8 @@ class TestSciSportsSubstitutionEvent:
         player_off = sub_event.player
         player_on = sub_event.replacement_player
 
-        assert player_off.player_id == "121"
-        assert player_on.player_id == "122"
+        assert player_off.player_id == "Player 09"
+        assert player_on.player_id == "Player 18"
 
         assert sub_event.time.period.id == 2
         assert sub_event.time.timestamp == timedelta(0)


### PR DESCRIPTION
## Why

SciSports team/player ids are integers scoped to a SciSports *account* (one competition pool, e.g. NEC's U21 group). Within an account they are stable, but they restart from 1 in every account and collide: `teamId 1` is one club here and a different one elsewhere; `playerId 9` is one player here and someone else elsewhere. So the raw ids are useless as a global identifier, which is what our downstream MongoDB needs to recognise the same team/player across matches and competitions.

SciSports carries names everywhere (`metaData.homeTeamName/awayTeamName`, `players[].playerName`, and inline `teamName`/`playerName`/`receiverName` on every event), so names are a globally stable identity.

## What

- `Team.team_id` = team name, `Player.player_id` = player name.
- Internal `teams` dict stays keyed by the raw numeric team id (possession tracking, `get_team_by_id` unchanged).
- New `players_by_raw_id` map (numeric id → `Player`) translates the raw ids in event rows at the three lookup sites:
  - per-event player resolution (`set_refs`)
  - pass receivers
  - substitution pairing
- Pass-receiver same-team check now compares against the raw event `teamId` instead of `Team.team_id` (which is now a name).

This mirrors how kloppy already synthesises string `player_id`s for tracking providers without stable source ids (`metrica_csv`, `signality`, `skillcorner`). Only the youth SciSports event path uses this deserializer; senior SciSports competitions use StatsPerform for events, so the change is self-contained.

## Validation

- All 51 `test_scisports.py` tests pass (assertions updated to names); Black clean.
- Loaded two real NEC U21 matches from `s3://mgp-raw`:
  - team_id = real club names (`NEC U21`, `sc Heerenveen U21`, `Vitesse U21`); every `player_id == name`
  - 0 events with a raw `playerId` left unresolved
  - all pass receivers resolve, 0 mismatches vs inline `receiverName`, all teammates
  - all 10 paired substitutions resolve, 0 mismatches vs inline `playerName`

## Downstream

`data-processing` will switch `provider_ids.scisports` to the name, so once this is re-pinned the events_df `player_id`/`team_id` already match with no translation. Ship this first, then re-pin and run META_DATA + EVENT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)