### PR TITLE
fix(korastats): decode penalty-shootout events instead of crashing

### DIFF
--- a/kloppy/infra/serializers/event/korastats/specification.py
+++ b/kloppy/infra/serializers/event/korastats/specification.py
@@ -53,6 +53,7 @@ class EVENT_CATEGORY_TYPE(Enum):
     GOALKEEPER_PENALTY = (2, 8)
     GOALKEEPER_ONE_ON_ONE = (2, 9)
     GOALKEEPER_SHOOT = (2, 10)
+    GOALKEEPER_PENALTY_SHOOT_OUT = (2, 46)
     GOALKEEPER_OWN_GOAL_CONCEDED = (2, 49)
 
     # Defensive events
@@ -948,7 +949,9 @@ def event_decoder(raw_event: Dict) -> Optional[EVENT]:
         EVENT_CATEGORY_TYPE.GOALKEEPER_PENALTY: GOALKEEPER,
         EVENT_CATEGORY_TYPE.GOALKEEPER_ONE_ON_ONE: GOALKEEPER,
         EVENT_CATEGORY_TYPE.GOALKEEPER_SHOOT: GOALKEEPER,
-        # EVENT_CATEGORY_TYPE.GOALKEEPER_PENALTY_SHOOT_OUT: None,
+        # Penalty shootouts are not part of the event model (period 5 is
+        # excluded downstream); skip the kicks/saves at decode time.
+        EVENT_CATEGORY_TYPE.GOALKEEPER_PENALTY_SHOOT_OUT: None,
         EVENT_CATEGORY_TYPE.GOALKEEPER_OWN_GOAL_CONCEDED: OWN_GOAL,
         # Defensive events
         EVENT_CATEGORY_TYPE.DEFENSIVE_BLOCK: BLOCK,
@@ -992,7 +995,7 @@ def event_decoder(raw_event: Dict) -> Optional[EVENT]:
         EVENT_CATEGORY_TYPE.ATTACK_FREEKICK: SHOT,
         EVENT_CATEGORY_TYPE.ATTACK_OWN_GOAL_IN_OPPONENT: None,
         EVENT_CATEGORY_TYPE.ATTACK_SHOOT_LOCATION: None,
-        # ATTACK_PENALTY_SHOOTOUT = "PenaltyShootOut"
+        EVENT_CATEGORY_TYPE.ATTACK_PENALTY_SHOOTOUT: None,
         # Ball actions
         EVENT_CATEGORY_TYPE.BALL_ACTIONS_BALL_PAST_LINE: BALL_OUT,
     }


### PR DESCRIPTION
## Ticket

N/A — hit live during ingestion of the Gent vs LNZ Cherkasy Conference League qualifier (KoraStats custom request); no Notion ticket.

## Change summary

KoraStats matches that go to a penalty shootout crashed the deserializer: `ATTACK_PENALTY_SHOOTOUT` (5, 45) was in the `EVENT_CATEGORY_TYPE` enum but had no entry in `tuple_type_to_event` (KeyError), and goalkeeper shootout saves (2, 46) were missing from the enum entirely (ValueError). Both are now decoded to `None`, the existing pattern for known-but-skipped event types. Shootout kicks are deliberately not modelled: period 5 is already excluded downstream (data-processing calls `korastats.load` with `exclude_penalty_shootouts=True`). Mapping them to real shot events was rejected because the shared `remove_penalty_shootout_data` machinery would strip them again anyway.

## Risk

Decoder-only change in the KoraStats path; other providers untouched. Previously-crashing matches now parse; matches without shootouts are byte-identical. Revertible by reverting the commit.

## Tests

Ran the data-processing EVENT pipeline against the real crashing match (KoraStats 131395, Gent vs LNZ Cherkasy, 4-2 pens, halves 1-5 in the feed): parses clean, events inserted to prod, shootout period excluded. Scanned the raw feed to confirm (5, 45) and (2, 46) are the only shootout event pairs present.

- **Gaps:** no unit test added for the shootout fixture; verified end-to-end via the live pipeline run instead.

## Reviewer attention

1. `GOALKEEPER_PENALTY_SHOOT_OUT = (2, 46)` — new enum member, id pair taken from the live feed (8 occurrences, `Goal Keeper / PenaltyShootOut`).
2. Both mappings are `None` on purpose — decode-time skip, consistent with `exclude_penalty_shootouts` downstream.

## Cross-repo coordination

- Sibling PRs + intended merge order: none required — data-processing pins `kloppy@mgp-fork/v11` (branch, not tag), so the next image build picks this up automatically.
- `@my-game-plan/types` added / changed / removed: N/A
- Breaking for consumers? no

🤖 Generated with [Claude Code](https://claude.com/claude-code)