### PR TITLE
korastats: read the starting formation from the MatchFormation feed

### DIFF
--- a/kloppy/_providers/korastats.py
+++ b/kloppy/_providers/korastats.py
@@ -4,23 +4,29 @@ from kloppy.infra.serializers.event.korastats import (
     KoraStatsInputs,
 )
 from kloppy.domain import EventDataset, Optional, List, EventFactory
-from kloppy.io import open_as_file, FileLike
+from kloppy.io import open_as_file, FileLike, Source
 
 
 def load(
     event_data: FileLike,
     squads_data: FileLike,
+    home_formation_data: Optional[FileLike] = None,
+    away_formation_data: Optional[FileLike] = None,
     event_types: Optional[List[str]] = None,
     coordinates: Optional[str] = None,
     event_factory: Optional[EventFactory] = None,
     exclude_penalty_shootouts: bool = False,
 ) -> EventDataset:
     """
-    Load Impect event data into a [`EventDataset`][kloppy.domain.models.event.EventDataset]
+    Load KoraStats event data into a [`EventDataset`][kloppy.domain.models.event.EventDataset]
 
     Parameters:
         event_data: filename of json containing the events
-        lineup_data: filename of json containing the lineup information
+        squads_data: filename of json containing the lineup information
+        home_formation_data: optional json of the home team's MatchFormation feed,
+            used for the starting formation
+        away_formation_data: optional json of the away team's MatchFormation feed,
+            used for the starting formation
         event_types:
         coordinates:
         event_factory:
@@ -33,10 +39,16 @@ def load(
     )
     with open_as_file(event_data) as event_data_fp, open_as_file(
         squads_data
-    ) as squads_data_fp:
+    ) as squads_data_fp, open_as_file(
+        Source.create(home_formation_data, optional=True)
+    ) as home_formation_data_fp, open_as_file(
+        Source.create(away_formation_data, optional=True)
+    ) as away_formation_data_fp:
         return deserializer.deserialize(
             inputs=KoraStatsInputs(
                 event_data=event_data_fp,
                 meta_data=squads_data_fp,
+                home_formation_data=home_formation_data_fp,
+                away_formation_data=away_formation_data_fp,
             )
         )

--- a/kloppy/domain/models/formation.py
+++ b/kloppy/domain/models/formation.py
@@ -38,6 +38,7 @@ class FormationType(Enum):
         FOUR_FOUR_TWO (str):
         FOUR_FIVE_ONE (str):
         FIVE_TWO_TWO_ONE (str):
+        FIVE_TWO_THREE (str):
         FIVE_THREE_TWO (str):
         FIVE_FOUR_ONE (str):
 
@@ -82,6 +83,7 @@ class FormationType(Enum):
     FIVE_ONE_THREE_ONE = "5-1-3-1"
     FIVE_TWO_ONE_TWO = "5-2-1-2"
     FIVE_TWO_TWO_ONE = "5-2-2-1"
+    FIVE_TWO_THREE = "5-2-3"
     FIVE_THREE_TWO = "5-3-2"
     FIVE_FOUR_ONE = "5-4-1"
     UNKNOWN = "Unknown"

--- a/kloppy/infra/serializers/event/korastats/deserializer.py
+++ b/kloppy/infra/serializers/event/korastats/deserializer.py
@@ -3,7 +3,7 @@ import json
 import warnings
 from collections import OrderedDict
 from dataclasses import replace
-from typing import Dict, List, NamedTuple, IO, Tuple
+from typing import Dict, List, NamedTuple, IO, Optional, Tuple
 from datetime import timedelta, datetime
 import logging
 
@@ -80,9 +80,69 @@ position_types_mapping: Dict[str, PositionType] = {
 }
 
 
+def parse_formation(raw_formation: Optional[str]) -> FormationType:
+    """Convert a KoraStats formation string into a `FormationType`.
+
+    KoraStats writes formations goalkeeper-first and without separators, so
+    "1-433" is a 4-3-3 and "1-4240" a 4-2-4-0. Strings that do not describe a
+    goalkeeper plus ten outfield players are treated as missing, since the
+    provider also emits partial ones (e.g. "1-53", " - ").
+    """
+    if not raw_formation:
+        return FormationType.UNKNOWN
+
+    lines = raw_formation.strip()
+    if not lines.startswith("1-"):
+        logger.warning(f"Unexpected KoraStats formation {raw_formation!r}")
+        return FormationType.UNKNOWN
+
+    lines = lines[2:]
+    if not lines.isdigit() or sum(int(line) for line in lines) != 10:
+        logger.warning(
+            f"KoraStats formation {raw_formation!r} does not describe eleven players"
+        )
+        return FormationType.UNKNOWN
+
+    try:
+        return FormationType("-".join(lines))
+    except ValueError:
+        logger.warning(f"Unknown KoraStats formation {raw_formation!r}")
+        return FormationType.UNKNOWN
+
+
+def parse_starting_formations(
+    formation_data: List[Optional[IO[bytes]]],
+) -> Dict[str, FormationType]:
+    """Map team id to starting formation from the MatchFormation feeds.
+
+    Each feed covers a single team and names it, so the formations are keyed by
+    team id rather than by the order in which the feeds were passed in.
+    """
+    starting_formations = {}
+    for formation_data_fp in formation_data:
+        if formation_data_fp is None:
+            continue
+
+        formation = json.load(formation_data_fp)
+        team_id = formation.get("teamId")
+        if team_id is None:
+            logger.warning(
+                "Skipping KoraStats formation feed without a team id"
+            )
+            continue
+
+        starting_formations[str(team_id)] = parse_formation(
+            formation.get("startingLineupFormation")
+        )
+
+    return starting_formations
+
+
 class KoraStatsInputs(NamedTuple):
     event_data: IO[bytes]
     meta_data: IO[bytes]
+    home_formation_data: Optional[IO[bytes]] = None
+    away_formation_data: Optional[IO[bytes]] = None
 
 
 class KoraStatsDeserializer(EventDataDeserializer[KoraStatsInputs]):
@@ -102,7 +162,12 @@ class KoraStatsDeserializer(EventDataDeserializer[KoraStatsInputs]):
         self.pair_substitutions(raw_events)
 
         with performance_logging("parse data", logger=logger):
-            teams = self.create_teams_and_players(metadata)
+            starting_formations = parse_starting_formations(
+                [inputs.home_formation_data, inputs.away_formation_data]
+            )
+            teams = self.create_teams_and_players(
+                metadata, starting_formations
+            )
 
         # Create periods
         with performance_logging("parse periods", logger=logger):
@@ -146,15 +211,22 @@ class KoraStatsDeserializer(EventDataDeserializer[KoraStatsInputs]):
         return dataset
 
     @staticmethod
-    def create_teams_and_players(metadata: Dict) -> List[Team]:
+    def create_teams_and_players(
+        metadata: Dict,
+        starting_formations: Optional[Dict[str, FormationType]] = None,
+    ) -> List[Team]:
+        starting_formations = starting_formations or {}
+
         def create_team(team_info: Dict, ground: Ground) -> Team:
-            starting_formation = FormationType.UNKNOWN
+            team_id = str(team_info["team"]["id"])
 
             team = Team(
-                team_id=str(team_info["team"]["id"]),
+                team_id=team_id,
                 name=team_info["team"]["name"],
                 ground=ground,
-                starting_formation=starting_formation,
+                starting_formation=starting_formations.get(
+                    team_id, FormationType.UNKNOWN
+                ),
             )
 
             players = []
@@ -168,9 +240,11 @@ class KoraStatsDeserializer(EventDataDeserializer[KoraStatsInputs]):
                         team=team,
                         name=player_info["name"],
                         jersey_no=player_info["shirt_number"],
-                        starting_position=starting_position
-                        if player_info["lineup"]
-                        else None,
+                        starting_position=(
+                            starting_position
+                            if player_info["lineup"]
+                            else None
+                        ),
                         starting=True if player_info["lineup"] else False,
                     )
                 )

--- a/kloppy/tests/files/korastats_formation_away.json
+++ b/kloppy/tests/files/korastats_formation_away.json
@@ -1,0 +1,10 @@
+{
+  "_type": "FORMATION",
+  "matchId": 76336,
+  "matchName": "Kalmar FF 3x2 Landskrona",
+  "teamId": 23109,
+  "teamName": "Landskrona",
+  "lineupFormationName": "1-433",
+  "endOfMatchFormationName": "1-513",
+  "startingLineupFormation": "1-433"
+}

--- a/kloppy/tests/files/korastats_formation_home.json
+++ b/kloppy/tests/files/korastats_formation_home.json
@@ -1,0 +1,10 @@
+{
+  "_type": "FORMATION",
+  "matchId": 76336,
+  "matchName": "Kalmar FF 3x2 Landskrona",
+  "teamId": 10107,
+  "teamName": "Kalmar FF",
+  "lineupFormationName": "1-423",
+  "endOfMatchFormationName": "1-422",
+  "startingLineupFormation": "1-433"
+}

--- a/kloppy/tests/test_korastats.py
+++ b/kloppy/tests/test_korastats.py
@@ -1,5 +1,7 @@
+import json
 from collections import defaultdict
 from datetime import timedelta
+from io import BytesIO
 from typing import cast
 
 import pytest
@@ -28,6 +30,10 @@ from kloppy.domain import (
     Time,
 )
 from kloppy.domain.models import PositionType
+from kloppy.infra.serializers.event.korastats.deserializer import (
+    parse_formation,
+    parse_starting_formations,
+)
 from kloppy.domain.models.event import (
     EventType,
     GoalkeeperActionType,
@@ -42,6 +48,12 @@ def dataset(base_dir) -> EventDataset:
     dataset = korastats.load(
         event_data=base_dir / "files" / "korastats_events.json",
         squads_data=base_dir / "files" / "korastats_squads.json",
+        home_formation_data=base_dir
+        / "files"
+        / "korastats_formation_home.json",
+        away_formation_data=base_dir
+        / "files"
+        / "korastats_formation_away.json",
         coordinates="korastats",
     )
 
@@ -69,13 +81,13 @@ class TestKoraStatsMetadata:
         """It should create the teams and player objects"""
         # There should be two teams with the correct names and starting formations
         assert dataset.metadata.teams[0].team_id == "10107"
-        # assert dataset.metadata.teams[0].starting_formation == FormationType(
-        #     "4-3-3"
-        # )
+        assert dataset.metadata.teams[0].starting_formation == FormationType(
+            "4-3-3"
+        )
         assert dataset.metadata.teams[1].team_id == "23109"
-        # assert dataset.metadata.teams[1].starting_formation == FormationType(
-        #     "5-3-2"
-        # )
+        assert dataset.metadata.teams[1].starting_formation == FormationType(
+            "4-3-3"
+        )
 
         # The teams should have the correct players
         player = dataset.metadata.teams[0].get_player_by_id("194622")
@@ -577,6 +589,70 @@ class TestKoraStatsRecoveryEvent:
     def test_deserialize_recoveries(self, dataset: EventDataset):
         events = dataset.find_all("recovery")
         assert len(events) == 157
+
+
+class TestKoraStatsFormation:
+    """Tests related to deserializing the MatchFormation feeds"""
+
+    @pytest.mark.parametrize(
+        "raw_formation,expected",
+        [
+            ("1-433", FormationType("4-3-3")),
+            ("1-442", FormationType("4-4-2")),
+            ("1-4240", FormationType("4-2-4-0")),
+            ("1-523", FormationType("5-2-3")),
+            ("1-541", FormationType("5-4-1")),
+            # Partial strings: fewer or more than ten outfield players
+            ("1-53", FormationType.UNKNOWN),
+            ("1-5301", FormationType.UNKNOWN),
+            ("1-4331", FormationType.UNKNOWN),
+            # A second goalkeeper is not a formation
+            ("2-423", FormationType.UNKNOWN),
+            # Missing values
+            (" - ", FormationType.UNKNOWN),
+            ("", FormationType.UNKNOWN),
+            (None, FormationType.UNKNOWN),
+        ],
+    )
+    def test_parse_formation(self, raw_formation, expected):
+        """It should read the goalkeeper-first formation strings"""
+        assert parse_formation(raw_formation) == expected
+
+    def test_keys_formations_by_team_id(self):
+        """It should key each feed by its own team id, not by argument order"""
+        home_feed = BytesIO(
+            json.dumps(
+                {"teamId": 10107, "startingLineupFormation": "1-433"}
+            ).encode()
+        )
+        away_feed = BytesIO(
+            json.dumps(
+                {"teamId": 23109, "startingLineupFormation": "1-532"}
+            ).encode()
+        )
+
+        # Pass the away feed first to prove the order does not matter
+        assert parse_starting_formations([away_feed, home_feed]) == {
+            "10107": FormationType("4-3-3"),
+            "23109": FormationType("5-3-2"),
+        }
+
+    def test_without_formation_data(self, base_dir):
+        """It should fall back to an unknown formation when the feeds are absent"""
+        dataset = korastats.load(
+            event_data=base_dir / "files" / "korastats_events.json",
+            squads_data=base_dir / "files" / "korastats_squads.json",
+            coordinates="korastats",
+        )
+
+        assert (
+            dataset.metadata.teams[0].starting_formation
+            == FormationType.UNKNOWN
+        )
+        assert (
+            dataset.metadata.teams[1].starting_formation
+            == FormationType.UNKNOWN
+        )
 
 
 def test_add_synthetic_event(dataset: EventDataset):


### PR DESCRIPTION
KoraStats puts no formation in the event or squad feeds, so the deserializer hardcoded `FormationType.UNKNOWN` and every MGP match ingested from KoraStats stores a single "Unknown" formation state for both teams.

Their undocumented `MatchFormation` endpoint does carry it. This accepts the two (optional) per-team feeds and reads `startingLineupFormation` from them.

- Formations are keyed by the `teamId` in each feed, so the argument order cannot swap the teams.
- The provider writes them goalkeeper-first without separators (`1-433` -> 4-3-3, `1-4240` -> 4-2-4-0), and also emits strings that do not add up to eleven players (`1-53`, `1-5301`, `" - "`); those fall back to `UNKNOWN`.
- Without the feeds, behaviour is unchanged.
- Adds `5-2-3` to `FormationType`, which KoraStats reports (13 of 91 team-matches in a sample) but the enum lacked.

In a 20-match sample, `startingLineupFormation` was present and well-formed for 36 of 40 team-matches. The two detected fields (`lineupFormationName`, `endOfMatchFormationName`) are deliberately not used: 20 of 40 accounted for only nine or eight outfield players.

Tested with the real feeds for the existing fixture match (Kalmar - Landskrona), plus unit tests for the string parsing and the team keying.