### PR TITLE
fix(korastats): pair bracketed substitutions by team

### DIFF
--- a/kloppy/infra/serializers/event/korastats/deserializer.py
+++ b/kloppy/infra/serializers/event/korastats/deserializer.py
@@ -99,6 +99,7 @@ class KoraStatsDeserializer(EventDataDeserializer[KoraStatsInputs]):
             event_data = json.load(inputs.event_data)
 
         raw_events = event_data["events"]
+        self.pair_substitutions(raw_events)
 
         with performance_logging("parse data", logger=logger):
             teams = self.create_teams_and_players(metadata)
@@ -182,6 +183,39 @@ class KoraStatsDeserializer(EventDataDeserializer[KoraStatsInputs]):
         away_team = create_team(metadata["away"], Ground.AWAY)
 
         return [home_team, away_team]
+
+    @staticmethod
+    def pair_substitutions(raw_events: List[Dict]) -> None:
+        """Annotate each SubstituteOut with its replacement player id.
+
+        KoraStats emits a separate SubstituteOut and SubstituteIn event per
+        substitution. They are usually adjacent, but when both teams sub at the
+        same stoppage the pairs get bracketed (two SubstituteOut events before
+        their SubstituteIn events), so the out/in pair is no longer adjacent.
+        Pair each out with the nearest unconsumed in of the same team in the
+        same half and store the replacement on the out event, so the
+        deserializer never has to rely on adjacency.
+        """
+        sub_ins_by_team = collections.defaultdict(list)
+        for ix, event in enumerate(raw_events):
+            if event.get("extra") == "SubstituteIn":
+                sub_ins_by_team[event.get("team_id")].append(ix)
+
+        consumed = set()
+        for ix, event in enumerate(raw_events):
+            if event.get("extra") != "SubstituteOut":
+                continue
+            best = None
+            for j in sub_ins_by_team.get(event.get("team_id"), []):
+                if j in consumed or raw_events[j].get("half") != event.get(
+                    "half"
+                ):
+                    continue
+                if best is None or abs(j - ix) < abs(best - ix):
+                    best = j
+            if best is not None:
+                consumed.add(best)
+                event["_replacement_player_id"] = raw_events[best]["player_id"]
 
     @staticmethod
     def create_periods(raw_events: List[Dict]) -> List[Period]:

--- a/kloppy/infra/serializers/event/korastats/specification.py
+++ b/kloppy/infra/serializers/event/korastats/specification.py
@@ -765,18 +765,30 @@ class SUBSTITUTION(EVENT):
         if self.extra == EXTRA.SUBSTITUTE_IN:
             return []
 
-        if next_event.get("extra") == "SubstituteIn":
+        # The deserializer pre-pairs each SubstituteOut with the matching
+        # SubstituteIn of the same team (see pair_substitutions), which handles
+        # both adjacent and bracketed pairs. Fall back to the adjacent events
+        # for robustness.
+        replacement_player_id = self.raw_event.get("_replacement_player_id")
+        if (
+            replacement_player_id is None
+            and next_event
+            and next_event.get("extra") == "SubstituteIn"
+        ):
             replacement_player_id = next_event["player_id"]
-            replacement_player = self.team.get_player_by_id(
-                str(replacement_player_id)
-            )
-        elif prior_event.get("extra") == "SubstituteIn":
+        if (
+            replacement_player_id is None
+            and prior_event
+            and prior_event.get("extra") == "SubstituteIn"
+        ):
             replacement_player_id = prior_event["player_id"]
-            replacement_player = self.team.get_player_by_id(
-                str(replacement_player_id)
-            )
-        else:
+
+        if replacement_player_id is None:
             raise ValueError("Substitution event without replacement player")
+
+        replacement_player = self.team.get_player_by_id(
+            str(replacement_player_id)
+        )
 
         sub_event = event_factory.build_substitution(
             result=None,

--- a/kloppy/tests/test_korastats.py
+++ b/kloppy/tests/test_korastats.py
@@ -405,9 +405,7 @@ class TestKoraStatsTackleEvent:
     See TAS-2898.
     """
 
-    def test_tackle_success_is_defending_duel_won(
-        self, dataset: EventDataset
-    ):
+    def test_tackle_success_is_defending_duel_won(self, dataset: EventDataset):
         # _id=144880593, event_id=33, result_id=10 → defender won
         event = dataset.get_event_by_id("144880593")
         assert event.event_type == EventType.DUEL
@@ -518,6 +516,50 @@ class TestKoraStatsSubstitutionEvent:
         #     assert event.replacement_player == event.team.get_player_by_id(
         #         replacement_player_id
         #     )
+
+    def test_pair_bracketed_substitutions(self):
+        """It should pair out/in even when the pairs are not adjacent.
+
+        KoraStats brackets substitution pairs when both teams sub at the same
+        stoppage: two SubstituteOut events emit before their SubstituteIn
+        events, so an out/in pair is no longer adjacent.
+        """
+        from kloppy.infra.serializers.event.korastats.deserializer import (
+            KoraStatsDeserializer,
+        )
+
+        # team 1's out (idx 0) brackets team 2's adjacent pair; its matching
+        # in is at idx 3.
+        raw_events = [
+            {
+                "extra": "SubstituteOut",
+                "team_id": 1,
+                "half": 2,
+                "player_id": 10,
+            },
+            {
+                "extra": "SubstituteOut",
+                "team_id": 2,
+                "half": 2,
+                "player_id": 20,
+            },
+            {
+                "extra": "SubstituteIn",
+                "team_id": 2,
+                "half": 2,
+                "player_id": 21,
+            },
+            {
+                "extra": "SubstituteIn",
+                "team_id": 1,
+                "half": 2,
+                "player_id": 11,
+            },
+        ]
+        KoraStatsDeserializer.pair_substitutions(raw_events)
+
+        assert raw_events[0]["_replacement_player_id"] == 11
+        assert raw_events[1]["_replacement_player_id"] == 21
 
 
 class TestKoraStatsFoulCommittedEvent:


### PR DESCRIPTION
## Problem
KoraStats emits a separate `SubstituteOut` and `SubstituteIn` event per substitution. They are usually adjacent, but when both teams sub at the same stoppage the pairs are **bracketed** (two `SubstituteOut` events before their `SubstituteIn` events), leaving an out/in pair non-adjacent.

The deserializer only inspected the immediately prior/next event, so it raised `Substitution event without replacement player` and failed the **entire match**. Hit on Heracles Almelo vs FC Groningen (KoraStats match 129262), blocking event ingestion for the friendly.

## Fix
- `KoraStatsDeserializer.pair_substitutions`: a team- and half-aware pre-pass that annotates each `SubstituteOut` with its matching `SubstituteIn`'s player id (nearest unconsumed in of the same team in the same half).
- `SUBSTITUTION` deserializer consumes that annotation, falling back to the adjacent-event heuristic for robustness.

## Tests
- Existing `test_korastats.py` suite: 34 → 35 passing (sample match's 8 subs still pair correctly).
- New `test_pair_bracketed_substitutions` unit test covering the bracketed case.
- Verified end-to-end: match 129262 now deserializes and ingests (2372 events).

🤖 Generated with [Claude Code](https://claude.com/claude-code)