### PR TITLE
fix-TAS-3302-smrtstats-emit-kick-off-events-nx3z6y

### DIFF
--- a/kloppy/infra/serializers/event/smrtstats/deserializer.py
+++ b/kloppy/infra/serializers/event/smrtstats/deserializer.py
@@ -880,6 +880,13 @@ class SmrtStatsDeserializer(EventDataDeserializer[SmrtStatsInputs]):
         events = []
         seen_fingerprints = set()
         seen_event_ids = set()
+        # SmrtStats has no raw kick-off marker, so we synthesise one:
+        # the first pass in each period, and the first pass after each
+        # goal, gets a KICK_OFF SetPieceQualifier (mirrors Wyscout v3).
+        # P5 (shootout) is excluded since it's dropped downstream.
+        kickoff_needed_periods: set = {
+            p.id for p in periods if p.id != 5
+        }
         # Iterate in preference order. For ET matches SmrtStats stores ET
         # events in two lists at once: the extra-time bucket
         # (first_extra_time_markers / second_extra_time_markers) AND
@@ -990,6 +997,13 @@ class SmrtStatsDeserializer(EventDataDeserializer[SmrtStatsInputs]):
                         pass_event_args = _parse_pass(
                             raw_event, action_id, team
                         )
+                        if period.id in kickoff_needed_periods:
+                            pass_event_args["qualifiers"] = list(
+                                pass_event_args["qualifiers"] or []
+                            ) + [
+                                SetPieceQualifier(value=SetPieceType.KICK_OFF)
+                            ]
+                            kickoff_needed_periods.discard(period.id)
                         event = self.event_factory.build_pass(
                             **pass_event_args, **generic_event_kwargs
                         )
@@ -998,6 +1012,8 @@ class SmrtStatsDeserializer(EventDataDeserializer[SmrtStatsInputs]):
                         event = self.event_factory.build_shot(
                             **shot_event_kwargs, **generic_event_kwargs
                         )
+                        if action_id in (GOAL, OWN_GOAL) and period.id != 5:
+                            kickoff_needed_periods.add(period.id)
                     elif action_id in INTERCEPTION_IDS:
                         interception_kwargs = _parse_interception(raw_event)
                         event = self.event_factory.build_interception(

--- a/kloppy/tests/test_smrtstats.py
+++ b/kloppy/tests/test_smrtstats.py
@@ -221,6 +221,29 @@ class TestSmrtStatsPassEvent:
             == SetPieceType.FREE_KICK
         )
 
+    def test_kick_off(self, dataset: EventDataset):
+        """It should add KICK_OFF qualifiers to the first pass of each period
+        and the first pass after each goal, matching other providers.
+
+        SmrtStats has no raw kick-off marker, so kloppy synthesises them.
+        """
+        kick_off_passes = [
+            e
+            for e in dataset.find_all("pass")
+            if SetPieceType.KICK_OFF
+            in e.get_qualifier_values(SetPieceQualifier)
+        ]
+        # 2 period starts + 3 goals in the fixture
+        assert len(kick_off_passes) == 5
+        kick_off_ids = {e.event_id for e in kick_off_passes}
+        assert kick_off_ids == {
+            "239947304",  # first pass of period 1
+            "239948170",  # first pass of period 2
+            "239947840",  # first pass after the first goal
+            "239948317",  # first pass after the second goal
+            "239948890",  # first pass after the third goal
+        }
+
     def test_interception(self, dataset: EventDataset):
         """It should split interception passes into two events"""
         interception = dataset.get_event_by_id("239947350")


### PR DESCRIPTION
## Summary

SmrtStats was the only event provider whose output contained no `kick_off` events. Its raw feed carries no explicit kick-off marker or qualifier, so this change synthesises one during deserialization, following the Wyscout v3 pattern:

- The first pass in each period gets a `SetPieceQualifier(value=SetPieceType.KICK_OFF)`.
- The first pass after each goal (regular or own goal) gets the same qualifier.
- P5 (penalty shootout) is excluded because it's dropped downstream by `remove_penalty_shootout_data`.

State is tracked per period, so the logic stays correct across the interleaved iteration order used for extra-time matches (P1 → P3 → P4 → P2).

## Verification

- Existing SmrtStats suite: 70 tests pass (69 pre-existing + 1 new `test_kick_off`).
- Runtime check across all three SmrtStats fixtures:
  - `smrtstats.json` (regulation match, 3 goals): 5 kick-offs (2 period starts + 3 post-goal). Confirmed each of the 5 pass IDs is the first pass in its period or the first pass after the corresponding goal.
  - `smrtstats_extra_time.json` (5 periods, small fixture): 4 kick-offs (one per real period; no in-period passes follow the two non-shootout goals in this truncated fixture).
  - `smrtstats_shootout.json`: 2 kick-offs (P1 + P2 starts; the only non-shootout goal has no follow-up pass in the fixture).
- Other event-provider tests (`wyscout`, `korastats`, `scisports`, `metrica`, `datafactory`) still pass, confirming no cross-provider regression.

## Ticket

https://app.notion.com/p/3923bf87de63819dbe8cc75431b58bd2 (TAS-3302)


---
_Generated by [Claude Code](https://claude.ai/code/session_01UoYmkkbqU7S4asFrW69pS4)_