### PR TITLE
fix(sequence): include OwnGoalForEvent in sequence state

### DIFF
--- a/kloppy/domain/services/state_builder/builders/sequence.py
+++ b/kloppy/domain/services/state_builder/builders/sequence.py
@@ -11,6 +11,7 @@ from kloppy.domain import (
     BallOutEvent,
     FoulCommittedEvent,
     ShotEvent,
+    OwnGoalForEvent,
     SetPieceQualifier,
     GoalkeeperEvent,
     GoalkeeperActionType,
@@ -52,7 +53,7 @@ EXCLUDED_OFF_BALL_EVENTS = (
     FormationChangeEvent,
 )
 
-CLOSE_SEQUENCE = (BallOutEvent, FoulCommittedEvent, ShotEvent)
+CLOSE_SEQUENCE = (BallOutEvent, FoulCommittedEvent, ShotEvent, OwnGoalForEvent)
 
 
 def is_ball_winning_defensive_action(event: Event) -> bool:
@@ -69,7 +70,7 @@ def is_failed_pass(event: Event) -> bool:
 
 
 def is_possessing_event(event: Event) -> bool:
-    if isinstance(event, (PassEvent, CarryEvent, RecoveryEvent, TakeOnEvent, ShotEvent)):
+    if isinstance(event, (PassEvent, CarryEvent, RecoveryEvent, TakeOnEvent, ShotEvent, OwnGoalForEvent)):
         return True
     elif isinstance(event, GoalkeeperEvent) and event.get_qualifier_value(
         GoalkeeperQualifier


### PR DESCRIPTION
## Summary

Synthetic `OwnGoalForEvent`s (inserted by `SyntheticOwnGoalForGenerator` after a shot with `ShotResult.OWN_GOAL`) were ending up with `Sequence(sequence_id=None, team=None)`. This breaks any downstream consumer that builds goals-conceded / goals-for stats off the sequence state on the benefiting team's side.

This PR adds `OwnGoalForEvent` to both `is_possessing_event()` and `CLOSE_SEQUENCE`, mirroring the symmetric handling of `ShotEvent`. The result is a one-event sequence opened on the benefiting team and immediately closed - exactly the semantics for an own-goal credited to the opposing team.

## Background

For a KoraStats own goal the raw events become, after `add_synthetic_event(OWN_GOAL_FOR)`:

1. `ShotEvent(result=OWN_GOAL)` - team = conceding side, e.g. Harju
2. `OwnGoalForEvent` - team = benefiting side, e.g. Nomme United

Before this fix:

- `ShotEvent` is in `CLOSE_SEQUENCE`, so `reduce_after` closes the sequence (team -> None).
- `OwnGoalForEvent` then arrives; `is_possessing_event` returns false for it, so `reduce_before` doesn't open a new sequence. State stays team=None.
- `post_process` sees `sequence.team is None` and explicitly nulls the sequence_id.

After this fix:

- `OwnGoalForEvent` is a possessing event, so `reduce_before` opens a new sequence on the benefiting team.
- `OwnGoalForEvent` is also in `CLOSE_SEQUENCE`, so `reduce_after` closes it again.
- The benefiting team gets a clean one-event sequence with a valid sequence_id.

## Verified

Ran end-to-end against a real KoraStats match (Nomme United 1-2 Harju, 2026-04-18) where the own goal was being lost downstream:

Before:
```
ShotEvent result=OWN_GOAL: sequence_id=114, team=Harju JK Laagri
OwnGoalForEvent:           sequence_id=None, team=None    <- broken
```

After:
```
ShotEvent result=OWN_GOAL: sequence_id=114, team=Harju JK Laagri
OwnGoalForEvent:           sequence_id=115, team=FC Nomme United    <- correct
```

Existing tests still pass:
- `test_sequence_state_builder_statsbomb`
- `test_sequence_state_builder_statsperform`

## Risk

- Adds an extra sequence per own-goal incident in downstream sequence-id space. Numerically negligible.
- Possession-switch qualifiers (GAIN/LOSE) added in `post_process` will now also be attached around own goals; this is consistent with how shots are handled.

## Out of scope

- Downstream data-processing still needs to map `OwnGoalForEvent` to `result: goal_ending` when it builds the MongoDB sequence sub-doc. Tracking that separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)