### PR TITLE
fix(opta): shift the goal-time qualifier across suspension gaps

### DIFF
--- a/kloppy/infra/serializers/event/statsperform/deserializer.py
+++ b/kloppy/infra/serializers/event/statsperform/deserializer.py
@@ -64,6 +64,12 @@ EVENT_TYPE_OFFSIDE_PROVOKED = 55
 # routine in-play delays (injuries, VAR) so only true match suspensions trigger.
 SUSPENSION_GAP_THRESHOLD = timedelta(minutes=15)
 
+# Qualifier 374 carries an absolute wall-clock time of its own (the actual time of
+# the shot on goal events) and overrides the event timestamp downstream, so it has
+# to be shifted alongside it when a suspension gap is normalized.
+EVENT_QUALIFIER_GOAL_TIMESTAMP = 374
+GOAL_TIMESTAMP_FORMAT = "%Y-%m-%d %H:%M:%S.%f"
+
 EVENT_TYPE_PASS = 1
 EVENT_TYPE_OFFSIDE_PASS = 2
 EVENT_TYPE_TAKE_ON = 3
@@ -805,6 +811,11 @@ def _normalize_suspension_gaps(raw_events: List[OptaEvent]) -> None:
     consecutive events exceeds the game-clock delta by more than
     `SUSPENSION_GAP_THRESHOLD`. The END_PERIOD event is included in the walk,
     so `period.end_timestamp` (set later from that event) is also corrected.
+
+    Goal events carry a second, independent wall-clock time in qualifier 374 that
+    overrides the event timestamp during deserialization. It is shifted by the same
+    amount, otherwise a goal scored after a suspension keeps its raw wall-clock time
+    and lands the length of the suspension ahead of its neighbours in the timeline.
     """
     shift_per_period: Dict[int, timedelta] = {}
     prev_per_period: Dict[int, OptaEvent] = {}
@@ -813,6 +824,7 @@ def _normalize_suspension_gaps(raw_events: List[OptaEvent]) -> None:
         shift = shift_per_period.get(period_id, timedelta(0))
         if shift:
             raw_event.timestamp -= shift
+            _shift_goal_timestamp_qualifier(raw_event, shift)
         prev = prev_per_period.get(period_id)
         if prev is not None:
             wall_delta = raw_event.timestamp - prev.timestamp
@@ -837,8 +849,34 @@ def _normalize_suspension_gaps(raw_events: List[OptaEvent]) -> None:
                     raw_event.time_sec,
                 )
                 raw_event.timestamp -= excess
+                _shift_goal_timestamp_qualifier(raw_event, excess)
                 shift_per_period[period_id] = shift + excess
         prev_per_period[period_id] = raw_event
+
+
+def _shift_goal_timestamp_qualifier(
+    raw_event: OptaEvent, shift: timedelta
+) -> None:
+    """Shift the absolute time in qualifier 374 back by `shift`, if present."""
+    raw_value = (raw_event.qualifiers or {}).get(
+        EVENT_QUALIFIER_GOAL_TIMESTAMP
+    )
+    if not raw_value:
+        return
+    try:
+        shifted = datetime.strptime(raw_value, GOAL_TIMESTAMP_FORMAT) - shift
+    except ValueError:
+        logger.warning(
+            "Could not parse qualifier %s value %r on event %s; leaving it "
+            "unshifted across the suspension gap.",
+            EVENT_QUALIFIER_GOAL_TIMESTAMP,
+            raw_value,
+            raw_event.id,
+        )
+        return
+    raw_event.qualifiers[EVENT_QUALIFIER_GOAL_TIMESTAMP] = shifted.strftime(
+        GOAL_TIMESTAMP_FORMAT
+    )
 
 
 class StatsPerformInputs(NamedTuple):
@@ -1010,12 +1048,17 @@ class StatsPerformDeserializer(EventDataDeserializer[StatsPerformInputs]):
                         EVENT_TYPE_SHOT_GOAL,
                     ):
                         if raw_event.type_id == EVENT_TYPE_SHOT_GOAL:
-                            if 374 in raw_event.qualifiers:
+                            if (
+                                EVENT_QUALIFIER_GOAL_TIMESTAMP
+                                in raw_event.qualifiers
+                            ):
                                 # Qualifier 374 specifies the actual time of the shot for all goal events
                                 # It uses London timezone for both MA3 and F24 feeds
                                 naive_datetime = datetime.strptime(
-                                    raw_event.qualifiers[374],
-                                    "%Y-%m-%d %H:%M:%S.%f",
+                                    raw_event.qualifiers[
+                                        EVENT_QUALIFIER_GOAL_TIMESTAMP
+                                    ],
+                                    GOAL_TIMESTAMP_FORMAT,
                                 )
                                 timezone = pytz.timezone("Europe/London")
                                 aware_datetime = timezone.localize(

--- a/kloppy/tests/test_opta.py
+++ b/kloppy/tests/test_opta.py
@@ -37,7 +37,9 @@ from kloppy.domain import (
 from kloppy import opta
 from kloppy.infra.serializers.event.statsperform.deserializer import (
     _get_end_coordinates,
+    _normalize_suspension_gaps,
 )
+from kloppy.infra.serializers.event.statsperform.parsers.base import OptaEvent
 from kloppy.infra.serializers.event.statsperform.parsers.f24_xml import (
     _parse_f24_datetime,
 )
@@ -610,6 +612,85 @@ class TestOptaAbandonment:
                 f"{row.key.possession_state} "
                 f"{row.key.player or row.key.team}"
             )
+
+    def test_goal_timestamp_qualifier_is_shifted_with_the_event(self):
+        """Qualifier 374 must move with the event timestamp across a suspension.
+
+        Goal events override their timestamp with qualifier 374, which carries an
+        absolute wall-clock time of its own. Leaving it unshifted strands a goal
+        scored after the suspension by the length of the suspension, which drives
+        the possession-state breakdown negative (NWSL Utah Royals - Washington
+        Spirit, 2026-07-30, suspended 1h20m in the first half).
+        """
+        kickoff = datetime(2026, 7, 30, 2, 8, 34)
+        gap = timedelta(minutes=80)
+
+        def raw_event(event_id, minute, second, timestamp, qualifiers=None):
+            return OptaEvent(
+                id=event_id,
+                event_id=int(event_id),
+                type_id=1,
+                period_id=1,
+                time_min=minute,
+                time_sec=second,
+                x=50.0,
+                y=50.0,
+                timestamp=timestamp,
+                last_modified=timestamp,
+                qualifiers=qualifiers or {},
+            )
+
+        before_gap = raw_event(
+            "1", 23, 41, kickoff + timedelta(minutes=23, seconds=41)
+        )
+        after_gap = raw_event(
+            "2", 23, 41, kickoff + timedelta(minutes=23, seconds=41) + gap
+        )
+        goal_timestamp = kickoff + timedelta(minutes=27, seconds=41) + gap
+        goal = raw_event(
+            "3",
+            27,
+            41,
+            goal_timestamp,
+            {374: goal_timestamp.strftime("%Y-%m-%d %H:%M:%S.%f")},
+        )
+
+        _normalize_suspension_gaps([before_gap, after_gap, goal])
+
+        assert goal.timestamp == kickoff + timedelta(minutes=27, seconds=41)
+        assert (
+            datetime.strptime(goal.qualifiers[374], "%Y-%m-%d %H:%M:%S.%f")
+            == goal.timestamp
+        )
+
+    def test_events_without_the_goal_qualifier_are_untouched(self):
+        """A shift on a non-goal event must not invent a qualifier 374."""
+        kickoff = datetime(2026, 7, 30, 2, 8, 34)
+        gap = timedelta(minutes=80)
+
+        def raw_event(event_id, minute, second, timestamp):
+            return OptaEvent(
+                id=event_id,
+                event_id=int(event_id),
+                type_id=1,
+                period_id=1,
+                time_min=minute,
+                time_sec=second,
+                x=50.0,
+                y=50.0,
+                timestamp=timestamp,
+                last_modified=timestamp,
+            )
+
+        before_gap = raw_event("1", 10, 0, kickoff + timedelta(minutes=10))
+        after_gap = raw_event(
+            "2", 10, 0, kickoff + timedelta(minutes=10) + gap
+        )
+
+        _normalize_suspension_gaps([before_gap, after_gap])
+
+        assert after_gap.timestamp == kickoff + timedelta(minutes=10)
+        assert after_gap.qualifiers == {}
 
 
 class TestOptaCardEvent:


### PR DESCRIPTION
## Problem

NWSL **Utah Royals FC - Washington Spirit** (2026-07-30) was suspended for 1h20m during the first half. StatsPerform delivered the F24 fine and we downloaded it, but ingestion crashed:

```
File "/app/src/methods/match.py", line 1025, in create_event_data
  isinstance(minutes_played.duration, timedelta)
AssertionError
```

24 of 102 `minutes_played` rows came back broken - Utah's `BALL_DEAD` bucket was **negative** (`-0:18:56`) and `OUT_OF_POSSESSION` was 1:37:42 out of a 98:34 match.

## Cause

`_normalize_suspension_gaps` correctly shifts wall-clock event timestamps back across the gap, and period durations come out right. But goal events take a different path: at `deserializer.py:1052` the timestamp is **overridden** by qualifier 374 ("actual time of the shot"), which carries an absolute wall-clock time of its own and was never shifted.

Washington's goal (event `2950082055`, game clock 27:41) carries:

```xml
<Q qualifier_id="374" value="2026-07-30 03:56:21.986"/>
```

Unshifted, so it landed at **1:47:47** into the period instead of 0:27:41 - exactly 4806s (the suspension gap) ahead of its neighbours. The possession-state aggregator walks events in timeline order, so that one event dumps ~80 minutes into `OUT_OF_POSSESSION` and drives `BALL_DEAD` negative.

## Fix

Shift qualifier 374 by the same per-period offset inside `_normalize_suspension_gaps`.

Verified against the real feeds (`s3://mgp-raw/event/statsperform/{F7,F24}-2622156.xml`):

| | before | after |
|---|---|---|
| out-of-range rows | 24 / 102 | **0 / 102** |
| IN_POSSESSION | 0:19:48 | 0:25:20 |
| OUT_OF_POSSESSION | 1:37:42 | 0:21:46 |
| BALL_DEAD | **-0:18:56** | 0:51:27 |

The three buckets now sum to 98:34, the actual match duration.

## Tests

Two unit tests on `_normalize_suspension_gaps`: the qualifier moves in lockstep with the event timestamp, and a shift on a non-goal event does not invent a qualifier.

The existing Örgryte abandonment fixture could not have caught this - its first-half goals all predate the suspension, and the shift for period 2 is zero.

`test_opta.py` + `test_statsperform.py`: 85 passed. `TestOptaBlockEvent::test_correct_deserialization` fails, but it fails identically on `mgp-fork/v11` without this change (pre-existing, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)