### PR TITLE
fix(korastats): map LWB/RWB wing back positions

### DIFF
--- a/kloppy/infra/serializers/event/korastats/deserializer.py
+++ b/kloppy/infra/serializers/event/korastats/deserializer.py
@@ -60,6 +60,8 @@ position_types_mapping: Dict[str, PositionType] = {
     "CB": PositionType.CenterBack,
     "RCB": PositionType.RightCenterBack,
     "RB": PositionType.RightBack,
+    "LWB": PositionType.LeftWingBack,
+    "RWB": PositionType.RightWingBack,
     "LDM": PositionType.LeftDefensiveMidfield,
     "DM": PositionType.CenterDefensiveMidfield,
     "RDM": PositionType.RightDefensiveMidfield,

--- a/kloppy/tests/test_korastats.py
+++ b/kloppy/tests/test_korastats.py
@@ -143,6 +143,15 @@ class TestKoraStatsMetadata:
         assert len(dataset.metadata.periods) == 2
         assert dataset.metadata.periods[0].id == 1
 
+    def test_wing_back_positions(self):
+        """Squads with wing backs (back-three lineups) should deserialize"""
+        from kloppy.infra.serializers.event.korastats.deserializer import (
+            position_types_mapping,
+        )
+
+        assert position_types_mapping["LWB"] == PositionType.LeftWingBack
+        assert position_types_mapping["RWB"] == PositionType.RightWingBack
+
 
 class TestKoraStatsEvent:
     """Generic tests related to deserializing events"""


### PR DESCRIPTION
## What
Adds `LWB` and `RWB` to the KoraStats `position_types_mapping`.

## Why
Squads with a back three list wing backs as `LWB`/`RWB`. Neither code was in the mapping, so `create_teams_and_players` crashed with `KeyError: 'RWB'` and the whole match failed to deserialize. First hit in production on Meistriliiga match 117120 (JK Trans Narva vs Kalju FC, 2026-08-08), which has been failing on every hourly EVENT run since 2026-08-09.

## Verification
- `pytest kloppy/tests/test_korastats.py` — 50 passed (includes new regression test)
- Deserialized the real failing match files (117120 squad/events/formations from `mgp-raw`): 1576 events, both wing backs mapped correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)