### PR TITLE
fix(statsbomb): map the 9 missing formation codes

### DIFF
--- a/kloppy/infra/serializers/event/statsbomb/specification.py
+++ b/kloppy/infra/serializers/event/statsbomb/specification.py
@@ -74,6 +74,8 @@ class Version(NamedTuple):
 
 
 FORMATIONS = {
+    31213: FormationType.THREE_ONE_TWO_ONE_THREE,
+    31312: FormationType.THREE_ONE_THREE_ONE_TWO,
     3142: FormationType.THREE_ONE_FOUR_TWO,
     312112: FormationType.THREE_ONE_TWO_ONE_ONE_TWO,
     31222: FormationType.THREE_ONE_TWO_TWO_TWO,
@@ -82,6 +84,8 @@ FORMATIONS = {
     32221: FormationType.THREE_TWO_TWO_TWO_ONE,
     3232: FormationType.THREE_TWO_THREE_TWO,
     3322: FormationType.THREE_THREE_TWO_TWO,
+    3241: FormationType.THREE_TWO_FOUR_ONE,
+    3331: FormationType.THREE_THREE_THREE_ONE,
     3412: FormationType.THREE_FOUR_ONE_TWO,
     3421: FormationType.THREE_FOUR_TWO_ONE,
     343: FormationType.THREE_FOUR_THREE,
@@ -97,13 +101,18 @@ FORMATIONS = {
     42211: FormationType.FOUR_TWO_TWO_ONE_ONE,
     4222: FormationType.FOUR_TWO_TWO_TWO,
     4231: FormationType.FOUR_TWO_THREE_ONE,
+    4240: FormationType.FOUR_TWO_FOUR_ZERO,
     4312: FormationType.FOUR_THREE_ONE_TWO,
     4321: FormationType.FOUR_THREE_TWO_ONE,
     433: FormationType.FOUR_THREE_THREE,
     4411: FormationType.FOUR_FOUR_ONE_ONE,
     442: FormationType.FOUR_FOUR_TWO,
     451: FormationType.FOUR_FIVE_ONE,
+    5122: FormationType.FIVE_ONE_TWO_TWO,
+    5131: FormationType.FIVE_ONE_THREE_ONE,
+    5212: FormationType.FIVE_TWO_ONE_TWO,
     5221: FormationType.FIVE_TWO_TWO_ONE,
+    523: FormationType.FIVE_TWO_THREE,
     532: FormationType.FIVE_THREE_TWO,
     541: FormationType.FIVE_FOUR_ONE,
 }
@@ -794,9 +803,14 @@ class BLOCK(EVENT):
         qualifiers = []
 
         # Convert to Interception subtype
-        shot_block = any(isinstance(related_event, SHOT) for related_event in self.related_events)
+        shot_block = any(
+            isinstance(related_event, SHOT)
+            for related_event in self.related_events
+        )
         interception_type = (
-            InterceptionType.SHOT_BLOCK if shot_block else InterceptionType.PASS_BLOCK
+            InterceptionType.SHOT_BLOCK
+            if shot_block
+            else InterceptionType.PASS_BLOCK
         )
         qualifiers.append(InterceptionQualifier(value=interception_type))
 
@@ -804,7 +818,11 @@ class BLOCK(EVENT):
         body_part_qualifiers = _get_body_part_qualifiers(block_dict)
         qualifiers.extend(body_part_qualifiers)
 
-        result = InterceptionResult.OUT if self.raw_event.get("out", False) else InterceptionResult.LOST
+        result = (
+            InterceptionResult.OUT
+            if self.raw_event.get("out", False)
+            else InterceptionResult.LOST
+        )
         interception_event = event_factory.build_interception(
             result=result,
             qualifiers=qualifiers,

--- a/kloppy/tests/test_statsbomb.py
+++ b/kloppy/tests/test_statsbomb.py
@@ -812,7 +812,9 @@ class TestStatsBombInterceptionEvent:
     def test_deserialize_all(self, dataset: EventDataset):
         """It should deserialize all interception events"""
         events = dataset.find_all("interception")
-        assert len(events) == 25 + 9 + 37 # interceptions + pass interceptions + blocks
+        assert (
+            len(events) == 25 + 9 + 37
+        )  # interceptions + pass interceptions + blocks
 
     def test_attributes(self, dataset: EventDataset):
         """Verify specific attributes of interceptions"""
@@ -858,9 +860,7 @@ class TestStatsBombOwnGoalEvent:
             event_data=base_dir / "files" / "statsbomb_event.json",
         )
 
-        source_shot = dataset.get_event_by_id(
-            "89dd4f4b-0a70-48d8-a0e7-ac4c"
-        )
+        source_shot = dataset.get_event_by_id("89dd4f4b-0a70-48d8-a0e7-ac4c")
         assert source_shot is not None
         assert source_shot.result == ShotResult.OWN_GOAL
 
@@ -917,23 +917,36 @@ class TestStatsBombBlockEvent:
     def test_deserialize_all(self, dataset: EventDataset):
         """It should convert all block events into interceptions"""
         events = dataset.find_all("interception")
-        assert len(events) == 25 + 9 + 37 # interceptions + pass interceptions + blocks
+        assert (
+            len(events) == 25 + 9 + 37
+        )  # interceptions + pass interceptions + blocks
 
     def test_attributes(self, dataset: EventDataset):
         """Verify specific attributes of converted blocks"""
-        interception = dataset.get_event_by_id("308ef2a5-f649-473d-8230-6ac20ccd0b4a")
+        interception = dataset.get_event_by_id(
+            "308ef2a5-f649-473d-8230-6ac20ccd0b4a"
+        )
         # Should have interception type qualifier PASS_BLOCK
-        assert interception.get_qualifier_value(InterceptionQualifier) == InterceptionType.PASS_BLOCK
+        assert (
+            interception.get_qualifier_value(InterceptionQualifier)
+            == InterceptionType.PASS_BLOCK
+        )
         assert interception.result == InterceptionResult.LOST
 
     def test_shot_block_vs_pass_block_counts(self, dataset: EventDataset):
         """Test that the correct number of shot/pass block interceptions are identified"""
         interceptions = dataset.find_all("interception")
         shot_blocks = [
-            e for e in interceptions if e.get_qualifier_value(InterceptionQualifier) == InterceptionType.SHOT_BLOCK
+            e
+            for e in interceptions
+            if e.get_qualifier_value(InterceptionQualifier)
+            == InterceptionType.SHOT_BLOCK
         ]
         pass_blocks = [
-            e for e in interceptions if e.get_qualifier_value(InterceptionQualifier) == InterceptionType.PASS_BLOCK
+            e
+            for e in interceptions
+            if e.get_qualifier_value(InterceptionQualifier)
+            == InterceptionType.PASS_BLOCK
         ]
         assert len(shot_blocks) == 7
         assert len(pass_blocks) == 30
@@ -1319,3 +1332,23 @@ class TestStatsBombTacticalShiftEvent:
                 PositionType.LeftMidfield,
             )
         ]
+
+
+class TestStatsBombFormations:
+    """Tests related to the StatsBomb formation code mapping"""
+
+    def test_all_numeric_formations_are_mapped(self):
+        """Every numeric FormationType should have a StatsBomb code
+
+        StatsBomb encodes a formation as the digits of the shape concatenated
+        into an int (3-3-3-1 -> 3331). A code missing from FORMATIONS raises a
+        KeyError that aborts the whole match, not just the one Tactical Shift,
+        so the mapping has to stay in sync with the enum.
+        """
+        for formation in FormationType:
+            if not formation.value.replace("-", "").isdigit():
+                continue
+            code = int(formation.value.replace("-", ""))
+            assert (
+                SB.FORMATIONS.get(code) == formation
+            ), f"{formation.value} is not mapped to StatsBomb code {code}"


### PR DESCRIPTION
## What
Adds the 9 numeric `FormationType` members that had no entry in the StatsBomb `FORMATIONS` mapping: `31213`, `31312`, `3241`, `3331`, `4240`, `5122`, `5131`, `5212`, `523`. Plus a regression test that keeps the dict in sync with the enum.

## Why
StatsBomb encodes a formation as its digits concatenated into an int (3-3-3-1 -> 3331). A code missing from `FORMATIONS` raises a `KeyError` in `_create_events`, which aborts the deserialization of the **whole match**, not just the one Tactical Shift event.

Hit in production on EFL Championship match 4071326 (Portsmouth vs Queens Park Rangers, 2026-08-15): Portsmouth shifted to 3-3-3-1 in the 72nd minute, `KeyError: 3331`, and the match has failed on every hourly EVENT run since 05:07 on 2026-08-16. QPR are a customer and this is their first game of the season, so no events, no insights, no post-match XML and no clips.

Same failure shape as #44 (KoraStats `KeyError: 'RWB'`): one unmapped provider code, whole match lost. The new test covers the class of bug rather than the one code.

## Verification
- `pytest kloppy/tests/test_statsbomb.py::TestStatsBombFormations` — passed
- Deserialized the real failing match files (4071326 events/lineups from `mgp-raw`): **3161 events**, all 4 formation changes read correctly including Portsmouth's 3-3-3-1
- Full `test_statsbomb.py`: 39 passed / 38 failed, byte-identical failure set to `mgp-fork/v11` before this change (pre-existing local fixture drift, untouched here)

## Note on the diff
The `black` hunks in `BLOCK`/`TestStatsBombInterceptionEvent`/`TestStatsBombOwnGoalEvent` are the pre-commit hook fixing formatting drift that was already failing `black --check .` on the branch. Unrelated to the fix, but the CI lint job cannot go green without them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)